### PR TITLE
fix: add missing snap LD_LIRARY_PATH

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -88,3 +88,5 @@ apps:
       - network-bind
       - home
       - ssh-keys
+    environment:
+        LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libproxy


### PR DESCRIPTION
A missing LD_LIRARY_PATH causes snap to print some warning on the first launch.