### PR TITLE
feat: improve instance creation process

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,5 +1,7 @@
+pub mod create_instance_action;
 pub mod start_instance_action;
 pub mod stop_instance_action;
 
+pub use create_instance_action::CreateInstanceAction;
 pub use start_instance_action::StartInstanceAction;
 pub use stop_instance_action::StopInstanceAction;

--- a/src/actions/create_instance_action.rs
+++ b/src/actions/create_instance_action.rs
@@ -1,0 +1,55 @@
+use crate::env::Environment;
+use crate::error::Error;
+use crate::fs::FS;
+use crate::image::Image;
+use crate::instance::{Instance, InstanceStore};
+use crate::util::SystemCommand;
+
+#[derive(Default)]
+pub struct CreateInstanceAction;
+
+impl CreateInstanceAction {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn run(
+        &mut self,
+        env: &Environment,
+        fs: &FS,
+        instance_store: &dyn InstanceStore,
+        image: &Image,
+        mut instance: Instance,
+    ) -> Result<(), Error> {
+        let instance_name = instance.name.clone();
+        let target_dir = &env.get_instance_dir2(&instance.name);
+        let tmp_dir = &format!("{target_dir}.tmp");
+        let tmp_image = &format!("{tmp_dir}/machine.img");
+
+        // Create virtual machine instance image file
+        fs.create_dir(tmp_dir)?;
+        SystemCommand::new("qemu-img")
+            .arg("convert")
+            .arg("-f")
+            .arg("qcow2")
+            .arg("-O")
+            .arg("qcow2")
+            .arg(env.get_image_file(&image.to_file_name()))
+            .arg(tmp_image)
+            .run()?;
+
+        // Set disk capacity
+        SystemCommand::new("qemu-img")
+            .arg("resize")
+            .arg(tmp_image)
+            .arg(instance.disk_capacity.to_string())
+            .run()?;
+
+        // Write configuration file
+        instance.name = format!("{instance_name}.tmp");
+        instance_store.store(&instance)?;
+        instance.name = instance_name;
+
+        fs.rename_file(tmp_dir, target_dir)
+    }
+}

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -68,11 +68,11 @@ impl CommandDispatcher {
         let instance_dao = InstanceDao::new(&env)?;
 
         match self.command {
-            Commands::Run(cmd) => cmd.run(console, &image_dao, &instance_dao, verbosity),
+            Commands::Run(cmd) => cmd.run(console, &env, &image_dao, &instance_dao, verbosity),
             Commands::Instances(cmd) => cmd.run(console, &instance_dao),
             Commands::Images(cmd) => cmd.run(console, &env),
             Commands::Ports(cmd) => cmd.run(console, &instance_dao),
-            Commands::Create(cmd) => cmd.run(console, &image_dao, &instance_dao),
+            Commands::Create(cmd) => cmd.run(console, &env, &image_dao, &instance_dao),
             Commands::Modify(cmd) => cmd.run(&instance_dao),
             Commands::Clone(cmd) => cmd.run(&instance_dao),
             Commands::Rename(cmd) => cmd.run(&instance_dao),

--- a/src/commands/instance_run_command.rs
+++ b/src/commands/instance_run_command.rs
@@ -1,4 +1,5 @@
 use crate::commands;
+use crate::env::Environment;
 use crate::error::Error;
 use crate::image::ImageDao;
 use crate::instance::{InstanceDao, Target};
@@ -16,13 +17,14 @@ impl InstanceRunCommand {
     pub fn run(
         &self,
         console: &mut dyn Console,
+        env: &Environment,
         image_dao: &ImageDao,
         instance_dao: &InstanceDao,
         verbosity: commands::Verbosity,
     ) -> Result<(), Error> {
         let instance_name = self.create_cmd.get_name()?;
 
-        self.create_cmd.run(console, image_dao, instance_dao)?;
+        self.create_cmd.run(console, env, image_dao, instance_dao)?;
         commands::InstanceSshCommand {
             target: Target::from_instance_name(instance_name.clone()),
             xforward: false,

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -78,12 +78,6 @@ impl FS {
         Path::new(path).exists()
     }
 
-    pub fn copy_file(&self, from: &str, to: &str) -> Result<(), Error> {
-        fs::copy(from, to)
-            .map(|_| ())
-            .map_err(|e| Error::FS(format!("Cannot copy file from '{from}' to '{to}' ({e})")))
-    }
-
     pub fn write_file(&self, path: &str, data: &[u8]) -> Result<(), Error> {
         self.create_file(path)?
             .write_all(data)

--- a/src/image/image_dao.rs
+++ b/src/image/image_dao.rs
@@ -3,7 +3,6 @@ use crate::error::Error;
 use crate::fs::FS;
 use crate::image::{Image, ImageFactory, ImageName, ImageStore};
 use std::path::Path;
-use std::str;
 
 pub struct ImageDao {
     fs: FS,
@@ -33,14 +32,6 @@ impl ImageStore for ImageDao {
             })
             .cloned()
             .ok_or(Error::UnknownImage(name.to_string()))
-    }
-
-    fn copy_image(&self, image: &Image, name: &str) -> Result<(), Error> {
-        self.fs.create_dir(&self.env.get_instance_dir2(name))?;
-        self.fs.copy_file(
-            &self.env.get_image_file(&image.to_file_name()),
-            &self.env.get_instance_image_file(name),
-        )
     }
 
     fn exists(&self, image: &Image) -> bool {

--- a/src/image/image_store.rs
+++ b/src/image/image_store.rs
@@ -3,7 +3,6 @@ use crate::image::{Image, ImageName};
 
 pub trait ImageStore {
     fn get(&self, name: &ImageName) -> Result<Image, Error>;
-    fn copy_image(&self, image: &Image, name: &str) -> Result<(), Error>;
     fn exists(&self, image: &Image) -> bool;
     fn prune(&self) -> Result<(), Error>;
 }

--- a/src/image/image_store_mock.rs
+++ b/src/image/image_store_mock.rs
@@ -22,10 +22,6 @@ pub mod tests {
                 .ok_or(Error::UnknownInstance(name.to_string()))
         }
 
-        fn copy_image(&self, _image: &Image, _name: &str) -> Result<(), Error> {
-            Ok(())
-        }
-
         fn exists(&self, image: &Image) -> bool {
             self.images.contains(image)
         }

--- a/src/view/spinner_view.rs
+++ b/src/view/spinner_view.rs
@@ -49,3 +49,9 @@ impl SpinnerView {
         self.thread.take().map(|t| t.join());
     }
 }
+
+impl Drop for SpinnerView {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}


### PR DESCRIPTION
The instance creation is improved by:
- Always create an uncompressed qcow2 file for higher performance
- Make sure that if the creation process fails it does not result in a corrupt instance
- Show a visual spinner during the creation process