### PR TITLE
feat: revise image subcommands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ simple, daemon-less and rootless design. All Cubic virtual machines run
 isolated in the user context. Cubic is built on top of QEMU, KVM and cloud-init.
 
 Show all supported images:
-$ cubic image ls --all
+$ cubic image ls
 
 Create a new virtual machine instance:
 $ cubic add --name mymachine --image ubuntu:noble

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cubic@quickstart:~$
 
 The supported images can be listed with:
 ```
-$ cubic image ls --all
+$ cubic image ls
 Vendor      Version  Name         Arch       Size
 archlinux    latest  latest      amd64
 debian            9  stretch     amd64
@@ -114,7 +114,7 @@ simple, daemon-less and rootless design. All Cubic virtual machines run
 isolated in the user context. Cubic is built on top of QEMU, KVM and cloud-init.
 
 Show all supported images:
-$ cubic image ls --all
+$ cubic image ls
 
 Create a new virtual machine instance:
 $ cubic add --name mymachine --image ubuntu:noble

--- a/docs/usage/list.md
+++ b/docs/usage/list.md
@@ -13,7 +13,7 @@ noble               1    1.0 GiB    2.0 GiB  STOPPED
 
 List all virtual machine images:
 ```
-$ cubic image ls --all
+$ cubic image ls
 Name               Arch         Size   
 archlinux:latest   amd64   516.0 MiB   
 debian:12          amd64   424.2 MiB   

--- a/src/image/image_dao.rs
+++ b/src/image/image_dao.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 use crate::image::{Image, ImageFactory};
 use crate::util;
 
-use std::fs::remove_file;
+use std::fs::{remove_dir_all, remove_file};
 use std::path::Path;
 use std::str;
 
@@ -53,5 +53,9 @@ impl ImageDao {
 
     pub fn delete(&self, image: &Image) -> Result<(), Error> {
         remove_file(format!("{}/{}", self.image_dir, image.to_file_name())).map_err(Error::Io)
+    }
+
+    pub fn prune(&self) -> Result<(), Error> {
+        remove_dir_all(&self.image_dir).map_err(Error::Io)
     }
 }


### PR DESCRIPTION
Changes:
- Show all available images by default in 'image ls' command
- Hide and mark -a/-all flag in 'image ls' command as deprecated
- Hide and mark 'image rm/del' command as deprecated
- Added 'image prune' command to clear local image cache
- Updated documentation