### PR TITLE
fix: improve standard machine instance settings

### DIFF
--- a/src/commands/instance_add_command.rs
+++ b/src/commands/instance_add_command.rs
@@ -4,6 +4,10 @@ use crate::image::ImageDao;
 use crate::instance::{Instance, InstanceDao, InstanceStore, USER};
 use crate::util;
 
+const DEFAULT_CPU_COUNT: u16 = 4;
+const DEFAULT_MEM_SIZE: &str = "4G";
+const DEFAULT_DISK_SIZE: &str = "100G";
+
 pub struct InstanceAddCommand {
     image: String,
     name: String,
@@ -42,32 +46,24 @@ impl InstanceAddCommand {
             return Result::Err(Error::InstanceAlreadyExists(self.name.to_string()));
         }
 
-        let image_size = image_dao.get_disk_capacity(&image)?;
-        let disk_capacity = self
-            .disk
-            .as_ref()
-            .map(|size| util::human_readable_to_bytes(size))
-            .unwrap_or(Result::Ok(image_size))?;
-
         image_dao.copy_image(&image, &instance_dir, "machine.img")?;
 
+        let disk_capacity =
+            util::human_readable_to_bytes(self.disk.as_deref().unwrap_or(DEFAULT_DISK_SIZE))?;
         let ssh_port = util::generate_random_ssh_port();
 
         let mut instance = Instance {
             name: self.name.clone(),
             arch: image.arch,
             user: USER.to_string(),
-            cpus: self.cpus.unwrap_or(1),
-            mem: util::human_readable_to_bytes(self.mem.as_deref().unwrap_or("1G"))?,
-            disk_capacity,
+            cpus: self.cpus.unwrap_or(DEFAULT_CPU_COUNT),
+            mem: util::human_readable_to_bytes(self.mem.as_deref().unwrap_or(DEFAULT_MEM_SIZE))?,
+            disk_capacity: 0, // Will be overwritten by resize operation below
             ssh_port,
             ..Instance::default()
         };
+        instance_dao.resize(&mut instance, disk_capacity)?;
         instance_dao.store(&instance)?;
-        if self.disk.is_some() {
-            instance_dao.resize(&mut instance, disk_capacity)?;
-        }
-
         Result::Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,6 @@ pub enum Error {
     UserDataCreationFailed(String),
     CannotParseSize(String),
     CannotShrinkDisk(String),
-    GetCapacityFailed(String),
     CannotOpenTerminal(String),
     HostFwdRuleMalformed(String),
     CommandFailed(String),
@@ -67,7 +66,6 @@ pub fn print_error(error: Error) {
         Error::CannotShrinkDisk(name) => {
             println!("Cannot shrink the disk of the instance '{name}'")
         }
-        Error::GetCapacityFailed(path) => println!("Failed to get capacity from image: '{path}'"),
         Error::CannotOpenTerminal(path) => println!("Failed to open terminal from path: '{path}'"),
         Error::HostFwdRuleMalformed(rule) => println!("Host forwarding rule is malformed: {rule}"),
         Error::CommandFailed(message) => println!("{message}"),

--- a/src/image/image_dao.rs
+++ b/src/image/image_dao.rs
@@ -52,11 +52,6 @@ impl ImageDao {
             .ok_or(Error::UnknownImage(id.to_string()))
     }
 
-    pub fn get_disk_capacity(&self, image: &Image) -> Result<u64, Error> {
-        let path = format!("{}/{}", self.image_dir, image.to_file_name());
-        util::get_disk_capacity(&path)
-    }
-
     pub fn copy_image(&self, image: &Image, dir: &str, name: &str) -> Result<(), Error> {
         let path = format!("{}/{}", self.image_dir, image.to_file_name());
         self.fs.create_dir(dir)?;

--- a/src/util/qemu.rs
+++ b/src/util/qemu.rs
@@ -2,37 +2,9 @@ use crate::error::Error;
 use crate::fs::FS;
 use crate::instance::{Instance, MountPoint};
 use crate::ssh_cmd::get_ssh_pub_keys;
-use serde_json::Value::{self, Number};
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::str;
-
-fn run_qemu_info(path: &str) -> Result<Value, Error> {
-    let out = Command::new("qemu-img")
-        .arg("info")
-        .arg("--output=json")
-        .arg(path)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .output()
-        .map_err(|_| Error::GetCapacityFailed(path.to_string()))?
-        .stdout;
-
-    let out_str = str::from_utf8(&out).map_err(|_| Error::GetCapacityFailed(path.to_string()))?;
-
-    serde_json::from_str(out_str).map_err(|_| Error::GetCapacityFailed(path.to_string()))
-}
-
-pub fn get_disk_capacity(path: &str) -> Result<u64, Error> {
-    let json: Value = run_qemu_info(path)?;
-
-    match &json["virtual-size"] {
-        Number(number) => number
-            .as_u64()
-            .ok_or(Error::GetCapacityFailed(path.to_string())),
-        _ => Result::Err(Error::GetCapacityFailed(path.to_string())),
-    }
-}
 
 pub fn bytes_to_human_readable(bytes: u64) -> String {
     match bytes.checked_ilog(1024) {


### PR DESCRIPTION
Use better default settings for new instances:
- Set CPUS to 4 instead of 1
- Set memory to 4G instead of 1G
- Set disk capacity to 100G instead of the original distro size Also cleaned up the get disk capacity functionality that is no longer used.