### PR TITLE
refator: use datasize for instance memory and disk size

### DIFF
--- a/src/actions/create_instance_action.rs
+++ b/src/actions/create_instance_action.rs
@@ -49,7 +49,7 @@ impl CreateInstanceAction {
         SystemCommand::new("qemu-img")
             .arg("resize")
             .arg(tmp_image)
-            .arg(instance.disk_capacity.to_string())
+            .arg(instance.disk_capacity.get_bytes().to_string())
             .run()?;
 
         // Write configuration file

--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -33,7 +33,7 @@ impl StartInstanceAction {
 
         let mut emulator = Emulator::from(self.instance.arch)?;
         emulator.set_cpus(self.instance.cpus);
-        emulator.set_memory(self.instance.mem);
+        emulator.set_memory(self.instance.mem.get_bytes() as u64);
         emulator.set_console(&env.get_console_file(&self.instance.name));
         emulator.add_drive(&env.get_instance_image_file(&self.instance.name), "qcow2");
         emulator.add_drive(&env.get_user_data_image_file(&self.instance.name), "raw");

--- a/src/commands/create_instance_command.rs
+++ b/src/commands/create_instance_command.rs
@@ -66,8 +66,8 @@ impl Command for CreateInstanceCommand {
             arch: image.arch,
             user: self.user.to_string(),
             cpus: self.cpus,
-            mem: self.mem.get_bytes() as u64,
-            disk_capacity: self.disk.get_bytes() as u64,
+            mem: self.mem.clone(),
+            disk_capacity: self.disk.clone(),
             ssh_port: PortChecker::new().get_new_port(),
             hostfwd: self.port.clone(),
             ..Instance::default()

--- a/src/commands/instance_modify_command.rs
+++ b/src/commands/instance_modify_command.rs
@@ -44,7 +44,7 @@ impl Command for InstanceModifyCommand {
         }
 
         if let Some(mem) = &self.mem {
-            instance.mem = mem.get_bytes() as u64;
+            instance.mem = mem.clone();
         }
 
         if let Some(disk) = &self.disk {

--- a/src/commands/instance_show_command.rs
+++ b/src/commands/instance_show_command.rs
@@ -3,7 +3,6 @@ use crate::env::Environment;
 use crate::error::Error;
 use crate::image::ImageStore;
 use crate::instance::{InstanceName, InstanceStore};
-use crate::model::DataSize;
 use crate::view::{Console, MapView};
 use clap::Parser;
 
@@ -31,18 +30,15 @@ impl Command for InstanceShowCommand {
         let mut view = MapView::new();
         view.add("Arch", &instance.arch.to_string());
         view.add("CPUs", &instance.cpus.to_string());
-        view.add("Memory", &DataSize::new(instance.mem as usize).to_size());
+        view.add("Memory", &instance.mem.to_size());
         view.add(
             "Disk Used",
             &instance
                 .disk_used
-                .map(|size| DataSize::new(size as usize).to_size())
+                .map(|size| size.to_size())
                 .unwrap_or("n/a".to_string()),
         );
-        view.add(
-            "Disk Total",
-            &DataSize::new(instance.disk_capacity as usize).to_size(),
-        );
+        view.add("Disk Total", &instance.disk_capacity.to_size());
         view.add("User", &instance.user);
         view.add("SSH Port", &instance.ssh_port.to_string());
         view.add(
@@ -68,6 +64,7 @@ mod tests {
     use crate::image::image_store_mock::tests::ImageStoreMock;
     use crate::instance::Instance;
     use crate::instance::instance_store_mock::tests::InstanceStoreMock;
+    use crate::model::DataSize;
     use crate::view::console_mock::tests::ConsoleMock;
     use std::str::FromStr;
 
@@ -81,8 +78,8 @@ mod tests {
             arch: Arch::AMD64,
             user: "cubic".to_string(),
             cpus: 1,
-            mem: 1024,
-            disk_capacity: 1048576,
+            mem: DataSize::new(1024),
+            disk_capacity: DataSize::new(1048576),
             ssh_port: 9000,
             hostfwd: Vec::new(),
             ..Instance::default()
@@ -119,8 +116,8 @@ SSH:        ssh -p 9000 cubic@localhost
             arch: Arch::ARM64,
             user: "john".to_string(),
             cpus: 2,
-            mem: 1,
-            disk_capacity: 1,
+            mem: DataSize::new(1),
+            disk_capacity: DataSize::new(1),
             ssh_port: 8000,
             hostfwd: Vec::new(),
             ..Instance::default()

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -3,7 +3,6 @@ use crate::env::Environment;
 use crate::error::Error;
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
-use crate::model::DataSize;
 use crate::view::{Alignment, Console, TableView};
 use clap::Parser;
 
@@ -44,21 +43,16 @@ impl Command for ListInstanceCommand {
                 .add(instance_name, Alignment::Left)
                 .add(&instance.arch.to_string(), Alignment::Left)
                 .add(&instance.cpus.to_string(), Alignment::Right)
-                .add(
-                    &DataSize::new(instance.mem as usize).to_size(),
-                    Alignment::Right,
-                )
+                .add(&instance.mem.to_size(), Alignment::Right)
                 .add(
                     &instance
                         .disk_used
-                        .map(|size| DataSize::new(size as usize).to_size())
+                        .as_ref()
+                        .map(|size| size.to_size())
                         .unwrap_or("n/a".to_string()),
                     Alignment::Right,
                 )
-                .add(
-                    &DataSize::new(instance.disk_capacity as usize).to_size(),
-                    Alignment::Right,
-                )
+                .add(&instance.disk_capacity.to_size(), Alignment::Right)
                 .add(
                     if instance_store.is_running(&instance) {
                         "running"
@@ -80,6 +74,7 @@ mod tests {
     use crate::image::image_store_mock::tests::ImageStoreMock;
     use crate::instance::Instance;
     use crate::instance::instance_store_mock::tests::InstanceStoreMock;
+    use crate::model::DataSize;
     use crate::view::console_mock::tests::ConsoleMock;
 
     #[test]
@@ -93,8 +88,8 @@ mod tests {
                 arch: Arch::AMD64,
                 user: "cubic".to_string(),
                 cpus: 1,
-                mem: 1024,
-                disk_capacity: 1048576,
+                mem: DataSize::new(1024),
+                disk_capacity: DataSize::new(1048576),
                 ssh_port: 9000,
                 hostfwd: Vec::new(),
                 ..Instance::default()
@@ -104,8 +99,8 @@ mod tests {
                 arch: Arch::AMD64,
                 user: "cubic".to_string(),
                 cpus: 5,
-                mem: 0,
-                disk_capacity: 5000,
+                mem: DataSize::new(0),
+                disk_capacity: DataSize::new(5000),
                 ssh_port: 9000,
                 hostfwd: Vec::new(),
                 ..Instance::default()

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -25,6 +25,8 @@ pub use target_path::*;
 pub use toml_instance_deserializer::*;
 pub use yaml_instance_deserializer::*;
 
+use crate::model::DataSize;
+
 fn default_user() -> String {
     USER.to_string()
 }
@@ -38,10 +40,10 @@ pub struct Instance {
     #[serde(default = "default_user")]
     pub user: String,
     pub cpus: u16,
-    pub mem: u64,
+    pub mem: DataSize,
     #[serde(skip)]
-    pub disk_used: Option<u64>,
-    pub disk_capacity: u64,
+    pub disk_used: Option<DataSize>,
+    pub disk_capacity: DataSize,
     pub ssh_port: u16,
     #[serde(default)]
     pub hostfwd: Vec<PortForward>,

--- a/src/instance/instance_serializer.rs
+++ b/src/instance/instance_serializer.rs
@@ -22,6 +22,7 @@ impl InstanceSerializer {
 mod tests {
     use super::*;
     use crate::arch::Arch;
+    use crate::model::DataSize;
 
     #[test]
     fn test_serialize_minimal_config() {
@@ -34,8 +35,8 @@ mod tests {
                     arch: Arch::AMD64,
                     user: "tux".to_string(),
                     cpus: 1,
-                    mem: 1000,
-                    disk_capacity: 1000,
+                    mem: DataSize::new(1000),
+                    disk_capacity: DataSize::new(1000),
                     ssh_port: 10000,
                     hostfwd: Vec::new(),
                     ..Instance::default()

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -56,8 +56,8 @@ ssh_port = 14357
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "cubic");
         assert_eq!(instance.cpus, 1);
-        assert_eq!(instance.mem, 1073741824);
-        assert_eq!(instance.disk_capacity, 2361393152);
+        assert_eq!(instance.mem.get_bytes(), 1073741824);
+        assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
         assert_eq!(instance.ssh_port, 14357);
         assert!(instance.hostfwd.is_empty());
     }
@@ -82,8 +82,8 @@ hostfwd = ["tcp:127.0.0.1:8000-:8000", "tcp:127.0.0.1:9000-:10000"]
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "tux");
         assert_eq!(instance.cpus, 1);
-        assert_eq!(instance.mem, 1073741824);
-        assert_eq!(instance.disk_capacity, 2361393152);
+        assert_eq!(instance.mem.get_bytes(), 1073741824);
+        assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
         assert_eq!(instance.ssh_port, 14357);
         assert_eq!(
             instance
@@ -114,8 +114,8 @@ ssh_port = 14357
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "tux");
         assert_eq!(instance.cpus, 1);
-        assert_eq!(instance.mem, 1073741824);
-        assert_eq!(instance.disk_capacity, 2361393152);
+        assert_eq!(instance.mem.get_bytes(), 1073741824);
+        assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
         assert_eq!(instance.ssh_port, 14357);
         assert!(instance.hostfwd.is_empty());
     }

--- a/src/instance/yaml_instance_deserializer.rs
+++ b/src/instance/yaml_instance_deserializer.rs
@@ -56,8 +56,8 @@ machine:
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "cubic");
         assert_eq!(instance.cpus, 1);
-        assert_eq!(instance.mem, 1073741824);
-        assert_eq!(instance.disk_capacity, 2361393152);
+        assert_eq!(instance.mem.get_bytes(), 1073741824);
+        assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
         assert_eq!(instance.ssh_port, 14357);
         assert!(instance.hostfwd.is_empty());
     }
@@ -83,8 +83,8 @@ machine:
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "tux");
         assert_eq!(instance.cpus, 1);
-        assert_eq!(instance.mem, 1073741824);
-        assert_eq!(instance.disk_capacity, 2361393152);
+        assert_eq!(instance.mem.get_bytes(), 1073741824);
+        assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
         assert_eq!(instance.ssh_port, 14357);
         assert_eq!(
             instance
@@ -117,8 +117,8 @@ machine:
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "tux");
         assert_eq!(instance.cpus, 1);
-        assert_eq!(instance.mem, 1073741824);
-        assert_eq!(instance.disk_capacity, 2361393152);
+        assert_eq!(instance.mem.get_bytes(), 1073741824);
+        assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
         assert_eq!(instance.ssh_port, 14357);
         assert!(instance.hostfwd.is_empty());
     }

--- a/src/model/data_size.rs
+++ b/src/model/data_size.rs
@@ -1,6 +1,7 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct DataSize {
     bytes: usize,
 }
@@ -63,6 +64,26 @@ impl FromStr for DataSize {
                 bytes: size * 1024_usize.pow(power),
             })
             .map_err(|_| error)
+    }
+}
+
+impl Serialize for DataSize {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(self.bytes as u64)
+    }
+}
+
+impl<'de> Deserialize<'de> for DataSize {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self {
+            bytes: usize::deserialize(deserializer)?,
+        })
     }
 }
 


### PR DESCRIPTION
Reuse DataSize in Instance to simplify the code.