### PR TITLE
feat: add display permission for snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -30,6 +30,10 @@ parts:
       - cloud-image-utils
       - openssh-client
       - qemu-system-x86
+      - qemu-system-gui
+      - qemu-system-modules-spice
+      - qemu-system-modules-opengl
+      - libgtk-4-dev
       - seabios
     override-build: |
       rm $SNAPCRAFT_PART_INSTALL/usr/share/qemu/openbios-ppc
@@ -43,3 +47,8 @@ apps:
       - network
       - network-bind
       - home
+      - wayland
+      - x11
+      - desktop
+      - desktop-legacy
+      - opengl

--- a/src/machine/machine_dao.rs
+++ b/src/machine/machine_dao.rs
@@ -272,6 +272,13 @@ impl MachineDao {
 
         let qemu_root = std::env::var("SNAP").unwrap_or_default();
 
+        if std::env::var("SNAP").is_ok() {
+            command.env(
+                "QEMU_MODULE_DIR",
+                "/snap/cubic/current/usr/lib/x86_64-linux-gnu/qemu",
+            );
+        }
+
         command
             .arg("-L")
             .arg(format!("{qemu_root}/usr/share/qemu"))


### PR DESCRIPTION
Changes:
- Added runtime dependencies: qemu-system-gui, qemu-system-modules-spice, qemu-system-modules-opengl, libgtk-4-dev
- Added snap permissions: wayland, x11, desktop, desktop-legacy, opengl
- Set QEMU_MODULE_DIR environment variable for snap