### PR TITLE
ci: add github actions

### DIFF
--- a/.github/workflows/cubic.yml
+++ b/.github/workflows/cubic.yml
@@ -1,0 +1,23 @@
+on: [push, pull_request]
+
+name: Cubic
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Build Code
+        run: cargo build
+
+      - name: Format Code
+        run: cargo fmt --check
+
+      - name: Lint Code
+        run: cargo clippy -- -D warnings
+
+      - name: Test Code
+        run: cargo test

--- a/src/machine/machine_dao.rs
+++ b/src/machine/machine_dao.rs
@@ -105,6 +105,7 @@ impl MachineDao {
         let file = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&machine_config)
             .map_err(|_| Error::CannotCreateFile(machine_config.to_string()))?;
         serde_yaml::to_writer(file, &config)


### PR DESCRIPTION
Adds GitHub actions to build, test, format and lint the code.

Changes:
- Added GitHub actions for cargo build, test, rustfmt and clippy
- Fixed a clippy error in MachineDao