### PR TITLE
fix: expose forwarded ports without an ip on localhost

### DIFF
--- a/src/commands/instance_add_command.rs
+++ b/src/commands/instance_add_command.rs
@@ -90,7 +90,7 @@ impl InstanceAddCommand {
             mem: util::human_readable_to_bytes(&self.mem)?,
             disk_capacity: 0, // Will be overwritten by resize operation below
             ssh_port,
-            hostfwd: self.port.iter().map(|p| p.to_qemu()).collect(),
+            hostfwd: self.port.clone(),
         };
         instance_dao.resize(&mut instance, disk_capacity)?;
         instance_dao.store(&instance)?;

--- a/src/commands/instance_info_command.rs
+++ b/src/commands/instance_info_command.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::instance::{InstanceStore, PortForward};
+use crate::instance::InstanceStore;
 use crate::util;
 use crate::view::{Console, MapView};
 use clap::Parser;
@@ -36,7 +36,7 @@ impl InstanceInfoCommand {
 
         for (index, rule) in instance.hostfwd.iter().enumerate() {
             let key = if index == 0 { "Forward" } else { "" };
-            view.add(key, &PortForward::from_qemu(rule).unwrap().to_string());
+            view.add(key, &rule.to_string());
         }
 
         view.print(console);

--- a/src/commands/instance_modify_command.rs
+++ b/src/commands/instance_modify_command.rs
@@ -41,11 +41,8 @@ impl InstanceModifyCommand {
             instance_dao.resize(&mut instance, util::human_readable_to_bytes(disk)?)?;
         }
 
-        let add_ports = &mut self.port.iter().map(|p| p.to_qemu()).collect::<Vec<_>>();
-        instance.hostfwd.append(add_ports);
-
-        let remove_ports = &mut self.rm_port.iter().map(|p| p.to_qemu()).collect::<Vec<_>>();
-        instance.hostfwd.retain(|p| !remove_ports.contains(p));
+        instance.hostfwd.append(&mut self.port.clone());
+        instance.hostfwd.retain(|p| !self.rm_port.contains(p));
 
         instance_dao.store(&instance)?;
         Result::Ok(())

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1,5 +1,6 @@
 use crate::arch::Arch;
 use crate::error::Error;
+use crate::instance::PortForward;
 use crate::util::SystemCommand;
 
 pub struct Emulator {
@@ -102,11 +103,11 @@ impl Emulator {
             .arg("chardev:console");
     }
 
-    pub fn set_network(&mut self, hostfwd: &[String], ssh_port: u16) {
+    pub fn set_network(&mut self, hostfwd: &[PortForward], ssh_port: u16) {
         let mut hostfwd_options = String::new();
         for fwd in hostfwd {
             hostfwd_options.push_str(",hostfwd=");
-            hostfwd_options.push_str(fwd);
+            hostfwd_options.push_str(&fwd.to_qemu());
         }
 
         self.command

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -30,7 +30,7 @@ pub struct Instance {
     pub disk_capacity: u64,
     pub ssh_port: u16,
     #[serde(default)]
-    pub hostfwd: Vec<String>,
+    pub hostfwd: Vec<PortForward>,
 }
 
 impl Instance {
@@ -114,7 +114,11 @@ machine:
         assert_eq!(instance.disk_capacity, 2361393152);
         assert_eq!(instance.ssh_port, 14357);
         assert_eq!(
-            instance.hostfwd,
+            instance
+                .hostfwd
+                .iter()
+                .map(|rule| rule.to_qemu())
+                .collect::<Vec<_>>(),
             ["tcp:127.0.0.1:8000-:8000", "tcp:127.0.0.1:9000-:10000"]
         );
     }


### PR DESCRIPTION
For security reasons treat the port forwarding rule '-p 8000:80' as '-p 127.0.0.1:8000:80/tcp' and not as '-p 0.0.0.0:8000:80/tcp'. This prevents that users expose virtual machine instance ports by accidents to their local area network.