### PR TITLE
refactor: pass instance name in add command without --name flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Show all supported images:
 $ cubic image ls
 
 Create a new virtual machine instance:
-$ cubic add --name mymachine --image ubuntu:noble
+$ cubic add mymachine --image ubuntu:noble
 
 List all virtual machine instances:
 $ cubic ls

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Show all supported images:
 $ cubic image ls
 
 Create a new virtual machine instance:
-$ cubic add --name mymachine --image ubuntu:noble
+$ cubic add mymachine --image ubuntu:noble
 
 List all virtual machine instances:
 $ cubic ls

--- a/docs/usage/add_delete.md
+++ b/docs/usage/add_delete.md
@@ -6,11 +6,13 @@ Create a virtual machine instance:
 $ cubic add --help
 Add a virtual machine instance
 
-Usage: cubic add [OPTIONS] --image <IMAGE> --name <NAME>
+Usage: cubic add [OPTIONS] --image <IMAGE> [INSTANCE_NAME]
+
+Arguments:
+  [INSTANCE_NAME]  Name of the virtual machine instance
 
 Options:
   -i, --image <IMAGE>  Name of the virtual machine image
-  -n, --name <NAME>    Name of the virtual machine instance
   -c, --cpus <CPUS>    Number of CPUs for the virtual machine instance
   -m, --mem <MEM>      Memory size of the virtual machine instance (e.g. 1G for 1 gigabyte)
   -d, --disk <DISK>    Disk size of the virtual machine instance  (e.g. 10G for 10 gigabytes)
@@ -18,7 +20,7 @@ Options:
 ```
 **Example**:
 ```
-$ cubic add --name example --image ubuntu:noble:amd64 --cpus 4 --mem 4G --disk 5G
+$ cubic add example --image ubuntu:noble:amd64 --cpus 4 --mem 4G --disk 5G
 ```
 
 ## Instance Delete Command

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::io;
 #[derive(Debug)]
 pub enum Error {
     UnknownCommand,
+    InvalidArgument(String),
     UnknownArch(String),
     UnknownInstance(String),
     InstanceIsRunning(String),
@@ -36,6 +37,7 @@ pub fn print_error(error: Error) {
     print!("ERROR: ");
     match error {
         Error::UnknownCommand => println!("Unknown command"),
+        Error::InvalidArgument(err) => println!("Argument error: {err}"),
         Error::UnknownArch(name) => println!("Unknown architecture: '{name}'"),
         Error::UnknownInstance(instance) => println!("Unknown instance '{instance}'"),
         Error::InstanceIsRunning(name) => println!("Instance '{name}' is already runing"),


### PR DESCRIPTION
Aligned the 'add' command with the other commands by passing the instance name as positional argument rather than a named one.

Replaced:
    cubic add --name <instance name> --image <image name>
with:
    cubic add <instance name> --image <image name>