### PR TITLE
fix: use full path for ssh keys

### DIFF
--- a/src/env/environment.rs
+++ b/src/env/environment.rs
@@ -109,10 +109,17 @@ impl Environment {
             .collect();
 
         for dir in search_dirs {
-            if let Ok(file_names) = fs.read_dir_file_names(&dir) {
-                for file_name in file_names {
-                    if file_name.starts_with("id_") && !file_name.contains(".") {
-                        private_keys.push(file_name.to_string());
+            if let Ok(file_paths) = fs.read_dir_file_paths(&dir) {
+                for file_path in file_paths {
+                    if file_path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .map(|name| name.starts_with("id_"))
+                        .unwrap_or_default()
+                        && file_path.extension().is_none()
+                        && let Some(file_path) = file_path.to_str()
+                    {
+                        private_keys.push(file_path.to_string());
                     }
                 }
             }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use std::fs;
 use std::io::prelude::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 pub struct FS;
@@ -42,12 +42,9 @@ impl FS {
         fs::read_dir(path).map_err(|e| Error::FS(format!("Cannot read directory '{path}' ({e})")))
     }
 
-    pub fn read_dir_file_names(&self, path: &str) -> Result<Vec<String>, Error> {
-        self.read_dir(path).map(|dir| {
-            dir.flatten()
-                .filter_map(|file| file.file_name().to_str().map(|name| name.to_string()))
-                .collect()
-        })
+    pub fn read_dir_file_paths(&self, path: &str) -> Result<Vec<PathBuf>, Error> {
+        self.read_dir(path)
+            .map(|dir| dir.flatten().map(|dir| dir.path()).collect())
     }
 
     pub fn remove_dir(&self, path: &str) -> Result<(), Error> {


### PR DESCRIPTION
Recent changes introduced a bug which caused to only use SSH key names instead of the full path and resulted in authentication failures.