### PR TITLE
refactor: add get_geometry() method to console trait

### DIFF
--- a/src/view/console.rs
+++ b/src/view/console.rs
@@ -7,6 +7,8 @@ pub trait Console {
     fn info(&mut self, msg: &str);
     fn error(&mut self, msg: &str);
 
+    fn get_geometry(&self) -> Option<(u32, u32)>;
+
     fn raw_mode(&mut self);
     fn reset(&mut self);
 }

--- a/src/view/console_mock.rs
+++ b/src/view/console_mock.rs
@@ -41,6 +41,10 @@ pub mod tests {
             self.log(msg)
         }
 
+        fn get_geometry(&self) -> Option<(u32, u32)> {
+            None
+        }
+
         fn raw_mode(&mut self) {}
         fn reset(&mut self) {}
     }

--- a/src/view/stdio.rs
+++ b/src/view/stdio.rs
@@ -45,6 +45,12 @@ impl Console for Stdio {
         eprintln!("{msg}");
     }
 
+    fn get_geometry(&self) -> Option<(u32, u32)> {
+        termion::terminal_size()
+            .map(|(w, h)| (w as u32, h as u32))
+            .ok()
+    }
+
     fn raw_mode(&mut self) {
         if self.raw_mode.is_none() {
             self.raw_mode = stdout().into_raw_mode().ok();


### PR DESCRIPTION
Moved terminal related code into the Console trait to reduce dependency to external libraries.