### PR TITLE
fix: show error when image download fails

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -31,4 +31,5 @@ pub enum Error {
     UserDataCreationFailed(String),
     CannotParseSize(String),
     CannotShrinkDisk(String),
+    ImageDownloadFailed(String),
 }

--- a/src/image/image_name.rs
+++ b/src/image/image_name.rs
@@ -37,4 +37,8 @@ impl ImageName {
     pub fn to_file_name(&self) -> String {
         format!("{}_{}_{}", self.vendor, self.image, self.arch)
     }
+
+    pub fn to_id(&self) -> String {
+        format!("{}:{}:{}", self.vendor, self.image, self.arch)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,7 @@ fn main() {
             Error::UserDataCreationFailed(name) => println!("Failed to create user data for machine '{name}'"),
             Error::CannotParseSize(size) => println!("Invalid data size format '{size}'"),
             Error::CannotShrinkDisk(name) => println!("Cannot shrink the disk of the machine '{name}'"),
+            Error::ImageDownloadFailed(name) => println!("Failed to download image: '{name}'"),
         }
     }
 }


### PR DESCRIPTION
Abort and show error when image cannot be downloaded

Changes:
  - Added Error::ImageDownloadFailed
  - Check return code of wget in ImageFetcher
  - Added to_id() method to ImageName
  - Print error message on ImageDownloadFailed