### PR TITLE
fix: remove cache files on machine deletion

### DIFF
--- a/src/machine/machine_dao.rs
+++ b/src/machine/machine_dao.rs
@@ -166,6 +166,8 @@ impl MachineDao {
         if self.is_running(machine) {
             Result::Err(Error::MachineNotStopped(machine.name.to_string()))
         } else {
+            fs::remove_dir_all(format!("{}/{}", self.cache_dir, machine.name))
+                .map_err(Error::Io)?;
             fs::remove_dir_all(format!("{}/{}", self.machine_dir, machine.name)).map_err(Error::Io)
         }
     }


### PR DESCRIPTION
Changes:
  - Remove $HOME/.cache/cubic/machines/<machine> when machine is deleted