### PR TITLE
feat: add --wait flag to start and stop commands

### DIFF
--- a/docs/reference/start.rst
+++ b/docs/reference/start.rst
@@ -17,4 +17,5 @@ cubic start
           --qemu-args <QEMU_ARGS>  Pass additional QEMU arguments
       -v, --verbose                Enable verbose logging
       -q, --quiet                  Reduce logging output
+      -w, --wait                   Wait for the virtual machine instance to be started
       -h, --help                   Print help

--- a/docs/reference/stop.rst
+++ b/docs/reference/stop.rst
@@ -17,4 +17,5 @@ cubic stop
       -a, --all      Stop all virtual machine instances
       -v, --verbose  Enable verbose logging
       -q, --quiet    Reduce logging output
+      -w, --wait     Wait for the virtual machine instance to be stopped
       -h, --help     Print help

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -144,6 +144,9 @@ pub enum Commands {
         /// Reduce logging output
         #[clap(short, long, default_value_t = false)]
         quiet: bool,
+        /// Wait for the virtual machine instance to be started
+        #[clap(short, long, default_value_t = false)]
+        wait: bool,
         /// Name of the virtual machine instances to start
         instances: Vec<String>,
     },
@@ -159,6 +162,9 @@ pub enum Commands {
         /// Reduce logging output
         #[clap(short, long, default_value_t = false)]
         quiet: bool,
+        /// Wait for the virtual machine instance to be stopped
+        #[clap(short, long, default_value_t = false)]
+        wait: bool,
         /// Name of the virtual machine instances to stop
         instances: Vec<String>,
     },
@@ -312,22 +318,26 @@ impl CommandDispatcher {
                 qemu_args,
                 verbose,
                 quiet,
+                wait,
                 instances,
             } => commands::start(
                 &instance_dao,
                 qemu_args,
                 Verbosity::new(*verbose, *quiet),
+                *wait,
                 instances,
             ),
             Commands::Stop {
                 instances,
                 verbose,
                 quiet,
+                wait,
                 all,
             } => commands::stop(
                 &instance_dao,
                 *all,
                 Verbosity::new(*verbose, *quiet),
+                *wait,
                 instances,
             ),
             Commands::Restart {

--- a/src/commands/console.rs
+++ b/src/commands/console.rs
@@ -13,6 +13,7 @@ pub fn console(instance_dao: &InstanceDao, name: &str) -> Result<(), Error> {
         instance_dao,
         &None,
         Verbosity::Quiet,
+        true,
         &vec![name.to_string()],
     )?;
 

--- a/src/commands/instance_remove_command.rs
+++ b/src/commands/instance_remove_command.rs
@@ -22,7 +22,7 @@ impl InstanceRemoveCommand {
 
     pub fn run(&self, instance_dao: &InstanceDao) -> Result<(), Error> {
         if self.force {
-            commands::stop(instance_dao, false, self.verbosity, &self.instances)?;
+            commands::stop(instance_dao, false, self.verbosity, true, &self.instances)?;
         }
 
         for instance in &self.instances {

--- a/src/commands/restart.rs
+++ b/src/commands/restart.rs
@@ -7,6 +7,6 @@ pub fn restart(
     verbosity: Verbosity,
     instances: &Vec<String>,
 ) -> Result<(), Error> {
-    commands::stop(instance_dao, false, verbosity, instances)?;
-    commands::start(instance_dao, &None, verbosity, instances)
+    commands::stop(instance_dao, false, verbosity, true, instances)?;
+    commands::start(instance_dao, &None, verbosity, true, instances)
 }

--- a/src/commands/ssh.rs
+++ b/src/commands/ssh.rs
@@ -44,7 +44,13 @@ pub fn ssh(
     let user = get_user_name(target)?.unwrap_or(instance.user.to_string());
     let ssh_port = instance.ssh_port;
 
-    commands::start(instance_dao, &None, verbosity, &vec![name.to_string()])?;
+    commands::start(
+        instance_dao,
+        &None,
+        verbosity,
+        true,
+        &vec![name.to_string()],
+    )?;
 
     let mut ssh = None;
     let mut start_time = Instant::now();

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -10,6 +10,7 @@ pub fn start(
     instance_dao: &InstanceDao,
     qemu_args: &Option<String>,
     verbosity: Verbosity,
+    wait: bool,
     instance_names: &Vec<String>,
 ) -> Result<(), Error> {
     // Launch virtual machine instances
@@ -30,7 +31,7 @@ pub fn start(
     }
 
     // Wait for virtual machine instances to be started
-    if !verbosity.is_quiet() {
+    if wait && !verbosity.is_quiet() {
         let mut spinner = SpinnerView::new("Starting instance(s)");
         while actions.iter().any(|a| !a.is_done()) {
             sleep(Duration::from_secs(1));

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -10,6 +10,7 @@ pub fn stop(
     instance_dao: &InstanceDao,
     all: bool,
     verbosity: Verbosity,
+    wait: bool,
     instances: &[String],
 ) -> Result<(), Error> {
     let stop_instances = if all {
@@ -25,7 +26,7 @@ pub fn stop(
         actions.push(action);
     }
 
-    if !verbosity.is_quiet() {
+    if wait && !verbosity.is_quiet() {
         let mut spinner = SpinnerView::new("Stopping instance(s)");
         while actions.iter().any(|action| !action.is_done(instance_dao)) {
             thread::sleep(Duration::from_secs(1))


### PR DESCRIPTION
Do not wait anymore by default for the virtual machine instance to be started or stopped. Instead the user need to pass the -w/--wait flag if the waiting is desired.