### PR TITLE
feat: rename 'rm' command in 'delete'

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,20 +37,20 @@ Reference
 * :ref:`ref_cubic`
 
   * :ref:`ref_cubic_run`
+  * :ref:`ref_cubic_add`
   * :ref:`ref_cubic_ls`
   * :ref:`ref_cubic_images`
   * :ref:`ref_cubic_ports`
-  * :ref:`ref_cubic_add`
   * :ref:`ref_cubic_show`
   * :ref:`ref_cubic_modify`
-  * :ref:`ref_cubic_rm`
-  * :ref:`ref_cubic_clone`
-  * :ref:`ref_cubic_rename`
   * :ref:`ref_cubic_console`
   * :ref:`ref_cubic_ssh`
   * :ref:`ref_cubic_scp`
   * :ref:`ref_cubic_start`
   * :ref:`ref_cubic_stop`
   * :ref:`ref_cubic_restart`
+  * :ref:`ref_cubic_rename`
+  * :ref:`ref_cubic_clone`
+  * :ref:`ref_cubic_delete`
   * :ref:`ref_cubic_image`
   * :ref:`ref_cubic_prune`

--- a/docs/reference/cubic.rst
+++ b/docs/reference/cubic.rst
@@ -45,7 +45,6 @@ cubic
       ports    List forwarded ports for all virtual machine instances
       show     Show a virtual machine instance
       modify   Modify a virtual machine instance configuration
-      rm       Delete virtual machine instances
       console  Open the console of an virtual machine instance
       ssh      Connect to a virtual machine instance with SSH
       scp      Copy a file from or to a virtual machine instance with SCP
@@ -54,6 +53,7 @@ cubic
       restart  Restart virtual machine instances
       rename   Rename a virtual machine instance
       clone    Clone a virtual machine instance
+      delete   Delete one or more virtual machine instances
       image    Image subcommands
       prune    Clear cache and free space
       help     Print this message or the help of the given subcommand(s)

--- a/docs/reference/delete.rst
+++ b/docs/reference/delete.rst
@@ -1,14 +1,14 @@
-.. _ref_cubic_rm:
+.. _ref_cubic_delete:
 
-cubic rm
-=========
+cubic delete
+============
 
 .. code-block::
 
-    $ cubic rm --help
-    Delete virtual machine instances
+    $ cubic delete --help
+    Delete one or more virtual machine instances
 
-    Usage: cubic rm [OPTIONS] [INSTANCES]...
+    Usage: cubic delete [OPTIONS] [INSTANCES]...
 
     Arguments:
       [INSTANCES]...  Name of the virtual machine instances to delete

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,11 +1,11 @@
 pub mod command_dispatcher;
+pub mod delete_instance_command;
 pub mod image;
 pub mod instance_add_command;
 pub mod instance_clone_command;
 pub mod instance_console_command;
 pub mod instance_list_command;
 pub mod instance_modify_command;
-pub mod instance_remove_command;
 pub mod instance_rename_command;
 pub mod instance_restart_command;
 pub mod instance_run_command;
@@ -21,13 +21,13 @@ pub mod prune_command;
 pub mod verbosity;
 
 pub use command_dispatcher::*;
+pub use delete_instance_command::*;
 pub use image::*;
 pub use instance_add_command::*;
 pub use instance_clone_command::*;
 pub use instance_console_command::*;
 pub use instance_list_command::*;
 pub use instance_modify_command::*;
-pub use instance_remove_command::*;
 pub use instance_rename_command::*;
 pub use instance_restart_command::*;
 pub use instance_run_command::*;

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -1,6 +1,6 @@
 use crate::commands::{
     self, InstanceAddCommand, InstanceCloneCommand, InstanceListCommand, InstanceModifyCommand,
-    InstanceRemoveCommand, InstanceRenameCommand,
+    InstanceRenameCommand,
 };
 use crate::env::EnvironmentFactory;
 use crate::error::Error;
@@ -21,8 +21,6 @@ pub enum Commands {
     Show(commands::InstanceShowCommand),
     #[clap(alias = "config")]
     Modify(InstanceModifyCommand),
-    #[clap(alias = "del")]
-    Rm(InstanceRemoveCommand),
     Console(commands::InstanceConsoleCommand),
     Ssh(commands::InstanceSshCommand),
     Scp(commands::InstanceScpCommand),
@@ -31,6 +29,8 @@ pub enum Commands {
     Restart(commands::InstanceRestartCommand),
     Rename(InstanceRenameCommand),
     Clone(InstanceCloneCommand),
+    #[clap(alias = "rm", alias = "del")]
+    Delete(commands::DeleteInstanceCommand),
     /// Image subcommands
     #[command(subcommand)]
     Image(commands::ImageCommands),
@@ -76,7 +76,6 @@ impl CommandDispatcher {
             Commands::Ports(cmd) => cmd.run(console, &instance_dao),
             Commands::Add(cmd) => cmd.run(console, &image_dao, &instance_dao),
             Commands::Modify(cmd) => cmd.run(&instance_dao),
-            Commands::Rm(cmd) => cmd.run(&instance_dao, verbosity),
             Commands::Clone(cmd) => cmd.run(&instance_dao),
             Commands::Rename(cmd) => cmd.run(&instance_dao),
             Commands::Show(cmd) => cmd.run(console, &instance_dao),
@@ -86,6 +85,7 @@ impl CommandDispatcher {
             Commands::Console(cmd) => cmd.run(&instance_dao, verbosity),
             Commands::Ssh(cmd) => cmd.run(console, &instance_dao, verbosity),
             Commands::Scp(cmd) => cmd.run(&instance_dao, verbosity),
+            Commands::Delete(cmd) => cmd.run(&instance_dao, verbosity),
             Commands::Image(command) => command.dispatch(console, &image_dao),
             Commands::Prune(cmd) => cmd.run(&image_dao),
             Commands::Net(command) => command.dispatch(console, &instance_dao),

--- a/src/commands/delete_instance_command.rs
+++ b/src/commands/delete_instance_command.rs
@@ -4,9 +4,9 @@ use crate::instance::{InstanceDao, InstanceStore};
 use crate::util;
 use clap::Parser;
 
-/// Delete virtual machine instances
+/// Delete one or more virtual machine instances
 #[derive(Parser)]
-pub struct InstanceRemoveCommand {
+pub struct DeleteInstanceCommand {
     /// Delete the virtual machine instances even when running
     #[clap(short, long, default_value_t = false)]
     force: bool,
@@ -17,7 +17,7 @@ pub struct InstanceRemoveCommand {
     instances: Vec<String>,
 }
 
-impl InstanceRemoveCommand {
+impl DeleteInstanceCommand {
     pub fn run(
         &self,
         instance_dao: &InstanceDao,

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -3,8 +3,7 @@ use crate::env::Environment;
 use crate::error::Error;
 use crate::fs::FS;
 use crate::image::{Image, ImageDao, ImageFactory, ImageFetcher, ImageStore};
-use crate::view::SpinnerView;
-use crate::view::{Console, MapView};
+use crate::view::{Console, MapView, SpinnerView};
 use clap::Subcommand;
 
 pub fn fetch_image_list(env: &Environment) -> Vec<Image> {
@@ -49,7 +48,6 @@ impl ImageCommands {
                 view.print(console);
                 Ok(())
             }
-
             ImageCommands::Fetch { image } => {
                 fetch_image_list(&image_dao.env);
                 let image = &image_dao.get(image)?;


### PR DESCRIPTION
Renamed 'rm' command in 'delete'. The old command name is still usable for backward compatibility.