### PR TITLE
refactor: add error() and debug() functions to console

### DIFF
--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -6,7 +6,7 @@ use crate::image::{Image, ImageDao, ImageFactory, ImageFetcher, ImageStore};
 use crate::util;
 use crate::view::SpinnerView;
 use crate::view::{Alignment, TableView};
-use crate::view::{MapView, Stdio};
+use crate::view::{Console, MapView};
 use clap::Subcommand;
 
 fn fetch_image_list(env: &Environment) -> Vec<Image> {
@@ -42,9 +42,7 @@ pub enum ImageCommands {
 }
 
 impl ImageCommands {
-    pub fn dispatch(&self, image_dao: &ImageDao) -> Result<(), Error> {
-        let console = &mut Stdio::new();
-
+    pub fn dispatch(&self, console: &mut dyn Console, image_dao: &ImageDao) -> Result<(), Error> {
         match self {
             ImageCommands::Ls { .. } => {
                 let images = fetch_image_list(&image_dao.env);

--- a/src/commands/instance_add_command.rs
+++ b/src/commands/instance_add_command.rs
@@ -3,6 +3,7 @@ use crate::error::Error;
 use crate::image::{ImageDao, ImageStore};
 use crate::instance::{Instance, InstanceDao, InstanceName, InstanceStore, PortForward};
 use crate::util;
+use crate::view::Console;
 use clap::Parser;
 
 pub const DEFAULT_CPU_COUNT: u16 = 4;
@@ -46,7 +47,12 @@ impl InstanceAddCommand {
             .ok_or(Error::InvalidArgument("Missing instance name".to_string()))
     }
 
-    pub fn run(&self, image_dao: &ImageDao, instance_dao: &InstanceDao) -> Result<(), Error> {
+    pub fn run(
+        &self,
+        console: &mut dyn Console,
+        image_dao: &ImageDao,
+        instance_dao: &InstanceDao,
+    ) -> Result<(), Error> {
         let name = self.get_name()?;
 
         if instance_dao.exists(name.as_str()) {
@@ -56,7 +62,7 @@ impl InstanceAddCommand {
         ImageCommands::Fetch {
             image: self.image.to_string(),
         }
-        .dispatch(image_dao)?;
+        .dispatch(console, image_dao)?;
         let image = image_dao.get(&self.image)?;
         image_dao.copy_image(&image, name.as_str())?;
 

--- a/src/commands/instance_run_command.rs
+++ b/src/commands/instance_run_command.rs
@@ -2,6 +2,7 @@ use crate::commands;
 use crate::error::Error;
 use crate::image::ImageDao;
 use crate::instance::{InstanceDao, Target};
+use crate::view::Console;
 use clap::Parser;
 
 /// Create, start and open a shell in a new virtual machine instance
@@ -14,19 +15,20 @@ pub struct InstanceRunCommand {
 impl InstanceRunCommand {
     pub fn run(
         &self,
+        console: &mut dyn Console,
         image_dao: &ImageDao,
         instance_dao: &InstanceDao,
         verbosity: commands::Verbosity,
     ) -> Result<(), Error> {
         let instance_name = self.add_cmd.get_name()?;
 
-        self.add_cmd.run(image_dao, instance_dao)?;
+        self.add_cmd.run(console, image_dao, instance_dao)?;
         commands::InstanceSshCommand {
             target: Target::from_instance_name(instance_name.clone()),
             xforward: false,
             ssh_args: None,
             cmd: None,
         }
-        .run(instance_dao, verbosity)
+        .run(console, instance_dao, verbosity)
     }
 }

--- a/src/commands/net.rs
+++ b/src/commands/net.rs
@@ -2,6 +2,7 @@ mod hostfwd;
 
 use crate::error::Error;
 use crate::instance::InstanceDao;
+use crate::view::Console;
 
 use clap::Subcommand;
 use hostfwd::HostfwdCommands;
@@ -23,9 +24,13 @@ pub enum NetworkCommands {
 }
 
 impl NetworkCommands {
-    pub fn dispatch(&self, instance_dao: &InstanceDao) -> Result<(), Error> {
+    pub fn dispatch(
+        &self,
+        console: &mut dyn Console,
+        instance_dao: &InstanceDao,
+    ) -> Result<(), Error> {
         match self {
-            NetworkCommands::Hostfwd(command) => command.dispatch(instance_dao),
+            NetworkCommands::Hostfwd(command) => command.dispatch(console, instance_dao),
         }
     }
 }

--- a/src/commands/net/hostfwd.rs
+++ b/src/commands/net/hostfwd.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::instance::{InstanceDao, InstanceStore, PortForward};
-use crate::view::{Alignment, Stdio, TableView};
+use crate::view::{Alignment, Console, TableView};
 use clap::Subcommand;
 
 #[derive(Subcommand)]
@@ -38,8 +38,11 @@ pub enum HostfwdCommands {
 }
 
 impl HostfwdCommands {
-    pub fn dispatch(&self, instance_dao: &InstanceDao) -> Result<(), Error> {
-        let console = &mut Stdio::new();
+    pub fn dispatch(
+        &self,
+        console: &mut dyn Console,
+        instance_dao: &InstanceDao,
+    ) -> Result<(), Error> {
         match self {
             HostfwdCommands::List => {
                 let instance_names = instance_dao.get_instances();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::view::Console;
 use std::io;
 
 #[derive(Debug)]
@@ -23,34 +24,41 @@ pub enum Error {
     SerdeYaml(serde_yaml::Error),
 }
 
-pub fn print_error(error: Error) {
-    print!("ERROR: ");
-    match error {
-        Error::InvalidArgument(err) => println!("Argument error: {err}"),
-        Error::UnknownArch(name) => println!("Unknown architecture: '{name}'"),
-        Error::UnknownInstance(instance) => println!("Unknown instance '{instance}'"),
-        Error::InstanceNotStopped(name) => println!("Instance '{name}' is not stopped"),
-        Error::InstanceAlreadyExists(id) => println!("Instance with name '{id}' already exists"),
-        Error::Io(e) => println!("{}", e),
-        Error::FS(e) => println!("{}", e),
-        Error::UnknownImage(name) => println!("Unknown image name {name}"),
-        Error::InvalidImageName(name) => println!("Invalid image name: {name}"),
-        Error::UnsetEnvVar(var) => println!("Environment variable '{var}' is not set"),
-        Error::CannotParseFile(path) => println!("Cannot parse file '{path}'"),
-        Error::CannotParseSize(size) => println!("Invalid data size format '{size}'"),
-        Error::CannotShrinkDisk(name) => {
-            println!("Cannot shrink the disk of the instance '{name}'")
-        }
-        Error::CannotOpenTerminal(path) => println!("Failed to open terminal from path: '{path}'"),
-        Error::HostFwdRuleMalformed(rule) => println!("Host forwarding rule is malformed: {rule}"),
-        Error::SystemCommandFailed(cmd, stderr) => {
-            println!(
-                "System command execution failed\n{cmd}\n\nReason: {}",
-                stderr.trim()
-            )
-        }
-        Error::SerdeJson(err) => println!("[JSON] {err}"),
-        Error::SerdeYaml(err) => println!("[YAML] {err}"),
-        Error::Web(e) => println!("{e}"),
+impl Error {
+    pub fn print(&self, console: &mut dyn Console) {
+        console.error(&format!(
+            "ERROR: {}",
+            match self {
+                Error::InvalidArgument(err) => format!("Argument error: {err}"),
+                Error::UnknownArch(name) => format!("Unknown architecture: '{name}'"),
+                Error::UnknownInstance(instance) => format!("Unknown instance '{instance}'"),
+                Error::InstanceNotStopped(name) => format!("Instance '{name}' is not stopped"),
+                Error::InstanceAlreadyExists(id) =>
+                    format!("Instance with name '{id}' already exists"),
+                Error::Io(e) => format!("{}", e),
+                Error::FS(e) => e.to_string(),
+                Error::UnknownImage(name) => format!("Unknown image name {name}"),
+                Error::InvalidImageName(name) => format!("Invalid image name: {name}"),
+                Error::UnsetEnvVar(var) => format!("Environment variable '{var}' is not set"),
+                Error::CannotParseFile(path) => format!("Cannot parse file '{path}'"),
+                Error::CannotParseSize(size) => format!("Invalid data size format '{size}'"),
+                Error::CannotShrinkDisk(name) => {
+                    format!("Cannot shrink the disk of the instance '{name}'")
+                }
+                Error::CannotOpenTerminal(path) =>
+                    format!("Failed to open terminal from path: '{path}'"),
+                Error::HostFwdRuleMalformed(rule) =>
+                    format!("Host forwarding rule is malformed: {rule}"),
+                Error::SystemCommandFailed(cmd, stderr) => {
+                    format!(
+                        "System command execution failed\n{cmd}\n\nReason: {}",
+                        stderr.trim()
+                    )
+                }
+                Error::SerdeJson(err) => format!("[JSON] {err}"),
+                Error::SerdeYaml(err) => format!("[YAML] {err}"),
+                Error::Web(e) => format!("{e}"),
+            }
+        ))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,9 @@ use crate::commands::CommandDispatcher;
 use clap::Parser;
 
 fn main() {
+    let console = &mut view::Stdio::new();
     CommandDispatcher::parse()
-        .dispatch()
-        .map_err(error::print_error)
+        .dispatch(console)
+        .map_err(|e| e.print(console))
         .ok();
 }

--- a/src/ssh_cmd/ssh.rs
+++ b/src/ssh_cmd/ssh.rs
@@ -9,7 +9,6 @@ pub struct Ssh {
     user: String,
     port: Option<u16>,
     args: String,
-    verbose: bool,
     xforward: bool,
     cmd: Option<String>,
 }
@@ -41,11 +40,6 @@ impl Ssh {
 
     pub fn set_args(&mut self, args: String) -> &mut Self {
         self.args = args;
-        self
-    }
-
-    pub fn set_verbose(&mut self, verbose: bool) -> &mut Self {
-        self.verbose = verbose;
         self
     }
 
@@ -85,10 +79,6 @@ impl Ssh {
             .args(self.args.split(' ').filter(|item| !item.is_empty()))
             .arg(format!("{}@127.0.0.1", self.user))
             .args(self.cmd.as_slice());
-
-        if self.verbose {
-            println!("{}", command.get_command());
-        }
 
         command
     }

--- a/src/view/console.rs
+++ b/src/view/console.rs
@@ -1,3 +1,8 @@
+use crate::commands::Verbosity;
+
 pub trait Console {
+    fn set_verbosity(&mut self, verbosity: Verbosity);
+    fn debug(&mut self, msg: &str);
     fn info(&mut self, msg: &str);
+    fn error(&mut self, msg: &str);
 }

--- a/src/view/console_mock.rs
+++ b/src/view/console_mock.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 pub mod tests {
 
+    use crate::commands::Verbosity;
     use crate::view::Console;
 
     #[derive(Default)]
@@ -10,17 +11,31 @@ pub mod tests {
 
     impl ConsoleMock {
         pub fn new() -> Self {
-            ConsoleMock::default()
+            Self::default()
         }
 
         pub fn get_output(&self) -> String {
             self.output.clone()
         }
+
+        fn log(&mut self, msg: &str) {
+            self.output = format!("{}{msg}\n", self.output);
+        }
     }
 
     impl Console for ConsoleMock {
+        fn set_verbosity(&mut self, _verbosity: Verbosity) {}
+
+        fn debug(&mut self, msg: &str) {
+            self.log(msg)
+        }
+
         fn info(&mut self, msg: &str) {
-            self.output = format!("{}{msg}\n", self.output);
+            self.log(msg)
+        }
+
+        fn error(&mut self, msg: &str) {
+            self.log(msg)
         }
     }
 }

--- a/src/view/stdio.rs
+++ b/src/view/stdio.rs
@@ -1,15 +1,36 @@
+use crate::commands::Verbosity;
 use crate::view::Console;
 
-pub struct Stdio;
+pub struct Stdio {
+    verbosity: Verbosity,
+}
 
 impl Stdio {
     pub fn new() -> Self {
-        Stdio {}
+        Self {
+            verbosity: Verbosity::new(false, false),
+        }
     }
 }
 
 impl Console for Stdio {
+    fn set_verbosity(&mut self, verbosity: Verbosity) {
+        self.verbosity = verbosity;
+    }
+
+    fn debug(&mut self, msg: &str) {
+        if self.verbosity.is_verbose() {
+            println!("{msg}");
+        }
+    }
+
     fn info(&mut self, msg: &str) {
-        println!("{msg}");
+        if !self.verbosity.is_quiet() {
+            println!("{msg}");
+        }
+    }
+
+    fn error(&mut self, msg: &str) {
+        eprintln!("{msg}");
     }
 }


### PR DESCRIPTION
Added the error() and debug() functions to the Console trait. This allows commands to simply call debug(), info() or error() for logging instead of checking every time the verbosity level.