### PR TITLE
fix: handle case when no machine.yaml file is present

### DIFF
--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -115,6 +115,9 @@ impl InstanceStore for InstanceDao {
         // remove deprecated yaml file format
         self.fs
             .remove_file(&self.env.get_instance_yaml_config_file(&instance.name))
+            .ok();
+
+        Ok(())
     }
 
     fn clone(&self, instance: &Instance, new_name: &str) -> Result<(), Error> {


### PR DESCRIPTION
Creating a new virtual machine instance fails with an error, that the machine.yaml can not be deleted. This fix removes the machine.yaml without runtime errors.