### PR TITLE
fix: remove ssh key requirement

### DIFF
--- a/src/util/qemu.rs
+++ b/src/util/qemu.rs
@@ -113,7 +113,18 @@ pub fn setup_cloud_init(instance: &Instance, dir: &str, force: bool) -> Result<(
         }
 
         if force || !Path::new(&user_data_path).exists() {
-            let ssh_pk = get_ssh_pub_keys()?.join("\n\u{20}\u{20}\u{20}\u{20}\u{20}\u{20}- ");
+            let ssh_pk = if let Ok(ssh_keys) = get_ssh_pub_keys() {
+                format!(
+                    "\u{20}\u{20}\u{20}\u{20}ssh-authorized-keys:\n{}",
+                    ssh_keys
+                        .iter()
+                        .map(|key| format!("\u{20}\u{20}\u{20}\u{20}\u{20}\u{20}- {key}"))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                )
+            } else {
+                String::new()
+            };
 
             let mut write_files = String::new();
             let mut consoles = String::new();
@@ -148,8 +159,7 @@ pub fn setup_cloud_init(instance: &Instance, dir: &str, force: bool) -> Result<(
                     #cloud-config\n\
                     users:\n\
                     \u{20}\u{20}- name: {user}\n\
-                    \u{20}\u{20}\u{20}\u{20}ssh-authorized-keys:\n\
-                    \u{20}\u{20}\u{20}\u{20}\u{20}\u{20}- {ssh_pk}\n\
+                    {ssh_pk}\n\
                     \u{20}\u{20}\u{20}\u{20}shell: /bin/bash\n\
                     \u{20}\u{20}\u{20}\u{20}sudo: ALL=(ALL) NOPASSWD:ALL\n\
                     packages:\n\


### PR DESCRIPTION
Starting an instance no longer requires the user to have SSH keys as instances may be accessed via serial without SSH.