### PR TITLE
feat: add port forwarding argument to add/run commands

### DIFF
--- a/docs/reference/add.rst
+++ b/docs/reference/add.rst
@@ -19,4 +19,5 @@ cubic add
       -c, --cpus <CPUS>    Number of CPUs for the virtual machine instance [default: 4]
       -m, --mem <MEM>      Memory size of the virtual machine instance (e.g. 1G for 1 gigabyte) [default: 4G]
       -d, --disk <DISK>    Disk size of the virtual machine instance (e.g. 10G for 10 gigabytes) [default: 100G]
+      -p, --port <PORT>    Forward ports from guest to host (e.g. -p 8000:80 or -p 127.0.0.1:9000:90/tcp)
       -h, --help           Print help

--- a/docs/reference/run.rst
+++ b/docs/reference/run.rst
@@ -19,6 +19,7 @@ cubic run
       -c, --cpus <CPUS>    Number of CPUs for the virtual machine instance [default: 4]
       -m, --mem <MEM>      Memory size of the virtual machine instance (e.g. 1G for 1 gigabyte) [default: 4G]
       -d, --disk <DISK>    Disk size of the virtual machine instance (e.g. 10G for 10 gigabytes) [default: 100G]
+      -p, --port <PORT>    Forward ports from guest to host (e.g. -p 8000:80 or -p 127.0.0.1:9000:90/tcp)
       -v, --verbose        Enable verbose logging
       -q, --quiet          Reduce logging output
       -h, --help           Print help

--- a/src/commands/instance_run_command.rs
+++ b/src/commands/instance_run_command.rs
@@ -4,7 +4,7 @@ use crate::commands::instance_add_command::{
 };
 use crate::error::Error;
 use crate::image::ImageDao;
-use crate::instance::InstanceDao;
+use crate::instance::{InstanceDao, PortForward};
 use clap::Parser;
 
 /// Create, start and open a shell in a new virtual machine instance
@@ -31,6 +31,9 @@ pub struct InstanceRunCommand {
     /// Disk size of the virtual machine instance (e.g. 10G for 10 gigabytes)
     #[clap(short, long, default_value = DEFAULT_DISK_SIZE)]
     disk: String,
+    /// Forward ports from guest to host (e.g. -p 8000:80 or -p 127.0.0.1:9000:90/tcp)
+    #[clap(short, long)]
+    port: Vec<PortForward>,
     /// Enable verbose logging
     #[clap(short, long, default_value_t = false)]
     verbose: bool,
@@ -55,6 +58,7 @@ impl InstanceRunCommand {
             self.cpus,
             self.mem.clone(),
             self.disk.clone(),
+            self.port.clone(),
         )
         .run(image_dao, instance_dao)?;
         commands::InstanceSshCommand {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2,12 +2,14 @@ pub mod instance_dao;
 pub mod instance_state;
 pub mod instance_store;
 pub mod instance_store_mock;
+pub mod port_forward;
 
 use crate::arch::Arch;
 pub use crate::error::Error;
 pub use instance_dao::*;
 pub use instance_state::*;
 pub use instance_store::*;
+pub use port_forward::*;
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 

--- a/src/instance/port_forward.rs
+++ b/src/instance/port_forward.rs
@@ -1,0 +1,176 @@
+use regex::Regex;
+use std::net::IpAddr;
+use std::str::FromStr;
+
+const FORMAT_ERROR: &str = "Must comply with format: [host_ip:]host_port:guest_port[/(udp|tcp)] (e.g. -p 8000:80 or -p 127.0.0.1:9000:90/tcp)";
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Protocol {
+    Udp,
+    Tcp,
+    Both,
+}
+
+impl FromStr for Protocol {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "udp" => Ok(Protocol::Udp),
+            "tcp" => Ok(Protocol::Tcp),
+            _ => Err(FORMAT_ERROR.to_string()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PortForward {
+    host_ip: Option<IpAddr>,
+    host_port: u16,
+    guest_port: u16,
+    protocol: Protocol,
+}
+
+impl PortForward {
+    pub fn new(
+        host_ip: Option<IpAddr>,
+        host_port: u16,
+        guest_port: u16,
+        protocol: Protocol,
+    ) -> Self {
+        Self {
+            host_ip,
+            host_port,
+            guest_port,
+            protocol,
+        }
+    }
+
+    pub fn to_qemu(&self) -> String {
+        format!(
+            "{}:{}:{}-:{}",
+            match self.protocol {
+                Protocol::Udp => "udp",
+                Protocol::Tcp => "tcp",
+                Protocol::Both => "",
+            },
+            self.host_ip.map(|ip| ip.to_string()).unwrap_or_default(),
+            self.host_port,
+            self.guest_port
+        )
+    }
+}
+
+impl FromStr for PortForward {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let re = Regex::new(r"^(([\d.:]+):)?(\d+):(\d+)(/(\w+))?$").unwrap();
+        let caps: Vec<_> = re
+            .captures(value)
+            .ok_or(FORMAT_ERROR.to_string())?
+            .iter()
+            .collect();
+
+        if let &[_, _, host_ip, Some(host_port), Some(guest_port), _, protocol] = caps.as_slice() {
+            Ok(Self::new(
+                if let Some(ip) = host_ip {
+                    Some(
+                        ip.as_str()
+                            .parse::<IpAddr>()
+                            .map_err(|_| FORMAT_ERROR.to_string())?,
+                    )
+                } else {
+                    None
+                },
+                host_port
+                    .as_str()
+                    .parse::<u16>()
+                    .map_err(|_| FORMAT_ERROR.to_string())?,
+                guest_port
+                    .as_str()
+                    .parse::<u16>()
+                    .map_err(|_| FORMAT_ERROR.to_string())?,
+                if let Some(protocol) = protocol {
+                    protocol
+                        .as_str()
+                        .parse()
+                        .map_err(|_| FORMAT_ERROR.to_string())?
+                } else {
+                    Protocol::Both
+                },
+            ))
+        } else {
+            Err(FORMAT_ERROR.to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn test_basic_parsing() {
+        assert_eq!(
+            "1000:10".parse(),
+            Ok(PortForward::new(None, 1000, 10, Protocol::Both))
+        )
+    }
+
+    #[test]
+    fn test_localhost_parsing() {
+        assert_eq!(
+            "127.0.0.1:2000:20".parse(),
+            Ok(PortForward::new(
+                Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+                2000,
+                20,
+                Protocol::Both
+            ))
+        )
+    }
+
+    #[test]
+    fn test_udp_parsing() {
+        assert_eq!(
+            "3000:30/udp".parse(),
+            Ok(PortForward::new(None, 3000, 30, Protocol::Udp))
+        )
+    }
+
+    #[test]
+    fn test_tcp_parsing() {
+        assert_eq!(
+            "4000:40/tcp".parse(),
+            Ok(PortForward::new(None, 4000, 40, Protocol::Tcp))
+        )
+    }
+
+    #[test]
+    fn test_ip_udp_parsing() {
+        assert_eq!(
+            "0.0.0.0:5000:50/udp".parse(),
+            Ok(PortForward::new(
+                Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
+                5000,
+                50,
+                Protocol::Udp
+            ))
+        )
+    }
+
+    #[test]
+    fn test_ip_tcp_parsing() {
+        assert_eq!(
+            "192.168.0.1:6000:60/tcp".parse(),
+            Ok(PortForward::new(
+                Some(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))),
+                6000,
+                60,
+                Protocol::Tcp
+            ))
+        )
+    }
+}


### PR DESCRIPTION
Added a new command line argument (-p/--port) to the commands 'add' and 'run' to allow port forwarding from the guest to the host.

Examples of the new argument:

    Create an instance with the name 'example1' and forward the guest port 80 to
    the host port 8000.
    $ cubic add --image debian:bookworm -p 8000:80 example1

    Create an instance with the name 'example2'and forward the guest tcp port 22
    to the host ip 127.0.0.1 and host tcp port 9000.
    $ cubic add --image debian:bookworm -p 127.0.0.1:9000:22/tcp example2

    Create an instance with the name 'example3' and forward the guest ports 80
    and 81 to the host ports 8000 and 8001.
    $ cubic add --image debian:bookworm -p 8000:80 -p 8001:81 example1