### PR TITLE
feat: use by default russh instead openssh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,16 +43,14 @@ categories = ["command-line-utilities"]
 edition = "2024"
 
 [features]
-default = ["russh"]
 qemu-sandbox = []
-russh = ["dep:russh", "dep:russh-sftp"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 regex = "1"
 reqwest = { version = "0", default-features = false, features = ["rustls-tls", "blocking", "gzip", "brotli"] }
-russh = { version = "0", optional = true }
-russh-sftp = { version = "2", optional = true }
+russh = "0"
+russh-sftp = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0"

--- a/src/commands/instance_scp_command.rs
+++ b/src/commands/instance_scp_command.rs
@@ -50,7 +50,7 @@ impl Command for InstanceScpCommand {
         check_target_is_running(instance_store, &self.to)?;
 
         let root_dir = env::var("SNAP").unwrap_or_default();
-        let mut ssh: Box<dyn Ssh> = SshFactory::new().create(self.russh);
+        let mut ssh: Box<dyn Ssh> = SshFactory::new().create(self.openssh);
 
         let pubkeys = env.get_ssh_private_key_paths(
             &FS::new(),

--- a/src/commands/instance_ssh_command.rs
+++ b/src/commands/instance_ssh_command.rs
@@ -59,7 +59,7 @@ impl Command for InstanceSshCommand {
             .map(|user| user.to_string())
             .unwrap_or(instance.user.to_string());
         let ssh_port = instance.ssh_port;
-        let mut ssh: Box<dyn Ssh> = SshFactory::new().create(self.args.russh);
+        let mut ssh: Box<dyn Ssh> = SshFactory::new().create(self.args.openssh);
         ssh.set_known_hosts_file(
             env::var("HOME")
                 .map(|dir| format!("{dir}/.ssh/known_hosts"))

--- a/src/ssh_cmd.rs
+++ b/src/ssh_cmd.rs
@@ -1,8 +1,6 @@
 mod openssh;
 mod port_checker;
-#[cfg(feature = "russh")]
 mod russh;
-#[cfg(feature = "russh")]
 mod sftp_path;
 mod ssh;
 mod ssh_factory;
@@ -10,9 +8,7 @@ mod ssh_key_generator;
 
 pub use openssh::Openssh;
 pub use port_checker::PortChecker;
-#[cfg(feature = "russh")]
 pub use russh::Russh;
-#[cfg(feature = "russh")]
 pub use sftp_path::SftpPath;
 pub use ssh::Ssh;
 pub use ssh_factory::SshFactory;

--- a/src/ssh_cmd/ssh_factory.rs
+++ b/src/ssh_cmd/ssh_factory.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "russh")]
 use crate::ssh_cmd::Russh;
 use crate::ssh_cmd::{Openssh, Ssh};
 
@@ -10,17 +9,11 @@ impl SshFactory {
         Self
     }
 
-    #[cfg(feature = "russh")]
-    pub fn create(&self, use_russh: bool) -> Box<dyn Ssh> {
-        if use_russh {
-            Box::new(Russh::new())
-        } else {
+    pub fn create(&self, use_openssh: bool) -> Box<dyn Ssh> {
+        if use_openssh {
             Box::new(Openssh::new())
+        } else {
+            Box::new(Russh::new())
         }
-    }
-
-    #[cfg(not(feature = "russh"))]
-    pub fn create(&self, _use_russh: bool) -> Box<dyn Ssh> {
-        Box::new(Openssh::new())
     }
 }


### PR DESCRIPTION
This is part of the transition to move from OpenSSH to a pure Rust SSH implementation. For the moment the OpenSSH implementation can still be used by using the --openssh flag.