### PR TITLE
feat: use default paths if xdg environment is undefined

### DIFF
--- a/src/env/environment_factory.rs
+++ b/src/env/environment_factory.rs
@@ -11,9 +11,13 @@ impl EnvironmentFactory {
 
     #[cfg(target_os = "linux")]
     pub fn create_env() -> Result<Environment, Error> {
-        let data_dir = Self::read_env("SNAP_USER_COMMON").or(Self::read_env("XDG_DATA_HOME"))?;
-        let cache_dir = Self::read_env("XDG_CACHE_HOME")?;
-        let runtime_dir = Self::read_env("XDG_RUNTIME_DIR")?;
+        let data_dir = Self::read_env("SNAP_USER_COMMON")
+            .or(Self::read_env("XDG_DATA_HOME"))
+            .or_else(|_| Self::read_env("HOME").map(|home| format!("{home}/.local/share")))?;
+        let cache_dir = Self::read_env("XDG_CACHE_HOME")
+            .or_else(|_| Self::read_env("HOME").map(|home| format!("{home}/.cache")))?;
+        let runtime_dir = Self::read_env("XDG_RUNTIME_DIR")
+            .or_else(|_| Self::read_env("UID").map(|uid| format!("/run/user/{uid}")))?;
 
         Ok(Environment::new(
             format!("{data_dir}/cubic"),


### PR DESCRIPTION
Use the following default paths under Linux if the XDG environment variables are not found:
    XDG_DATA_HOME   => $HOME/.local/share
    XDG_CACHE_HOME  => $HOME/.cache
    XDG_RUNTIME_DIR => /run/user/$UID