### PR TITLE
fix: do not access the /proc filesystem

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -74,6 +74,10 @@ impl FS {
         fs::File::open(path).map_err(|e| Error::FS(format!("Cannot open file '{path}' ({e})")))
     }
 
+    pub fn path_exists(&self, path: &str) -> bool {
+        Path::new(path).exists()
+    }
+
     pub fn copy_file(&self, from: &str, to: &str) -> Result<(), Error> {
         fs::copy(from, to)
             .map(|_| ())

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -166,9 +166,8 @@ impl InstanceStore for InstanceDao {
     }
 
     fn is_running(&self, instance: &Instance) -> bool {
-        self.get_pid(instance)
-            .map(|pid| Path::new(&format!("/proc/{pid}")).exists())
-            .unwrap_or(false)
+        self.fs
+            .path_exists(&format!("{}/{}/qemu.pid", self.cache_dir, instance.name))
     }
 
     fn get_pid(&self, instance: &Instance) -> Result<u64, ()> {


### PR DESCRIPTION
Removed platform dependent code, which accessed the /proc filesystem.