### PR TITLE
feat: use termion to set terminal into raw mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,6 @@ name = "cubic"
 version = "0.16.0"
 dependencies = [
  "clap",
- "libc",
  "regex",
  "reqwest",
  "russh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ russh = ["dep:russh", "dep:russh-sftp"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-libc = "0"
 regex = "1"
 reqwest = { version = "0", default-features = false, features = ["rustls-tls", "blocking", "gzip", "brotli"] }
 russh = { version = "0", optional = true }


### PR DESCRIPTION
Use termion instead of the libc library to enable and disable raw terminal mode to simplify the code.