### PR TITLE
feat: make russh dependency an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,15 +40,17 @@ categories = ["command-line-utilities"]
 edition = "2024"
 
 [features]
+default = ["russh"]
 qemu-sandbox = []
+russh = ["dep:russh", "dep:russh-sftp"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 libc = "0"
 regex = "1"
 reqwest = { version = "0", default-features = false, features = ["rustls-tls", "blocking", "gzip", "brotli"] }
-russh = "0"
-russh-sftp = "2"
+russh = { version = "0", optional = true }
+russh-sftp = { version = "2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0"

--- a/src/commands/instance_scp_command.rs
+++ b/src/commands/instance_scp_command.rs
@@ -3,7 +3,7 @@ use crate::env::Environment;
 use crate::error::Error;
 use crate::image::ImageStore;
 use crate::instance::{InstanceStore, TargetPath};
-use crate::ssh_cmd::{Openssh, Russh, Ssh, get_ssh_private_key_names};
+use crate::ssh_cmd::{Ssh, SshFactory, get_ssh_private_key_names};
 use crate::view::Console;
 use clap::Parser;
 use std::env;
@@ -49,12 +49,7 @@ impl Command for InstanceScpCommand {
         check_target_is_running(instance_store, &self.to)?;
 
         let root_dir = env::var("SNAP").unwrap_or_default();
-
-        let mut ssh: Box<dyn Ssh> = if !self.russh {
-            Box::new(Openssh::new())
-        } else {
-            Box::new(Russh::new())
-        };
+        let mut ssh: Box<dyn Ssh> = SshFactory::new().create(self.russh);
 
         ssh.set_known_hosts_file(
             env::var("HOME")

--- a/src/commands/instance_ssh_command.rs
+++ b/src/commands/instance_ssh_command.rs
@@ -3,7 +3,7 @@ use crate::env::Environment;
 use crate::error::Error;
 use crate::image::ImageStore;
 use crate::instance::{InstanceStore, Target};
-use crate::ssh_cmd::{Openssh, Russh, Ssh, get_ssh_private_key_names};
+use crate::ssh_cmd::{Ssh, SshFactory, get_ssh_private_key_names};
 use crate::view::Console;
 use clap::Parser;
 use std::env;
@@ -59,11 +59,7 @@ impl Command for InstanceSshCommand {
             .unwrap_or(instance.user.to_string());
         let ssh_port = instance.ssh_port;
 
-        let mut ssh: Box<dyn Ssh> = if !self.args.russh {
-            Box::new(Openssh::new())
-        } else {
-            Box::new(Russh::new())
-        };
+        let mut ssh: Box<dyn Ssh> = SshFactory::new().create(self.args.russh);
         ssh.set_known_hosts_file(
             env::var("HOME")
                 .map(|dir| format!("{dir}/.ssh/known_hosts"))

--- a/src/ssh_cmd.rs
+++ b/src/ssh_cmd.rs
@@ -1,16 +1,22 @@
 mod openssh;
 mod port_checker;
+#[cfg(feature = "russh")]
 mod russh;
+#[cfg(feature = "russh")]
 mod sftp_path;
 mod ssh;
+mod ssh_factory;
 
 use crate::error::Error;
 use crate::fs::FS;
 pub use openssh::Openssh;
 pub use port_checker::PortChecker;
+#[cfg(feature = "russh")]
 pub use russh::Russh;
+#[cfg(feature = "russh")]
 pub use sftp_path::SftpPath;
 pub use ssh::Ssh;
+pub use ssh_factory::SshFactory;
 use std::env;
 use std::fs::DirEntry;
 

--- a/src/ssh_cmd/ssh_factory.rs
+++ b/src/ssh_cmd/ssh_factory.rs
@@ -1,0 +1,26 @@
+#[cfg(feature = "russh")]
+use crate::ssh_cmd::Russh;
+use crate::ssh_cmd::{Openssh, Ssh};
+
+#[derive(Default)]
+pub struct SshFactory;
+
+impl SshFactory {
+    pub fn new() -> Self {
+        Self
+    }
+
+    #[cfg(feature = "russh")]
+    pub fn create(&self, use_russh: bool) -> Box<dyn Ssh> {
+        if use_russh {
+            Box::new(Russh::new())
+        } else {
+            Box::new(Openssh::new())
+        }
+    }
+
+    #[cfg(not(feature = "russh"))]
+    pub fn create(&self, _use_russh: bool) -> Box<dyn Ssh> {
+        Box::new(Openssh::new())
+    }
+}


### PR DESCRIPTION
Allow to build Cubic optionally without the Russh dependency in order to integrate it into build system that do not provide yet this library.