### PR TITLE
feat: use toml instead of yaml for image cache

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,6 @@ pub enum Error {
     SystemCommandFailed(String, String),
     Web(reqwest::Error),
     SerdeJson(serde_json::Error),
-    SerdeYaml(serde_yaml::Error),
     SerdeToml(toml::ser::Error),
     InvalidChecksum,
 }
@@ -56,7 +55,6 @@ impl Error {
                     )
                 }
                 Error::SerdeJson(err) => format!("[JSON] {err}"),
-                Error::SerdeYaml(err) => format!("[YAML] {err}"),
                 Error::SerdeToml(err) => format!("[TOML] {err}"),
                 Error::Web(e) => format!("{e}"),
                 Error::InvalidChecksum => "Verification of image failed".to_string(),


### PR DESCRIPTION
Since the serde_yaml crate is deprecated the image cache is stored in TOML format instead of YAML.