### PR TITLE
feat: revamped ssh implementation

### DIFF
--- a/docs/install/snap.md
+++ b/docs/install/snap.md
@@ -3,6 +3,8 @@
 Cubic can be installed from the Snap Store:
 ```
 $ sudo snap install cubic
+$ sudo snap connect cubic:kvm
+$ sudo snap connect cubic:ssh-keys
 ```
 
 ## How to enable Kernel Virtual Machine (KVM) acceleration?

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -88,3 +88,4 @@ apps:
       - network
       - network-bind
       - home
+      - ssh-keys

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,6 +1,5 @@
 use crate::error::Error;
 use crate::machine::MachineDao;
-use crate::util;
 
 pub fn start(
     machine_dao: &MachineDao,
@@ -9,8 +8,6 @@ pub fn start(
     verbose: bool,
     ids: &Vec<String>,
 ) -> Result<(), Error> {
-    util::check_ssh_key();
-
     for id in ids {
         if !machine_dao.exists(id) {
             return Result::Err(Error::UnknownMachine(id.clone()));

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,8 +42,13 @@ pub fn print_error(error: Error) {
         Error::MachineAlreadyExists(id) => println!("Machine with name '{id}' already exists"),
         Error::Io(e) => println!("{}", e),
         Error::UnknownImage(name) => println!("Unknown image name {name}"),
-        Error::MissingSshKey => println!(
-            "Could not find any ssh keys. Please create a ssh key to access the virtual machine"
+        Error::MissingSshKey => print!(
+            "No SSH keys found. Please try the following:\n\
+- Check if cubic has read access to $HOME/.ssh
+  - Snap users must grant access with: `sudo snap connect cubic:ssh-keys`\n\
+- Check if you have a ssh key in $HOME/.ssh
+  - You can generate one with `ssh-keygen`\n\
+- Use `cubic sh mymachine` instead\n"
         ),
         Error::InvalidImageName(name) => println!("Invalid image name: {name}"),
         Error::UnsetEnvVar(var) => println!("Environment variable '{var}' is not set"),

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -90,8 +90,8 @@ machine:
         assert_eq!(machine.mem, 1073741824);
         assert_eq!(machine.disk_capacity, 2361393152);
         assert_eq!(machine.ssh_port, 14357);
-        assert_eq!(machine.display, false);
-        assert_eq!(machine.gpu, false);
+        assert!(!machine.display);
+        assert!(!machine.gpu);
         assert!(machine.mounts.is_empty());
         assert!(machine.hostfwd.is_empty());
     }
@@ -123,8 +123,8 @@ machine:
         assert_eq!(machine.mem, 1073741824);
         assert_eq!(machine.disk_capacity, 2361393152);
         assert_eq!(machine.ssh_port, 14357);
-        assert_eq!(machine.display, false);
-        assert_eq!(machine.gpu, false);
+        assert!(!machine.display);
+        assert!(!machine.gpu);
         assert_eq!(
             machine.mounts,
             [MountPoint {
@@ -163,8 +163,8 @@ machine:
         assert_eq!(machine.mem, 1073741824);
         assert_eq!(machine.disk_capacity, 2361393152);
         assert_eq!(machine.ssh_port, 14357);
-        assert_eq!(machine.display, true);
-        assert_eq!(machine.gpu, true);
+        assert!(machine.display);
+        assert!(machine.gpu);
         assert!(machine.mounts.is_empty());
         assert!(machine.hostfwd.is_empty());
     }

--- a/src/machine/machine_dao.rs
+++ b/src/machine/machine_dao.rs
@@ -2,6 +2,7 @@ use crate::emulator::Emulator;
 use crate::error::Error;
 use crate::machine::{Machine, MountPoint};
 use crate::qemu::Monitor;
+use crate::ssh_cmd::PortChecker;
 use crate::util;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -238,7 +239,7 @@ impl MachineDao {
 
     pub fn get_state(&self, machine: &Machine) -> MachineState {
         if self.is_running(machine) {
-            if util::SSHClient::new(machine.ssh_port).try_connect() {
+            if PortChecker::new(machine.ssh_port).try_connect() {
                 MachineState::Running
             } else {
                 MachineState::Starting

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod error;
 mod image;
 mod machine;
 mod qemu;
+mod ssh_cmd;
 mod util;
 
 use clap::Parser;

--- a/src/ssh_cmd.rs
+++ b/src/ssh_cmd.rs
@@ -1,0 +1,65 @@
+mod port_checker;
+mod scp;
+mod ssh;
+
+use crate::error::Error;
+use std::env;
+use std::fs::{read_dir, read_to_string, DirEntry};
+
+pub use port_checker::PortChecker;
+pub use scp::Scp;
+pub use ssh::Ssh;
+
+fn get_ssh_key_dirs() -> Vec<String> {
+    ["SNAP_REAL_HOME", "HOME"]
+        .iter()
+        .filter_map(|var| env::var(var).ok())
+        .map(|dir| format!("{dir}/.ssh"))
+        .collect()
+}
+
+fn get_ssh_keys() -> Vec<DirEntry> {
+    get_ssh_key_dirs()
+        .iter()
+        .filter_map(|dir| read_dir(dir).ok())
+        .flatten()
+        .filter_map(|item| item.ok())
+        .filter(|item| {
+            item.file_name()
+                .to_str()
+                .map(|name| name.starts_with("id_"))
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
+pub fn get_ssh_private_key_names() -> Result<Vec<String>, Error> {
+    let mut keys = Vec::new();
+
+    for entry in get_ssh_keys() {
+        let path = entry.path();
+        let extension = path
+            .extension()
+            .unwrap_or_default()
+            .to_str()
+            .unwrap_or_default();
+        if extension.is_empty() {
+            keys.push(path.as_os_str().to_str().unwrap().to_string());
+        }
+    }
+
+    if keys.is_empty() {
+        return Result::Err(Error::MissingSshKey);
+    }
+
+    Ok(keys)
+}
+
+pub fn get_ssh_pub_keys() -> Result<Vec<String>, Error> {
+    get_ssh_private_key_names().map(|key| {
+        key.iter()
+            .filter_map(|path| read_to_string(format!("{path}.pub")).ok())
+            .map(|content| content.trim().to_string())
+            .collect()
+    })
+}

--- a/src/ssh_cmd/port_checker.rs
+++ b/src/ssh_cmd/port_checker.rs
@@ -1,0 +1,22 @@
+use std::net::TcpStream;
+use std::time::Duration;
+
+pub struct PortChecker {
+    pub port: u16,
+}
+
+impl PortChecker {
+    pub fn new(port: u16) -> Self {
+        PortChecker { port }
+    }
+
+    pub fn try_connect(&self) -> bool {
+        let mut buf = [0];
+        TcpStream::connect(format!("127.0.0.1:{}", &self.port))
+            .and_then(|stream| {
+                stream.set_read_timeout(Some(Duration::new(0, 100000000)))?;
+                stream.peek(&mut buf)
+            })
+            .is_ok()
+    }
+}

--- a/src/ssh_cmd/scp.rs
+++ b/src/ssh_cmd/scp.rs
@@ -1,0 +1,132 @@
+use crate::util;
+use std::process::Command;
+
+#[derive(Default)]
+pub struct Scp {
+    root_dir: String,
+    private_keys: Vec<String>,
+    port: Option<u16>,
+    args: String,
+    verbose: bool,
+}
+
+impl Scp {
+    pub fn new() -> Self {
+        Scp::default()
+    }
+
+    pub fn set_root_dir(&mut self, root_dir: &str) -> &mut Self {
+        self.root_dir = root_dir.to_string();
+        self
+    }
+
+    pub fn set_private_keys(&mut self, private_keys: Vec<String>) -> &mut Self {
+        self.private_keys = private_keys;
+        self
+    }
+
+    pub fn set_port(&mut self, port: Option<u16>) -> &mut Self {
+        self.port = port;
+        self
+    }
+
+    pub fn set_args(&mut self, args: &str) -> &mut Self {
+        self.args = args.to_string();
+        self
+    }
+
+    pub fn set_verbose(&mut self, verbose: bool) -> &mut Self {
+        self.verbose = verbose;
+        self
+    }
+
+    pub fn copy(&self, from: &str, to: &str) -> Command {
+        let mut command = Command::new(format!("{}/usr/bin/scp", self.root_dir));
+
+        command
+            .arg("-r")
+            .args(self.port.map(|port| format!("-P{port}")).as_slice())
+            .arg(format!("-S{}/usr/bin/ssh", self.root_dir))
+            .args(
+                self.private_keys
+                    .iter()
+                    .map(|key| format!("-i{key}"))
+                    .collect::<Vec<_>>(),
+            )
+            .args(self.args.split(' ').filter(|item| !item.is_empty()))
+            .arg(from)
+            .arg(to);
+
+        if self.verbose {
+            util::print_command(&command);
+        }
+
+        command
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn test_scp_minimal() {
+        let cmd = Scp::new().copy("/from/file", "/to/file");
+        let args: Vec<&OsStr> = cmd.get_args().collect();
+
+        assert_eq!(cmd.get_program(), "/usr/bin/scp");
+        assert_eq!(args, &["-r", "-S/usr/bin/ssh", "/from/file", "/to/file"]);
+    }
+
+    #[test]
+    fn test_scp_minimal_snap() {
+        let cmd = Scp::new()
+            .set_root_dir("/snap/cubic/current")
+            .copy("/from/file", "/to/file");
+        let args: Vec<&OsStr> = cmd.get_args().collect();
+
+        assert_eq!(cmd.get_program(), "/snap/cubic/current/usr/bin/scp");
+        assert_eq!(
+            args,
+            &[
+                "-r",
+                "-S/snap/cubic/current/usr/bin/ssh",
+                "/from/file",
+                "/to/file"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_scp_advanced() {
+        let cmd = Scp::new()
+            .set_root_dir("/snap/cubic/current")
+            .set_verbose(true)
+            .set_private_keys(vec![
+                "/home/cubic/.ssh/id_rsa".to_string(),
+                "/home/cubic/.ssh/id_ed25519".to_string(),
+            ])
+            .set_port(Some(10000))
+            .set_args("-myarg1 -myarg2 -myarg3")
+            .copy("/from/file", "/to/file");
+        let args: Vec<&OsStr> = cmd.get_args().collect();
+
+        assert_eq!(cmd.get_program(), "/snap/cubic/current/usr/bin/scp");
+        assert_eq!(
+            args,
+            &[
+                "-r",
+                "-P10000",
+                "-S/snap/cubic/current/usr/bin/ssh",
+                "-i/home/cubic/.ssh/id_rsa",
+                "-i/home/cubic/.ssh/id_ed25519",
+                "-myarg1",
+                "-myarg2",
+                "-myarg3",
+                "/from/file",
+                "/to/file"
+            ]
+        );
+    }
+}

--- a/src/ssh_cmd/ssh.rs
+++ b/src/ssh_cmd/ssh.rs
@@ -1,0 +1,76 @@
+use crate::util;
+use std::process::Command;
+
+#[derive(Default)]
+pub struct Ssh {
+    private_keys: Vec<String>,
+    user: String,
+    port: Option<u16>,
+    args: String,
+    verbose: bool,
+    xforward: bool,
+    cmd: Option<String>,
+}
+
+impl Ssh {
+    pub fn new() -> Self {
+        Ssh::default()
+    }
+
+    pub fn set_private_keys(&mut self, private_keys: Vec<String>) -> &mut Self {
+        self.private_keys = private_keys;
+        self
+    }
+
+    pub fn set_user(&mut self, user: String) -> &mut Self {
+        self.user = user;
+        self
+    }
+
+    pub fn set_port(&mut self, port: Option<u16>) -> &mut Self {
+        self.port = port;
+        self
+    }
+
+    pub fn set_args(&mut self, args: String) -> &mut Self {
+        self.args = args;
+        self
+    }
+
+    pub fn set_verbose(&mut self, verbose: bool) -> &mut Self {
+        self.verbose = verbose;
+        self
+    }
+
+    pub fn set_xforward(&mut self, xforward: bool) -> &mut Self {
+        self.xforward = xforward;
+        self
+    }
+
+    pub fn set_cmd(&mut self, cmd: Option<String>) -> &mut Self {
+        self.cmd = cmd;
+        self
+    }
+
+    pub fn connect(&self) -> Command {
+        let mut command = Command::new("ssh");
+        command
+            .args(self.port.map(|port| format!("-p{port}")).as_slice())
+            .args(
+                self.private_keys
+                    .iter()
+                    .map(|key| format!("-i{key}"))
+                    .collect::<Vec<_>>(),
+            )
+            .args(self.xforward.then_some("-X").as_slice())
+            .args(self.args.split(' ').filter(|item| !item.is_empty()))
+            .arg(format!("{}@127.0.0.1", self.user))
+            .args(self.cmd.as_slice());
+
+        if self.verbose {
+            util::print_command(&command);
+        }
+
+        command
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,6 @@ pub mod input;
 pub mod migration;
 pub mod process;
 pub mod qemu;
-pub mod ssh;
 pub mod terminal;
 
 pub use env::*;
@@ -15,5 +14,4 @@ pub use input::*;
 pub use migration::*;
 pub use process::*;
 pub use qemu::*;
-pub use ssh::*;
 pub use terminal::*;

--- a/src/util/qemu.rs
+++ b/src/util/qemu.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use crate::machine::{Machine, MountPoint, CONSOLE_COUNT};
+use crate::ssh_cmd::get_ssh_pub_keys;
 use crate::util;
 use serde_json::Value::{self, Number};
 use std::fs::File;
@@ -111,7 +112,7 @@ pub fn setup_cloud_init(machine: &Machine, dir: &str, force: bool) -> Result<(),
         }
 
         if force || !Path::new(&user_data_path).exists() {
-            let ssh_pk = util::get_ssh_pub_keys()?.join("\n\u{20}\u{20}\u{20}\u{20}\u{20}\u{20}- ");
+            let ssh_pk = get_ssh_pub_keys()?.join("\n\u{20}\u{20}\u{20}\u{20}\u{20}\u{20}- ");
 
             let mut write_files = String::new();
             let mut consoles = String::new();


### PR DESCRIPTION
Changes:
- Relocated all SSH related code under src/ssh_cmd
- Use SSH keys from user's home directory and the snap home directory
- Added ssh-keys interface to snap
- Removed ssh-keygen invocation and display error message if no keys were found
- Renamed SSHClient in PortChecker
- Added unit tests
- Updated snap install documentation