### PR TITLE
feat: replace cloud-utils with mkisofs to strip dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 ENV DEBIAN_FRONTEND=noninteractive
 ENV XDG_RUNTIME_DIR=/tmp
 RUN apt update && \
-    apt install -y qemu-utils cloud-utils qemu-system-x86 qemu-system-arm
+    apt install -y qemu-utils genisoimage qemu-system-x86 qemu-system-arm
 RUN rustup component add clippy rustfmt && \
     cargo install --locked cargo-audit@0.21.1 &&\
     cargo fetch

--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -3,12 +3,12 @@
 Cubic requires the following dependencies:
   - Cargo
   - QEMU
-  - Cloud Utils
   - OpenSSH Client
+  - mkisofs
 
 The dependencies can be installed for Debian and Ubuntu with the following command:
 ```
-$ sudo apt install cargo openssl libssl-dev pkg-config ca-certificates qemu-system-x86 cloud-image-utils openssh-client
+$ sudo apt install cargo qemu-system-x86 qemu-system-arm qemu-utils genisoimage openssh-client
 ```
 
 Build the Rust project with the Cargo package manager:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,8 +21,9 @@ parts:
   runtime-dependencies:
     plugin: nil
     stage-packages:
-      - cloud-image-utils
+      - genisoimage
       - openssh-client
+      - qemu-utils
       - qemu-system-x86
       - qemu-system-arm
       - qemu-system-gui


### PR DESCRIPTION
The dependency cloud-utils was used to create an ISO file which is necessary for cloud-init. This change uses mkisofs to write the ISO file, which has fewer dependencies.