### PR TITLE
feat: add instance name validation

### DIFF
--- a/src/commands/instance_add_command.rs
+++ b/src/commands/instance_add_command.rs
@@ -1,7 +1,7 @@
 use crate::commands::image::ImageCommands;
 use crate::error::Error;
 use crate::image::{ImageDao, ImageStore};
-use crate::instance::{Instance, InstanceDao, InstanceStore, PortForward};
+use crate::instance::{Instance, InstanceDao, InstanceName, InstanceStore, PortForward};
 use crate::util;
 use clap::Parser;
 
@@ -14,13 +14,13 @@ pub const DEFAULT_DISK_SIZE: &str = "100G";
 pub struct InstanceAddCommand {
     /// Name of the virtual machine instance
     #[clap(conflicts_with = "name")]
-    instance_name: Option<String>,
+    instance_name: Option<InstanceName>,
     /// Name of the virtual machine image
     #[clap(short, long)]
     image: String,
     /// Name of the virtual machine instance
     #[clap(short, long, conflicts_with = "instance_name", hide = true)]
-    name: Option<String>,
+    name: Option<InstanceName>,
     /// Name of the user
     #[clap(short, long, default_value = "cubic")]
     user: String,
@@ -40,7 +40,7 @@ pub struct InstanceAddCommand {
 
 impl InstanceAddCommand {
     pub fn new(
-        instance_name: String,
+        instance_name: InstanceName,
         image: String,
         user: String,
         cpus: u16,

--- a/src/commands/instance_clone_command.rs
+++ b/src/commands/instance_clone_command.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::instance::{InstanceDao, InstanceStore};
+use crate::instance::{InstanceDao, InstanceName, InstanceStore};
 use crate::util;
 use clap::Parser;
 
@@ -7,16 +7,19 @@ use clap::Parser;
 #[derive(Parser)]
 pub struct InstanceCloneCommand {
     /// Name of the virtual machine instance to clone
-    name: String,
+    name: InstanceName,
     /// Name of the copy
-    new_name: String,
+    new_name: InstanceName,
 }
 
 impl InstanceCloneCommand {
     pub fn run(&self, instance_dao: &InstanceDao) -> Result<(), Error> {
-        instance_dao.clone(&instance_dao.load(&self.name)?, &self.new_name)?;
+        instance_dao.clone(
+            &instance_dao.load(self.name.as_str())?,
+            self.new_name.as_str(),
+        )?;
 
-        let mut new_instance = instance_dao.load(&self.new_name)?;
+        let mut new_instance = instance_dao.load(self.new_name.as_str())?;
         new_instance.ssh_port = util::generate_random_ssh_port();
         instance_dao.store(&new_instance)
     }

--- a/src/commands/instance_rename_command.rs
+++ b/src/commands/instance_rename_command.rs
@@ -1,18 +1,21 @@
 use crate::error::Error;
-use crate::instance::{InstanceDao, InstanceStore};
+use crate::instance::{InstanceDao, InstanceName, InstanceStore};
 use clap::Parser;
 
 /// Rename a virtual machine instance
 #[derive(Parser)]
 pub struct InstanceRenameCommand {
     /// Name of the virtual machine instance to rename
-    old_name: String,
+    old_name: InstanceName,
     /// New name of the virtual machine instance
-    new_name: String,
+    new_name: InstanceName,
 }
 
 impl InstanceRenameCommand {
     pub fn run(&self, instance_dao: &InstanceDao) -> Result<(), Error> {
-        instance_dao.rename(&mut instance_dao.load(&self.old_name)?, &self.new_name)
+        instance_dao.rename(
+            &mut instance_dao.load(self.old_name.as_str())?,
+            self.new_name.as_str(),
+        )
     }
 }

--- a/src/commands/instance_run_command.rs
+++ b/src/commands/instance_run_command.rs
@@ -4,7 +4,7 @@ use crate::commands::instance_add_command::{
 };
 use crate::error::Error;
 use crate::image::ImageDao;
-use crate::instance::{InstanceDao, PortForward};
+use crate::instance::{InstanceDao, InstanceName, PortForward};
 use clap::Parser;
 
 /// Create, start and open a shell in a new virtual machine instance
@@ -12,13 +12,13 @@ use clap::Parser;
 pub struct InstanceRunCommand {
     /// Name of the virtual machine instance
     #[clap(conflicts_with = "name")]
-    instance_name: Option<String>,
+    instance_name: Option<InstanceName>,
     /// Name of the virtual machine image
     #[clap(short, long)]
     image: String,
     /// Name of the virtual machine instance
     #[clap(short, long, conflicts_with = "instance_name", hide = true)]
-    name: Option<String>,
+    name: Option<InstanceName>,
     /// Name of the user
     #[clap(short, long, default_value = "cubic")]
     user: String,
@@ -48,8 +48,7 @@ impl InstanceRunCommand {
             .instance_name
             .as_ref()
             .or(self.name.as_ref())
-            .ok_or(Error::InvalidArgument("Missing instance name".to_string()))?
-            .to_string();
+            .ok_or(Error::InvalidArgument("Missing instance name".to_string()))?;
 
         InstanceAddCommand::new(
             instance_name.clone(),
@@ -62,7 +61,7 @@ impl InstanceRunCommand {
         )
         .run(image_dao, instance_dao)?;
         commands::InstanceSshCommand {
-            instance: instance_name.clone(),
+            instance: instance_name.to_string(),
             xforward: false,
             verbose: self.verbose,
             quiet: self.quiet,

--- a/src/commands/instance_show_command.rs
+++ b/src/commands/instance_show_command.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::instance::InstanceStore;
+use crate::instance::{InstanceName, InstanceStore};
 use crate::util;
 use crate::view::{Console, MapView};
 use clap::Parser;
@@ -8,7 +8,7 @@ use clap::Parser;
 #[derive(Parser)]
 pub struct InstanceShowCommand {
     /// Name of the virtual machine instance
-    instance: String,
+    instance: InstanceName,
 }
 
 impl InstanceShowCommand {
@@ -17,11 +17,11 @@ impl InstanceShowCommand {
         console: &mut dyn Console,
         instance_store: &dyn InstanceStore,
     ) -> Result<(), Error> {
-        if !instance_store.exists(&self.instance) {
+        if !instance_store.exists(self.instance.as_str()) {
             return Result::Err(Error::UnknownInstance(self.instance.to_string()));
         }
 
-        let instance = instance_store.load(&self.instance)?;
+        let instance = instance_store.load(self.instance.as_str())?;
 
         let mut view = MapView::new();
         view.add("Arch", &instance.arch.to_string());
@@ -52,6 +52,7 @@ mod tests {
     use crate::instance::instance_store_mock::tests::InstanceStoreMock;
     use crate::instance::Instance;
     use crate::view::console_mock::tests::ConsoleMock;
+    use std::str::FromStr;
 
     #[test]
     fn test_show_command() {
@@ -68,7 +69,7 @@ mod tests {
         }]);
 
         InstanceShowCommand {
-            instance: "test".to_string(),
+            instance: InstanceName::from_str("test").unwrap(),
         }
         .run(console, instance_store)
         .unwrap();
@@ -93,7 +94,7 @@ SSH Port: 9000
 
         assert!(matches!(
             InstanceShowCommand {
-                instance: "test".to_string()
+                instance: InstanceName::from_str("test").unwrap()
             }
             .run(console, instance_store),
             Result::Err(Error::UnknownInstance(_))

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,4 +1,5 @@
 pub mod instance_dao;
+pub mod instance_name;
 pub mod instance_state;
 pub mod instance_store;
 pub mod instance_store_mock;
@@ -7,6 +8,7 @@ pub mod port_forward;
 use crate::arch::Arch;
 pub use crate::error::Error;
 pub use instance_dao::*;
+pub use instance_name::*;
 pub use instance_state::*;
 pub use instance_store::*;
 pub use port_forward::*;

--- a/src/instance/instance_name.rs
+++ b/src/instance/instance_name.rs
@@ -1,0 +1,72 @@
+use regex::Regex;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Clone)]
+pub struct InstanceName {
+    name: String,
+}
+
+impl InstanceName {
+    pub fn as_str(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+impl FromStr for InstanceName {
+    type Err = String;
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        if Regex::new("^[\\w_-]+$").unwrap().is_match(name) {
+            Ok(Self {
+                name: name.to_string(),
+            })
+        } else {
+            Err(
+                "Instance name must only contain letters, numbers, underlines and dashes"
+                    .to_string(),
+            )
+        }
+    }
+}
+
+impl fmt::Display for InstanceName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_letters() {
+        InstanceName::from_str("foobar").unwrap();
+    }
+
+    #[test]
+    fn test_numbers() {
+        InstanceName::from_str("12345").unwrap();
+    }
+
+    #[test]
+    fn test_underline() {
+        InstanceName::from_str("_").unwrap();
+    }
+
+    #[test]
+    fn test_dash() {
+        InstanceName::from_str("-").unwrap();
+    }
+
+    #[test]
+    fn test_valid_name() {
+        InstanceName::from_str("10foo-bar_5").unwrap();
+    }
+
+    #[test]
+    fn test_invalid_name() {
+        assert!(InstanceName::from_str("foo/bar").is_err());
+    }
+}


### PR DESCRIPTION
Restricted instance names to unicode letters, numbers, underlines and dashes to avoid problems with OS file names.