### PR TITLE
feat: implement command argument for russh

### DIFF
--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -164,7 +164,11 @@ impl Russh {
             .await
             .map_err(|_| ())?;
 
-        channel.request_shell(true).await.map_err(|_| ())?;
+        if let Some(cmd) = &self.cmd {
+            channel.exec(true, cmd.as_str()).await.map_err(|_| ())?;
+        } else {
+            channel.request_shell(true).await.map_err(|_| ())?;
+        }
         let (ssh_in, ssh_out) = channel.split();
 
         let stdin_stream = tokio::spawn(handle_stdin_stream(ssh_out));


### PR DESCRIPTION
Implemented the command argument option for russh. A command may be executed on a virtual machine instance by:
    cubic ssh --rush <target instance> <cmd>