### PR TITLE
refactor: define verbose and quiet as global flags

### DIFF
--- a/docs/reference/add.rst
+++ b/docs/reference/add.rst
@@ -20,4 +20,6 @@ cubic add
       -m, --mem <MEM>      Memory size of the virtual machine instance (e.g. 1G for 1 gigabyte) [default: 4G]
       -d, --disk <DISK>    Disk size of the virtual machine instance (e.g. 10G for 10 gigabytes) [default: 100G]
       -p, --port <PORT>    Forward ports from guest to host (e.g. -p 8000:80 or -p 127.0.0.1:9000:90/tcp)
+      -v, --verbose        Increase logging output
+      -q, --quiet          Reduce logging output
       -h, --help           Print help

--- a/docs/reference/clone.rst
+++ b/docs/reference/clone.rst
@@ -8,11 +8,13 @@ cubic clone
     $ cubic clone --help
     Clone a virtual machine instance
 
-    Usage: cubic clone <NAME> <NEW_NAME>
+    Usage: cubic clone [OPTIONS] <NAME> <NEW_NAME>
 
     Arguments:
       <NAME>      Name of the virtual machine instance to clone
       <NEW_NAME>  Name of the copy
 
     Options:
-      -h, --help  Print help
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
+      -h, --help     Print help

--- a/docs/reference/console.rst
+++ b/docs/reference/console.rst
@@ -8,10 +8,12 @@ cubic console
     $ cubic console --help
     Open the console of an virtual machine instance
 
-    Usage: cubic console <INSTANCE>
+    Usage: cubic console [OPTIONS] <INSTANCE>
 
     Arguments:
       <INSTANCE>  Name of the virtual machine instance
 
     Options:
-      -h, --help  Print help
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
+      -h, --help     Print help

--- a/docs/reference/cubic.rst
+++ b/docs/reference/cubic.rst
@@ -35,7 +35,7 @@ cubic
     $ cubic scp <machine>:<path/to/guest/file> <path/to/host/file>
 
 
-    Usage: cubic [COMMAND]
+    Usage: cubic [OPTIONS] [COMMAND]
 
     Commands:
       run      Create, start and open a shell in a new virtual machine instance
@@ -57,5 +57,7 @@ cubic
       help     Print this message or the help of the given subcommand(s)
 
     Options:
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
       -h, --help     Print help
       -V, --version  Print version

--- a/docs/reference/image.rst
+++ b/docs/reference/image.rst
@@ -8,7 +8,7 @@ cubic image
     $ cubic image --help
     Image subcommands
 
-    Usage: cubic image <COMMAND>
+    Usage: cubic image [OPTIONS] <COMMAND>
 
     Commands:
       ls     List images
@@ -18,4 +18,6 @@ cubic image
       help   Print this message or the help of the given subcommand(s)
 
     Options:
-      -h, --help  Print help
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
+      -h, --help     Print help

--- a/docs/reference/ls.rst
+++ b/docs/reference/ls.rst
@@ -6,9 +6,11 @@ cubic ls
 .. code-block::
 
     $ cubic ls --help
-    List virtual machine instances
+    List all virtual machine instances
 
-    Usage: cubic ls
+    Usage: cubic ls [OPTIONS]
 
     Options:
-      -h, --help  Print help
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
+      -h, --help     Print help

--- a/docs/reference/modify.rst
+++ b/docs/reference/modify.rst
@@ -19,4 +19,6 @@ cubic modify
       -d, --disk <DISK>        Disk size of the virtual machine instance  (e.g. 10G for 10 gigabytes)
       -p, --port <PORT>        Add port forwarding rule (e.g. -p 8000:80)
       -P, --rm-port <RM_PORT>  Remove port forwarding rule (e.g. -P 8000:80)
+      -v, --verbose            Increase logging output
+      -q, --quiet              Reduce logging output
       -h, --help               Print help

--- a/docs/reference/prune.rst
+++ b/docs/reference/prune.rst
@@ -8,7 +8,9 @@ cubic prune
     $ cubic prune --help
     Clear cache and free space
 
-    Usage: cubic prune
+    Usage: cubic prune [OPTIONS]
 
     Options:
-      -h, --help  Print help
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
+      -h, --help     Print help

--- a/docs/reference/rename.rst
+++ b/docs/reference/rename.rst
@@ -8,11 +8,12 @@ cubic rename
     $ cubic rename --help
     Rename a virtual machine instance
 
-    Usage: cubic rename <OLD_NAME> <NEW_NAME>
+    Usage: cubic rename [OPTIONS] <OLD_NAME> <NEW_NAME>
 
     Arguments:
       <OLD_NAME>  Name of the virtual machine instance to rename
       <NEW_NAME>  New name of the virtual machine instance
 
     Options:
-      -h, --help  Print help
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging

--- a/docs/reference/restart.rst
+++ b/docs/reference/restart.rst
@@ -14,6 +14,6 @@ cubic restart
       [INSTANCES]...  Name of the virtual machine instances to restart
 
     Options:
-      -v, --verbose  Enable verbose logging
+      -v, --verbose  Increase logging output
       -q, --quiet    Reduce logging output
       -h, --help     Print help

--- a/docs/reference/rm.rst
+++ b/docs/reference/rm.rst
@@ -14,8 +14,8 @@ cubic rm
       [INSTANCES]...  Name of the virtual machine instances to delete
 
     Options:
-      -v, --verbose  Enable verbose logging
-      -q, --quiet    Reduce logging output
       -f, --force    Delete the virtual machine instances even when running
       -y, --yes      Delete the virtual machine instances without confirmation
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
       -h, --help     Print help

--- a/docs/reference/run.rst
+++ b/docs/reference/run.rst
@@ -20,6 +20,6 @@ cubic run
       -m, --mem <MEM>      Memory size of the virtual machine instance (e.g. 1G for 1 gigabyte) [default: 4G]
       -d, --disk <DISK>    Disk size of the virtual machine instance (e.g. 10G for 10 gigabytes) [default: 100G]
       -p, --port <PORT>    Forward ports from guest to host (e.g. -p 8000:80 or -p 127.0.0.1:9000:90/tcp)
-      -v, --verbose        Enable verbose logging
+      -v, --verbose        Increase logging output
       -q, --quiet          Reduce logging output
       -h, --help           Print help

--- a/docs/reference/scp.rst
+++ b/docs/reference/scp.rst
@@ -15,7 +15,7 @@ cubic scp
       <TO>    Target of the data to copy
 
     Options:
-      -v, --verbose              Enable verbose logging
-      -q, --quiet                Reduce logging output
           --scp-args <SCP_ARGS>  Pass additional SCP arguments
+      -v, --verbose              Increase logging output
+      -q, --quiet                Reduce logging output
       -h, --help                 Print help

--- a/docs/reference/show.rst
+++ b/docs/reference/show.rst
@@ -8,10 +8,12 @@ cubic show
     $ cubic show --help
     Show a virtual machine instance
 
-    Usage: cubic show <INSTANCE>
+    Usage: cubic show [OPTIONS] <INSTANCE>
 
     Arguments:
       <INSTANCE>  Name of the virtual machine instance
 
     Options:
-      -h, --help  Print help
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
+      -h, --help     Print help

--- a/docs/reference/ssh.rst
+++ b/docs/reference/ssh.rst
@@ -16,7 +16,7 @@ cubic ssh
 
     Options:
       -X                         Forward X over SSH
-      -v, --verbose              Enable verbose logging
-      -q, --quiet                Reduce logging output
           --ssh-args <SSH_ARGS>  Pass additional SSH arguments
+      -v, --verbose              Increase logging output
+      -q, --quiet                Reduce logging output
       -h, --help                 Print help

--- a/docs/reference/start.rst
+++ b/docs/reference/start.rst
@@ -15,7 +15,7 @@ cubic start
 
     Options:
           --qemu-args <QEMU_ARGS>  Pass additional QEMU arguments
-      -v, --verbose                Enable verbose logging
-      -q, --quiet                  Reduce logging output
       -w, --wait                   Wait for the virtual machine instance to be started
+      -v, --verbose                Increase logging output
+      -q, --quiet                  Reduce logging output
       -h, --help                   Print help

--- a/docs/reference/stop.rst
+++ b/docs/reference/stop.rst
@@ -15,7 +15,7 @@ cubic stop
 
     Options:
       -a, --all      Stop all virtual machine instances
-      -v, --verbose  Enable verbose logging
-      -q, --quiet    Reduce logging output
       -w, --wait     Wait for the virtual machine instance to be stopped
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
       -h, --help     Print help

--- a/src/commands/instance_console_command.rs
+++ b/src/commands/instance_console_command.rs
@@ -15,15 +15,17 @@ pub struct InstanceConsoleCommand {
 }
 
 impl InstanceConsoleCommand {
-    pub fn run(&self, instance_dao: &InstanceDao) -> Result<(), Error> {
+    pub fn run(
+        &self,
+        instance_dao: &InstanceDao,
+        verbosity: commands::Verbosity,
+    ) -> Result<(), Error> {
         commands::InstanceStartCommand {
             qemu_args: None,
-            verbose: false,
-            quiet: true,
             wait: false,
             instances: vec![self.instance.to_string()],
         }
-        .run(instance_dao)?;
+        .run(instance_dao, verbosity)?;
 
         println!("Press CTRL+W to exit the console.");
         let console_path = instance_dao.env.get_console_file(&self.instance);

--- a/src/commands/instance_remove_command.rs
+++ b/src/commands/instance_remove_command.rs
@@ -1,4 +1,4 @@
-use crate::commands::{self};
+use crate::commands;
 use crate::error::Error;
 use crate::instance::{InstanceDao, InstanceStore};
 use crate::util;
@@ -7,12 +7,6 @@ use clap::Parser;
 /// Delete virtual machine instances
 #[derive(Parser)]
 pub struct InstanceRemoveCommand {
-    /// Enable verbose logging
-    #[clap(short, long, default_value_t = false)]
-    verbose: bool,
-    /// Reduce logging output
-    #[clap(short, long, default_value_t = false)]
-    quiet: bool,
     /// Delete the virtual machine instances even when running
     #[clap(short, long, default_value_t = false)]
     force: bool,
@@ -24,16 +18,18 @@ pub struct InstanceRemoveCommand {
 }
 
 impl InstanceRemoveCommand {
-    pub fn run(&self, instance_dao: &InstanceDao) -> Result<(), Error> {
+    pub fn run(
+        &self,
+        instance_dao: &InstanceDao,
+        verbosity: commands::Verbosity,
+    ) -> Result<(), Error> {
         if self.force {
             commands::InstanceStopCommand {
                 all: false,
-                verbose: self.verbose,
-                quiet: self.quiet,
                 wait: true,
                 instances: self.instances.clone(),
             }
-            .run(instance_dao)?;
+            .run(instance_dao, verbosity)?;
         }
 
         for instance in &self.instances {

--- a/src/commands/instance_restart_command.rs
+++ b/src/commands/instance_restart_command.rs
@@ -6,33 +6,27 @@ use clap::Parser;
 /// Restart virtual machine instances
 #[derive(Parser)]
 pub struct InstanceRestartCommand {
-    /// Enable verbose logging
-    #[clap(short, long, default_value_t = false)]
-    verbose: bool,
-    /// Reduce logging output
-    #[clap(short, long, default_value_t = false)]
-    quiet: bool,
     /// Name of the virtual machine instances to restart
     instances: Vec<String>,
 }
 
 impl InstanceRestartCommand {
-    pub fn run(&self, instance_dao: &InstanceDao) -> Result<(), Error> {
+    pub fn run(
+        &self,
+        instance_dao: &InstanceDao,
+        verbosity: commands::Verbosity,
+    ) -> Result<(), Error> {
         commands::InstanceStopCommand {
             all: false,
-            verbose: self.verbose,
-            quiet: self.quiet,
             wait: true,
             instances: self.instances.to_vec(),
         }
-        .run(instance_dao)?;
+        .run(instance_dao, verbosity)?;
         commands::InstanceStartCommand {
             qemu_args: None,
-            verbose: self.verbose,
-            quiet: self.quiet,
             wait: true,
             instances: self.instances.to_vec(),
         }
-        .run(instance_dao)
+        .run(instance_dao, verbosity)
     }
 }

--- a/src/commands/instance_run_command.rs
+++ b/src/commands/instance_run_command.rs
@@ -9,27 +9,24 @@ use clap::Parser;
 pub struct InstanceRunCommand {
     #[clap(flatten)]
     add_cmd: commands::InstanceAddCommand,
-    /// Enable verbose logging
-    #[clap(short, long, default_value_t = false)]
-    verbose: bool,
-    /// Reduce logging output
-    #[clap(short, long, default_value_t = false)]
-    quiet: bool,
 }
 
 impl InstanceRunCommand {
-    pub fn run(&self, image_dao: &ImageDao, instance_dao: &InstanceDao) -> Result<(), Error> {
+    pub fn run(
+        &self,
+        image_dao: &ImageDao,
+        instance_dao: &InstanceDao,
+        verbosity: commands::Verbosity,
+    ) -> Result<(), Error> {
         let instance_name = self.add_cmd.get_name()?;
 
         self.add_cmd.run(image_dao, instance_dao)?;
         commands::InstanceSshCommand {
             target: Target::from_instance_name(instance_name.clone()),
             xforward: false,
-            verbose: self.verbose,
-            quiet: self.quiet,
             ssh_args: None,
             cmd: None,
         }
-        .run(instance_dao)
+        .run(instance_dao, verbosity)
     }
 }

--- a/src/commands/instance_scp_command.rs
+++ b/src/commands/instance_scp_command.rs
@@ -1,4 +1,4 @@
-use crate::commands::Verbosity;
+use crate::commands;
 use crate::error::Error;
 use crate::instance::{InstanceStore, TargetPath};
 use crate::ssh_cmd::{get_ssh_private_key_names, Scp};
@@ -12,22 +12,19 @@ pub struct InstanceScpCommand {
     from: TargetPath,
     /// Target of the data to copy
     to: TargetPath,
-    /// Enable verbose logging
-    #[clap(short, long, default_value_t = false)]
-    verbose: bool,
-    /// Reduce logging output
-    #[clap(short, long, default_value_t = false)]
-    quiet: bool,
     /// Pass additional SCP arguments
     #[clap(long)]
     scp_args: Option<String>,
 }
 
 impl InstanceScpCommand {
-    pub fn run(&self, instance_store: &dyn InstanceStore) -> Result<(), Error> {
+    pub fn run(
+        &self,
+        instance_store: &dyn InstanceStore,
+        verbosity: commands::Verbosity,
+    ) -> Result<(), Error> {
         let from = &self.from.to_scp(instance_store)?;
         let to = &self.to.to_scp(instance_store)?;
-        let verbosity = Verbosity::new(self.verbose, self.quiet);
 
         Scp::new()
             .set_root_dir(env::var("SNAP").unwrap_or_default().as_str())

--- a/src/commands/instance_ssh_command.rs
+++ b/src/commands/instance_ssh_command.rs
@@ -16,12 +16,6 @@ pub struct InstanceSshCommand {
     /// Forward X over SSH
     #[clap(short = 'X', default_value_t = false)]
     pub xforward: bool,
-    /// Enable verbose logging
-    #[clap(short, long, default_value_t = false)]
-    pub verbose: bool,
-    /// Reduce logging output
-    #[clap(short, long, default_value_t = false)]
-    pub quiet: bool,
     /// Pass additional SSH arguments
     #[clap(long)]
     pub ssh_args: Option<String>,
@@ -30,7 +24,7 @@ pub struct InstanceSshCommand {
 }
 
 impl InstanceSshCommand {
-    pub fn run(&self, instance_dao: &InstanceDao) -> Result<(), Error> {
+    pub fn run(&self, instance_dao: &InstanceDao, verbosity: Verbosity) -> Result<(), Error> {
         let name = self.target.get_instance();
         let instance = instance_dao.load(name.as_str())?;
         let user = self
@@ -39,16 +33,13 @@ impl InstanceSshCommand {
             .map(|user| user.to_string())
             .unwrap_or(instance.user.to_string());
         let ssh_port = instance.ssh_port;
-        let verbosity = Verbosity::new(self.verbose, self.quiet);
 
         commands::InstanceStartCommand {
             qemu_args: None,
-            verbose: self.verbose,
-            quiet: self.quiet,
             wait: true,
             instances: vec![name.to_string()],
         }
-        .run(instance_dao)?;
+        .run(instance_dao, verbosity)?;
 
         let mut ssh = None;
         let mut start_time = Instant::now();

--- a/src/commands/instance_start_command.rs
+++ b/src/commands/instance_start_command.rs
@@ -13,12 +13,6 @@ pub struct InstanceStartCommand {
     /// Pass additional QEMU arguments
     #[clap(long)]
     pub qemu_args: Option<String>,
-    /// Enable verbose logging
-    #[clap(short, long, default_value_t = false)]
-    pub verbose: bool,
-    /// Reduce logging output
-    #[clap(short, long, default_value_t = false)]
-    pub quiet: bool,
     /// Wait for the virtual machine instance to be started
     #[clap(short, long, default_value_t = false)]
     pub wait: bool,
@@ -27,8 +21,7 @@ pub struct InstanceStartCommand {
 }
 
 impl InstanceStartCommand {
-    pub fn run(&self, instance_dao: &InstanceDao) -> Result<(), Error> {
-        let verbosity = Verbosity::new(self.verbose, self.quiet);
+    pub fn run(&self, instance_dao: &InstanceDao, verbosity: Verbosity) -> Result<(), Error> {
         // Launch virtual machine instances
         let mut actions = Vec::new();
         for name in &self.instances {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,6 @@ use std::io;
 
 #[derive(Debug)]
 pub enum Error {
-    UnknownCommand,
     InvalidArgument(String),
     UnknownArch(String),
     UnknownInstance(String),
@@ -27,7 +26,6 @@ pub enum Error {
 pub fn print_error(error: Error) {
     print!("ERROR: ");
     match error {
-        Error::UnknownCommand => println!("Unknown command"),
         Error::InvalidArgument(err) => println!("Argument error: {err}"),
         Error::UnknownArch(name) => println!("Unknown architecture: '{name}'"),
         Error::UnknownInstance(instance) => println!("Unknown instance '{instance}'"),

--- a/src/instance/instance_store_mock.rs
+++ b/src/instance/instance_store_mock.rs
@@ -33,23 +33,23 @@ pub mod tests {
         }
 
         fn store(&self, _instance: &Instance) -> Result<(), Error> {
-            Result::Err(Error::UnknownCommand)
+            Result::Ok(())
         }
 
         fn clone(&self, _instance: &Instance, _new_name: &str) -> Result<(), Error> {
-            Result::Err(Error::UnknownCommand)
+            Result::Ok(())
         }
 
         fn rename(&self, _instance: &mut Instance, _new_name: &str) -> Result<(), Error> {
-            Result::Err(Error::UnknownCommand)
+            Result::Ok(())
         }
 
         fn resize(&self, _instance: &mut Instance, _size: u64) -> Result<(), Error> {
-            Result::Err(Error::UnknownCommand)
+            Result::Ok(())
         }
 
         fn delete(&self, _instance: &Instance) -> Result<(), Error> {
-            Result::Err(Error::UnknownCommand)
+            Result::Ok(())
         }
 
         fn get_state(&self, _instance: &Instance) -> InstanceState {
@@ -65,7 +65,7 @@ pub mod tests {
         }
 
         fn get_monitor(&self, _instance: &Instance) -> Result<Monitor, Error> {
-            Result::Err(Error::UnknownCommand)
+            Result::Err(Error::InvalidArgument("not supported".to_string()))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,10 @@ mod view;
 mod web;
 
 use crate::commands::CommandDispatcher;
+use clap::Parser;
 
 fn main() {
-    CommandDispatcher::new()
+    CommandDispatcher::parse()
         .dispatch()
         .map_err(error::print_error)
         .ok();


### PR DESCRIPTION
Removed duplicated code by defining the --verbose and --quiet flag globally.