### PR TITLE
feat: relocate runtime dir

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ pub enum Error {
     UnknownImage(String),
     MissingSshKey,
     InvalidImageName(String),
-    UnsetHomeVar,
+    UnsetEnvVar(String),
     InvalidOption(String),
     CannotCopyFile(String, String),
     CannotCopyDir(String, String),
@@ -47,7 +47,7 @@ pub fn print_error(error: Error) {
             "Could not find any ssh keys. Please create a ssh key to access the virtual machine"
         ),
         Error::InvalidImageName(name) => println!("Invalid image name: {name}"),
-        Error::UnsetHomeVar => println!("Environment variable 'HOME' is not defined"),
+        Error::UnsetEnvVar(var) => println!("Environment variable '{var}' is not set"),
         Error::InvalidOption(option) => println!("'{option}' is not a valid option"),
         Error::CannotCopyFile(from, to) => println!("Cannot copy file from '{from}' to '{to}'"),
         Error::CannotCopyDir(from, to) => println!("Cannot copy directory from '{from}' to '{to}'"),

--- a/src/machine/machine_dao.rs
+++ b/src/machine/machine_dao.rs
@@ -33,7 +33,8 @@ impl MachineDao {
     pub fn new() -> Result<Self, Error> {
         let home_dir = util::get_home_dir()?;
         let machine_dir = format!("{home_dir}/.local/share/cubic/machines");
-        let cache_dir = format!("{home_dir}/.cache/cubic/machines");
+        let xdg_runtime_dir = util::get_xdg_runtime_dir()?;
+        let cache_dir = format!("{xdg_runtime_dir}/cubic/machines");
         util::setup_directory_access(&machine_dir)?;
         util::setup_directory_access(&cache_dir)?;
 

--- a/src/util/env.rs
+++ b/src/util/env.rs
@@ -2,7 +2,12 @@ use crate::error::Error;
 use std::env;
 
 const HOME_ENV: &str = "HOME";
+const XDG_RUNTIME_DIR_ENV: &str = "XDG_RUNTIME_DIR";
 
 pub fn get_home_dir() -> Result<String, Error> {
-    env::var(HOME_ENV).map_err(|_| Error::UnsetHomeVar)
+    env::var(HOME_ENV).map_err(|_| Error::UnsetEnvVar(HOME_ENV.to_string()))
+}
+
+pub fn get_xdg_runtime_dir() -> Result<String, Error> {
+    env::var(XDG_RUNTIME_DIR_ENV).map_err(|_| Error::UnsetEnvVar(XDG_RUNTIME_DIR_ENV.to_string()))
 }


### PR DESCRIPTION
Changes:
- Store runtime information in volatile directory (XDG_RUNTIME_DIR)
- Rename UnsetHomeVar in UnsetEnvVar
- Implemented get_xdg_runtime_dir()