### PR TITLE
feat: shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +669,7 @@ name = "cubic"
 version = "0.18.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "crossterm",
  "rand 0.8.5",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ qemu-sandbox = []
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 crossterm = "0"
 rand = "=0.8"
 regex = "1"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,5 @@
 pub mod command_dispatcher;
+pub mod completions_command;
 pub mod create_instance_command;
 pub mod delete_instance_command;
 pub mod image;
@@ -22,6 +23,7 @@ pub mod show_image_command;
 pub mod verbosity;
 
 pub use command_dispatcher::*;
+pub use completions_command::*;
 pub use create_instance_command::*;
 pub use delete_instance_command::*;
 pub use image::*;

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -27,6 +27,7 @@ pub enum Commands {
     Clone(InstanceCloneCommand),
     Delete(commands::DeleteInstanceCommand),
     Prune(commands::PruneCommand),
+    Completions(commands::CompletionsCommand),
 }
 
 #[derive(Parser, Default)]
@@ -77,6 +78,7 @@ impl CommandDispatcher {
             Commands::Scp(cmd) => cmd,
             Commands::Delete(cmd) => cmd,
             Commands::Prune(cmd) => cmd,
+            Commands::Completions(cmd) => cmd,
         }
         .run(console, &env, &image_dao, &instance_dao)
     }

--- a/src/commands/completions_command.rs
+++ b/src/commands/completions_command.rs
@@ -1,0 +1,35 @@
+use crate::commands::{Command, CommandDispatcher};
+use crate::env::Environment;
+use crate::error::Error;
+use crate::image::ImageStore;
+use crate::instance::InstanceStore;
+use crate::view::Console;
+use clap::{CommandFactory, Parser};
+use clap_complete::Shell;
+
+/// Generate command completions for your shell
+#[derive(Parser)]
+#[clap(alias = "completion")]
+pub struct CompletionsCommand {
+    /// The shell to generate completions for
+    shell: Option<Shell>,
+}
+
+impl Command for CompletionsCommand {
+    fn run(
+        &self,
+        _console: &mut dyn Console,
+        _env: &Environment,
+        _image_store: &dyn ImageStore,
+        _instance_store: &dyn InstanceStore,
+    ) -> Result<(), Error> {
+        let Some(shell) = self.shell.or_else(Shell::from_env) else {
+            return Err(Error::CouldNotDetectShell);
+        };
+
+        let mut cmd = CommandDispatcher::command();
+        let name = cmd.get_name().to_string();
+        clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,7 @@ pub enum Error {
     SerdeJson(serde_json::Error),
     SerdeToml(toml::ser::Error),
     InvalidChecksum,
+    CouldNotDetectShell,
     Ssh(ssh_key::Error),
 }
 
@@ -63,6 +64,7 @@ impl Error {
                 Error::SerdeToml(err) => format!("[TOML] {err}"),
                 Error::Web(e) => format!("{e}"),
                 Error::InvalidChecksum => "Verification of image failed".to_string(),
+                Error::CouldNotDetectShell => "Could not detect shell".to_string(),
                 Error::Ssh(ssh) => format!("SSH error: {ssh}"),
             }
         ))


### PR DESCRIPTION
Use [clap_complete](https://docs.rs/clap_complete/latest/clap_complete/) to add a `completion`/`completions` command.

```console
❯ cubic completions --help
Generate command completions for your shell

Usage: cubic completions [OPTIONS] [SHELL]

Arguments:
  [SHELL]  The shell to generate completions for [possible values: bash, elvish, fish, powershell, zsh]

Options:
  -v, --verbose  Increase logging output
  -q, --quiet    Reduce logging output
  -h, --help     Print help
```