### PR TITLE
feat: add common command aliases

### DIFF
--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -32,6 +32,7 @@ pub enum Commands {
     },
 
     /// List instances
+    #[clap(alias = "ls")]
     List,
 
     /// Get information about an instance

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -7,6 +7,7 @@ use clap::Subcommand;
 #[derive(Subcommand)]
 pub enum ImageCommands {
     /// List images
+    #[clap(alias = "ls")]
     List {
         /// List all images
         #[clap(short, long, default_value_t = false)]
@@ -26,6 +27,7 @@ pub enum ImageCommands {
     },
 
     /// Delete images
+    #[clap(alias = "rm")]
     Del {
         /// List of images to delete
         images: Vec<String>,

--- a/src/commands/instance.rs
+++ b/src/commands/instance.rs
@@ -9,6 +9,7 @@ use clap::Subcommand;
 #[derive(Subcommand)]
 pub enum InstanceCommands {
     /// List instances
+    #[clap(alias = "ls")]
     List,
 
     /// Add an instance
@@ -31,6 +32,7 @@ pub enum InstanceCommands {
     },
 
     /// Delete instances
+    #[clap(alias = "rm")]
     Del {
         /// Enable verbose logging
         #[clap(short, long, default_value_t = false)]

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 #[derive(Subcommand)]
 pub enum MountCommands {
     /// List mount mounts
+    #[clap(alias = "ls")]
     List {
         /// Name of the virtual machine instance
         name: String,
@@ -23,6 +24,7 @@ pub enum MountCommands {
     },
 
     /// Delete a directory mount
+    #[clap(alias = "rm")]
     Del {
         /// Name of the virtual machine instance
         name: String,

--- a/src/commands/net/hostfwd.rs
+++ b/src/commands/net/hostfwd.rs
@@ -10,7 +10,7 @@ pub enum HostfwdCommands {
     ///
     /// List forwarded ports for all instances:
     /// $ cubic net hostfwd list
-    #[clap(verbatim_doc_comment)]
+    #[clap(verbatim_doc_comment, alias = "ls")]
     List,
 
     /// Add host port forwarding rule
@@ -29,7 +29,7 @@ pub enum HostfwdCommands {
     ///
     /// Remove port forwarding:
     /// $ cubic net hostfwd del myinstance tcp:127.0.0.1:8000-:22
-    #[clap(verbatim_doc_comment)]
+    #[clap(verbatim_doc_comment, alias = "rm")]
     Del {
         /// Virtual machine instance
         instance: String,


### PR DESCRIPTION
Added shorter aliases to commands:
  - cubic ls              -> cubic list
  - cubic image ls        -> cubic image list
  - cubic image del       -> cubic image rm
  - cubic instance ls     -> cubic instance list
  - cubic instance del    -> cubic instance rm
  - cubic mount ls        -> cubic mount ls
  - cubic mount del       -> cubic mount rm
  - cubic net hostfwd ls  -> cubic net hostfwd ls
  - cubic net hostfwd del -> cubic net hostfwd del