### PR TITLE
feat: rename command 'add' in 'create'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Show all supported images:
 $ cubic image ls
 
 Create a new virtual machine instance:
-$ cubic add mymachine --image ubuntu:noble
+$ cubic create mymachine --image ubuntu:noble
 
 List all virtual machine instances:
 $ cubic ls

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Show all supported images:
 $ cubic image ls
 
 Create a new virtual machine instance:
-$ cubic add mymachine --image ubuntu:noble
+$ cubic create mymachine --image ubuntu:noble
 
 List all virtual machine instances:
 $ cubic ls
@@ -137,7 +137,7 @@ Usage: cubic [COMMAND]
 
 Commands:
   run      Create, start and open a shell in a new virtual machine instance
-  add      Create a new virtual machine instance
+  create   Create a new virtual machine instance
   ls       List all virtual machine instances
   rm       Delete virtual machine instances
   info     Get information about an virtual machine instance

--- a/docs/howto/add_instance.rst
+++ b/docs/howto/add_instance.rst
@@ -39,7 +39,7 @@ In the next step you can create the virtual machine with a single command:
 
 .. code-block::
 
-    $ cubic add example --image debian:bookworm
+    $ cubic create example --image debian:bookworm
 
 List all Virtual Machine
 ------------------------
@@ -60,7 +60,7 @@ For example to create a virtual machine with 4 CPU cores, 4 GiB of memory and 10
 
 .. code-block::
 
-    $ cubic add example --image debian:bookworm --cpus 4 --mem 4G  --disk 10G
+    $ cubic create example --image debian:bookworm --cpus 4 --mem 4G  --disk 10G
 
 
 Start the virtual machine

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ Reference
 * :ref:`ref_cubic`
 
   * :ref:`ref_cubic_run`
-  * :ref:`ref_cubic_add`
+  * :ref:`ref_cubic_create`
   * :ref:`ref_cubic_ls`
   * :ref:`ref_cubic_images`
   * :ref:`ref_cubic_ports`

--- a/docs/reference/add.rst
+++ b/docs/reference/add.rst
@@ -1,14 +1,14 @@
-.. _ref_cubic_add:
+.. _ref_cubic_create:
 
-cubic add
-=========
+cubic create
+============
 
 .. code-block::
 
-    $ cubic add --help
+    $ cubic create --help
     Create a new virtual machine instance
 
-    Usage: cubic add [OPTIONS] --image <IMAGE> [INSTANCE_NAME]
+    Usage: cubic create [OPTIONS] --image <IMAGE> [INSTANCE_NAME]
 
     Arguments:
       [INSTANCE_NAME]  Name of the virtual machine instance

--- a/docs/reference/cubic.rst
+++ b/docs/reference/cubic.rst
@@ -14,7 +14,7 @@ cubic
     $ cubic image ls
 
     Create a new virtual machine instance:
-    $ cubic add mymachine --image ubuntu:noble
+    $ cubic create mymachine --image ubuntu:noble
 
     List all virtual machine instances:
     $ cubic ls
@@ -39,7 +39,7 @@ cubic
 
     Commands:
       run      Create, start and open a shell in a new virtual machine instance
-      add      Create a new virtual machine instance
+      create   Create a new virtual machine instance
       ls       List all virtual machine instances
       images   List all supported virtual machine images
       ports    List forwarded ports for all virtual machine instances

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,7 @@
 pub mod command_dispatcher;
+pub mod create_instance_command;
 pub mod delete_instance_command;
 pub mod image;
-pub mod instance_add_command;
 pub mod instance_clone_command;
 pub mod instance_console_command;
 pub mod instance_list_command;
@@ -21,9 +21,9 @@ pub mod prune_command;
 pub mod verbosity;
 
 pub use command_dispatcher::*;
+pub use create_instance_command::*;
 pub use delete_instance_command::*;
 pub use image::*;
-pub use instance_add_command::*;
 pub use instance_clone_command::*;
 pub use instance_console_command::*;
 pub use instance_list_command::*;

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -1,6 +1,5 @@
 use crate::commands::{
-    self, InstanceAddCommand, InstanceCloneCommand, InstanceListCommand, InstanceModifyCommand,
-    InstanceRenameCommand,
+    self, InstanceCloneCommand, InstanceListCommand, InstanceModifyCommand, InstanceRenameCommand,
 };
 use crate::env::EnvironmentFactory;
 use crate::error::Error;
@@ -12,7 +11,8 @@ use clap::{Parser, Subcommand};
 #[derive(Subcommand)]
 pub enum Commands {
     Run(commands::InstanceRunCommand),
-    Add(InstanceAddCommand),
+    #[clap(alias = "add")]
+    Create(commands::CreateInstanceCommand),
     #[clap(alias = "list")]
     Ls(InstanceListCommand),
     Images(commands::ListImageCommand),
@@ -74,7 +74,7 @@ impl CommandDispatcher {
             Commands::Ls(cmd) => cmd.run(console, &instance_dao),
             Commands::Images(cmd) => cmd.run(console, &env),
             Commands::Ports(cmd) => cmd.run(console, &instance_dao),
-            Commands::Add(cmd) => cmd.run(console, &image_dao, &instance_dao),
+            Commands::Create(cmd) => cmd.run(console, &image_dao, &instance_dao),
             Commands::Modify(cmd) => cmd.run(&instance_dao),
             Commands::Clone(cmd) => cmd.run(&instance_dao),
             Commands::Rename(cmd) => cmd.run(&instance_dao),

--- a/src/commands/create_instance_command.rs
+++ b/src/commands/create_instance_command.rs
@@ -12,7 +12,7 @@ pub const DEFAULT_DISK_SIZE: &str = "100G";
 
 /// Create a new virtual machine instance
 #[derive(Parser)]
-pub struct InstanceAddCommand {
+pub struct CreateInstanceCommand {
     /// Name of the virtual machine instance
     #[clap(conflicts_with = "name")]
     instance_name: Option<InstanceName>,
@@ -39,7 +39,7 @@ pub struct InstanceAddCommand {
     port: Vec<PortForward>,
 }
 
-impl InstanceAddCommand {
+impl CreateInstanceCommand {
     pub fn get_name(&self) -> Result<InstanceName, Error> {
         self.instance_name
             .clone()

--- a/src/commands/instance_run_command.rs
+++ b/src/commands/instance_run_command.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 #[derive(Parser)]
 pub struct InstanceRunCommand {
     #[clap(flatten)]
-    add_cmd: commands::InstanceAddCommand,
+    create_cmd: commands::CreateInstanceCommand,
 }
 
 impl InstanceRunCommand {
@@ -20,9 +20,9 @@ impl InstanceRunCommand {
         instance_dao: &InstanceDao,
         verbosity: commands::Verbosity,
     ) -> Result<(), Error> {
-        let instance_name = self.add_cmd.get_name()?;
+        let instance_name = self.create_cmd.get_name()?;
 
-        self.add_cmd.run(console, image_dao, instance_dao)?;
+        self.create_cmd.run(console, image_dao, instance_dao)?;
         commands::InstanceSshCommand {
             target: Target::from_instance_name(instance_name.clone()),
             xforward: false,


### PR DESCRIPTION
Renamed the 'add' command in 'create'. The old command name remains available for backward compatiblity.