### PR TITLE
feat: add --yes option to 'rm' command

### DIFF
--- a/docs/reference/rm.rst
+++ b/docs/reference/rm.rst
@@ -16,5 +16,6 @@ cubic rm
     Options:
       -v, --verbose  Enable verbose logging
       -q, --quiet    Reduce logging output
-      -f, --force    Delete the virtual machine instances without confirmation
+      -f, --force    Delete the virtual machine instances even when running
+      -y, --yes      Delete the virtual machine instances without confirmation
       -h, --help     Print help

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -70,9 +70,12 @@ pub enum Commands {
         /// Reduce logging output
         #[clap(short, long, default_value_t = false)]
         quiet: bool,
-        /// Delete the virtual machine instances without confirmation
+        /// Delete the virtual machine instances even when running
         #[clap(short, long, default_value_t = false)]
         force: bool,
+        /// Delete the virtual machine instances without confirmation
+        #[clap(short, long, default_value_t = false)]
+        yes: bool,
         /// Name of the virtual machine instances to delete
         instances: Vec<String>,
     },
@@ -291,9 +294,15 @@ impl CommandDispatcher {
                 verbose,
                 quiet,
                 force,
+                yes,
                 instances,
-            } => InstanceRemoveCommand::new(Verbosity::new(*verbose, *quiet), *force, instances)
-                .run(&instance_dao),
+            } => InstanceRemoveCommand::new(
+                Verbosity::new(*verbose, *quiet),
+                *force,
+                *yes,
+                instances,
+            )
+            .run(&instance_dao),
 
             Commands::Clone { name, new_name } => {
                 InstanceCloneCommand::new(name, new_name).run(&instance_dao)

--- a/src/commands/instance.rs
+++ b/src/commands/instance.rs
@@ -42,9 +42,12 @@ pub enum InstanceCommands {
         /// Reduce logging output
         #[clap(short, long, default_value_t = false)]
         quiet: bool,
-        /// Delete the virtual machine instances without confirmation
+        /// Delete the virtual machine instances even when running
         #[clap(short, long, default_value_t = false)]
         force: bool,
+        /// Delete the virtual machine instances without confirmation
+        #[clap(short, long, default_value_t = false)]
+        yes: bool,
         /// Name of the virtual machine instances to delete
         instances: Vec<String>,
     },
@@ -104,9 +107,15 @@ impl InstanceCommands {
                 verbose,
                 quiet,
                 force,
+                yes,
                 instances,
-            } => InstanceRemoveCommand::new(Verbosity::new(*verbose, *quiet), *force, instances)
-                .run(instance_dao),
+            } => InstanceRemoveCommand::new(
+                Verbosity::new(*verbose, *quiet),
+                *force,
+                *yes,
+                instances,
+            )
+            .run(instance_dao),
             InstanceCommands::Config {
                 instance,
                 cpus,

--- a/src/commands/instance_remove_command.rs
+++ b/src/commands/instance_remove_command.rs
@@ -6,14 +6,16 @@ use crate::util;
 pub struct InstanceRemoveCommand {
     verbosity: Verbosity,
     force: bool,
+    yes: bool,
     instances: Vec<String>,
 }
 
 impl InstanceRemoveCommand {
-    pub fn new(verbosity: Verbosity, force: bool, instances: &[String]) -> Self {
+    pub fn new(verbosity: Verbosity, force: bool, yes: bool, instances: &[String]) -> Self {
         Self {
             verbosity,
             force,
+            yes,
             instances: instances.to_vec(),
         }
     }
@@ -34,9 +36,11 @@ impl InstanceRemoveCommand {
         }
 
         for instance in &self.instances {
-            if util::confirm(&format!(
-                "Do you really want delete the instance '{instance}'? [y/n]: "
-            )) {
+            if self.yes
+                || util::confirm(&format!(
+                    "Do you really want delete the instance '{instance}'? [y/n]: "
+                ))
+            {
                 instance_dao.delete(&instance_dao.load(instance)?)?;
                 println!("Deleted instance {instance}");
             }


### PR DESCRIPTION
Allow to delete a virtual machine instance without an interactive confirmation.