### PR TITLE
feat: show used disk space in 'show' and 'instances' commands

### DIFF
--- a/src/commands/create_instance_command.rs
+++ b/src/commands/create_instance_command.rs
@@ -82,6 +82,7 @@ impl CreateInstanceCommand {
             disk_capacity: self.disk.get_bytes() as u64,
             ssh_port: util::generate_random_ssh_port(),
             hostfwd: self.port.clone(),
+            ..Instance::default()
         };
         CreateInstanceAction::new().run(env, &FS::new(), instance_dao, &image, instance)?;
 

--- a/src/commands/instance_show_command.rs
+++ b/src/commands/instance_show_command.rs
@@ -28,7 +28,14 @@ impl InstanceShowCommand {
         view.add("CPUs", &instance.cpus.to_string());
         view.add("Memory", &DataSize::new(instance.mem as usize).to_size());
         view.add(
-            "Disk",
+            "Disk Used",
+            &instance
+                .disk_used
+                .map(|size| DataSize::new(size as usize).to_size())
+                .unwrap_or("n/a".to_string()),
+        );
+        view.add(
+            "Disk Total",
             &DataSize::new(instance.disk_capacity as usize).to_size(),
         );
         view.add("User", &instance.user);
@@ -66,6 +73,7 @@ mod tests {
             disk_capacity: 1048576,
             ssh_port: 9000,
             hostfwd: Vec::new(),
+            ..Instance::default()
         }]);
 
         InstanceShowCommand {
@@ -77,12 +85,13 @@ mod tests {
         assert_eq!(
             console.get_output(),
             "\
-Arch:     amd64
-CPUs:     1
-Memory:   1.0 KiB
-Disk:     1.0 MiB
-User:     cubic
-SSH Port: 9000
+Arch:       amd64
+CPUs:       1
+Memory:     1.0 KiB
+Disk Used:  n/a
+Disk Total: 1.0 MiB
+User:       cubic
+SSH Port:   9000
 "
         );
     }

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -23,7 +23,8 @@ impl ListInstanceCommand {
             .add("Arch", Alignment::Left)
             .add("CPUs", Alignment::Right)
             .add("Memory", Alignment::Right)
-            .add("Disk", Alignment::Right)
+            .add("Disk Used", Alignment::Right)
+            .add("Disk Total", Alignment::Right)
             .add("State", Alignment::Left);
 
         for instance_name in &instance_names {
@@ -40,6 +41,13 @@ impl ListInstanceCommand {
                 .add(&instance.cpus.to_string(), Alignment::Right)
                 .add(
                     &DataSize::new(instance.mem as usize).to_size(),
+                    Alignment::Right,
+                )
+                .add(
+                    &instance
+                        .disk_used
+                        .map(|size| DataSize::new(size as usize).to_size())
+                        .unwrap_or("n/a".to_string()),
                     Alignment::Right,
                 )
                 .add(
@@ -81,6 +89,7 @@ mod tests {
                 disk_capacity: 1048576,
                 ssh_port: 9000,
                 hostfwd: Vec::new(),
+                ..Instance::default()
             },
             Instance {
                 name: "test2".to_string(),
@@ -91,6 +100,7 @@ mod tests {
                 disk_capacity: 5000,
                 ssh_port: 9000,
                 hostfwd: Vec::new(),
+                ..Instance::default()
             },
         ]);
 
@@ -99,9 +109,9 @@ mod tests {
         assert_eq!(
             console.get_output(),
             "\
-PID   Name    Arch    CPUs    Memory      Disk   State
-      test    amd64      1   1.0 KiB   1.0 MiB   STOPPED
-      test2   amd64      5     0   B   4.9 KiB   STOPPED
+PID   Name    Arch    CPUs    Memory   Disk Used   Disk Total   State
+      test    amd64      1   1.0 KiB         n/a      1.0 MiB   STOPPED
+      test2   amd64      5     0   B         n/a      4.9 KiB   STOPPED
 "
         );
     }
@@ -115,7 +125,7 @@ PID   Name    Arch    CPUs    Memory      Disk   State
 
         assert_eq!(
             console.get_output(),
-            "PID   Name   Arch   CPUs   Memory   Disk   State\n"
+            "PID   Name   Arch   CPUs   Memory   Disk Used   Disk Total   State\n"
         );
     }
 }

--- a/src/env/environment.rs
+++ b/src/env/environment.rs
@@ -1,4 +1,4 @@
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct Environment {
     data_dir: String,
     cache_dir: String,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -33,6 +33,8 @@ pub struct Instance {
     pub user: String,
     pub cpus: u16,
     pub mem: u64,
+    #[serde(skip)]
+    pub disk_used: Option<u64>,
     pub disk_capacity: u64,
     pub ssh_port: u16,
     #[serde(default)]
@@ -167,6 +169,7 @@ machine:
             disk_capacity: 1000,
             ssh_port: 10000,
             hostfwd: Vec::new(),
+            ..Instance::default()
         }
         .serialize(&mut writer)
         .expect("Cannot parser config");

--- a/src/instance/target_path.rs
+++ b/src/instance/target_path.rs
@@ -81,6 +81,7 @@ mod tests {
             disk_capacity: 1024,
             ssh_port: 22,
             hostfwd: Vec::new(),
+            ..Instance::default()
         }]);
         assert_eq!(
             path.to_scp(&store).unwrap().as_str(),
@@ -101,6 +102,7 @@ mod tests {
             disk_capacity: 1024,
             ssh_port: 22,
             hostfwd: Vec::new(),
+            ..Instance::default()
         }]);
         assert_eq!(
             path.to_scp(&store).unwrap().as_str(),

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -1,7 +1,9 @@
 pub mod monitor;
+pub mod qemu_img;
 pub mod qmp;
 pub mod qmp_message;
 
 pub use monitor::*;
+pub use qemu_img::*;
 pub use qmp::*;
 pub use qmp_message::*;

--- a/src/qemu/qemu_img.rs
+++ b/src/qemu/qemu_img.rs
@@ -1,0 +1,66 @@
+use crate::env::Environment;
+use crate::instance::Instance;
+use crate::util::SystemCommand;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageInfo {
+    #[serde(alias = "actual-size")]
+    pub actual_size: u64,
+    #[serde(alias = "virtual-size")]
+    pub virtual_size: u64,
+}
+
+pub struct QemuImg;
+
+impl QemuImg {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn get_image_info(&self, env: &Environment, instance: &Instance) -> Option<ImageInfo> {
+        SystemCommand::new("qemu-img")
+            .arg("info")
+            .arg("--output")
+            .arg("json")
+            .arg(env.get_instance_image_file(&instance.name))
+            .output()
+            .ok()
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .and_then(|stdout| serde_json::from_str(&stdout).ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_image_info() {
+        let input = r#"
+        {
+        "virtual-size": 1073741824,
+        "filename": "/tmp/cache/cubic/images/ubuntu_noble_amd64",
+        "cluster-size": 65536,
+        "format": "qcow2",
+        "actual-size": 200704,
+        "format-specific": {
+            "type": "qcow2",
+            "data": {
+                "compat": "1.1",
+                "compression-type": "zlib",
+                "lazy-refcounts": false,
+                "refcount-bits": 16,
+                "corrupt": false,
+                "extended-l2": false
+            }
+        },
+        "dirty-flag": false
+        }
+        "#;
+
+        println!("{input}");
+        let result: ImageInfo = serde_json::from_str(input).unwrap();
+        assert_eq!(result.actual_size, 200704);
+    }
+}

--- a/src/util/system_command.rs
+++ b/src/util/system_command.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use std::ffi::OsStr;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 use std::str::from_utf8;
 
 pub struct SystemCommand {
@@ -83,6 +83,14 @@ impl SystemCommand {
             .stdout(Stdio::inherit())
             .stderr(Stdio::piped())
             .spawn()
+            .map_err(|e| Error::SystemCommandFailed(self.get_command(), e.to_string()))
+    }
+
+    pub fn output(&mut self) -> Result<Output, Error> {
+        self.cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
             .map_err(|e| Error::SystemCommandFailed(self.get_command(), e.to_string()))
     }
 }


### PR DESCRIPTION
Display the used disk space in addition to the disk total capacity. The current implmentation can only read the used disk size when the instance is stopped.