### PR TITLE
doc: add make rule to generate command reference docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,3 +53,4 @@ Reference
   * :ref:`ref_cubic_clone`
   * :ref:`ref_cubic_delete`
   * :ref:`ref_cubic_prune`
+  * :ref:`ref_cubic_completions`

--- a/docs/reference/clone.rst
+++ b/docs/reference/clone.rst
@@ -1,19 +1,19 @@
 .. _ref_cubic_clone:
 
 cubic clone
-===========
+=====
 
 .. code-block::
 
     $ cubic clone --help
     Clone a virtual machine instance
-
+    
     Usage: cubic clone [OPTIONS] <NAME> <NEW_NAME>
-
+    
     Arguments:
       <NAME>      Name of the virtual machine instance to clone
       <NEW_NAME>  Name of the copy
-
+    
     Options:
       -v, --verbose  Increase logging output
       -q, --quiet    Reduce logging output

--- a/docs/reference/completions.rst
+++ b/docs/reference/completions.rst
@@ -1,0 +1,19 @@
+.. _ref_cubic_completions:
+
+cubic completions
+=====
+
+.. code-block::
+
+    $ cubic completions --help
+    Generate command completions for your shell
+    
+    Usage: cubic completions [OPTIONS] [SHELL]
+    
+    Arguments:
+      [SHELL]  The shell to generate completions for [possible values: bash, elvish, fish, powershell, zsh]
+    
+    Options:
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
+      -h, --help     Print help

--- a/docs/reference/console.rst
+++ b/docs/reference/console.rst
@@ -1,18 +1,18 @@
 .. _ref_cubic_console:
 
 cubic console
-=============
+=====
 
 .. code-block::
 
     $ cubic console --help
     Open the console of an virtual machine instance
-
+    
     Usage: cubic console [OPTIONS] <INSTANCE>
-
+    
     Arguments:
       <INSTANCE>  Name of the virtual machine instance
-
+    
     Options:
       -v, --verbose  Increase logging output
       -q, --quiet    Reduce logging output

--- a/docs/reference/create.rst
+++ b/docs/reference/create.rst
@@ -1,18 +1,18 @@
 .. _ref_cubic_create:
 
 cubic create
-============
+=====
 
 .. code-block::
 
     $ cubic create --help
     Create a new virtual machine instance
-
-    Usage: cubic create [OPTIONS] --image <IMAGE> [INSTANCE_NAME]
-
+    
+    Usage: cubic create [OPTIONS] --image <IMAGE> <INSTANCE_NAME>
+    
     Arguments:
-      [INSTANCE_NAME]  Name of the virtual machine instance
-
+      <INSTANCE_NAME>  Name of the virtual machine instance
+    
     Options:
       -i, --image <IMAGE>  Name of the virtual machine image
       -u, --user <USER>    Name of the user [default: cubic]

--- a/docs/reference/cubic.rst
+++ b/docs/reference/cubic.rst
@@ -9,54 +9,58 @@ cubic
     Cubic is a lightweight command line manager for virtual machines. It has a
     simple, daemon-less and rootless design. All Cubic virtual machines run
     isolated in the user context. Cubic is built on top of QEMU, KVM and cloud-init.
-
+    
+    https://cubic-vm.org
+    https://github.com/cubic-vm/cubic
+    
     Show all supported images:
     $ cubic images
-
+    
     Create a new virtual machine instance:
     $ cubic create mymachine --image ubuntu:noble
-
+    
     List all virtual machine instances:
     $ cubic instances
-
+    
     Start an instance:
     $ cubic start <instance name>
-
+    
     Stop an instance:
     $ cubic stop <instance name>
-
+    
     Open a shell in the instance:
     $ cubic ssh <machine name>
-
+    
     Copy a file from the host to the instance:
     $ cubic scp <path/to/host/file> <machine>:<path/to/guest/file>
-
+    
     Copy a file from the instance to the hots:
     $ cubic scp <machine>:<path/to/guest/file> <path/to/host/file>
-
-
+    
+    
     Usage: cubic [OPTIONS] <COMMAND>
-
+    
     Commands:
-      run        Create, start and open a shell in a new virtual machine instance
-      create     Create a new virtual machine instance
-      instances  List all virtual machine instances
-      images     List all supported virtual machine images
-      ports      List forwarded ports for all virtual machine instances
-      show       Show virtual machine image or instance information
-      modify     Modify a virtual machine instance configuration
-      console    Open the console of an virtual machine instance
-      ssh        Connect to a virtual machine instance with SSH
-      scp        Copy a file from or to a virtual machine instance with SCP
-      start      Start virtual machine instances
-      stop       Stop virtual machine instances
-      restart    Restart virtual machine instances
-      rename     Rename a virtual machine instance
-      clone      Clone a virtual machine instance
-      delete     Delete one or more virtual machine instances
-      prune      Clear cache and free space
-      help       Print this message or the help of the given subcommand(s)
-
+      run          Create, start and open a shell in a new virtual machine instance
+      create       Create a new virtual machine instance
+      instances    List all virtual machine instances
+      images       List all supported virtual machine images
+      ports        List forwarded ports for all virtual machine instances
+      show         Show virtual machine image or instance information
+      modify       Modify a virtual machine instance configuration
+      console      Open the console of an virtual machine instance
+      ssh          Connect to a virtual machine instance with SSH
+      scp          Copy a file from or to a virtual machine instance with SCP
+      start        Start virtual machine instances
+      stop         Stop virtual machine instances
+      restart      Restart virtual machine instances
+      rename       Rename a virtual machine instance
+      clone        Clone a virtual machine instance
+      delete       Delete one or more virtual machine instances
+      prune        Clear cache and free space
+      completions  Generate command completions for your shell
+      help         Print this message or the help of the given subcommand(s)
+    
     Options:
       -v, --verbose  Increase logging output
       -q, --quiet    Reduce logging output

--- a/docs/reference/delete.rst
+++ b/docs/reference/delete.rst
@@ -1,18 +1,18 @@
 .. _ref_cubic_delete:
 
 cubic delete
-============
+=====
 
 .. code-block::
 
     $ cubic delete --help
     Delete one or more virtual machine instances
-
+    
     Usage: cubic delete [OPTIONS] [INSTANCES]...
-
+    
     Arguments:
       [INSTANCES]...  Name of the virtual machine instances to delete
-
+    
     Options:
       -f, --force    Delete the virtual machine instances even when running
       -y, --yes      Delete the virtual machine instances without confirmation

--- a/docs/reference/images.rst
+++ b/docs/reference/images.rst
@@ -1,15 +1,15 @@
 .. _ref_cubic_images:
 
 cubic images
-============
+=====
 
 .. code-block::
 
     $ cubic images --help
     List all supported virtual machine images
-
+    
     Usage: cubic images [OPTIONS]
-
+    
     Options:
       -a, --all      Show all images
       -v, --verbose  Increase logging output

--- a/docs/reference/instances.rst
+++ b/docs/reference/instances.rst
@@ -1,15 +1,15 @@
 .. _ref_cubic_instances:
 
 cubic instances
-===============
+=====
 
 .. code-block::
 
     $ cubic instances --help
     List all virtual machine instances
-
+    
     Usage: cubic instances [OPTIONS]
-
+    
     Options:
       -v, --verbose  Increase logging output
       -q, --quiet    Reduce logging output

--- a/docs/reference/modify.rst
+++ b/docs/reference/modify.rst
@@ -1,18 +1,18 @@
 .. _ref_cubic_modify:
 
 cubic modify
-============
+=====
 
 .. code-block::
 
     $ cubic modify --help
     Modify a virtual machine instance configuration
-
+    
     Usage: cubic modify [OPTIONS] <INSTANCE>
-
+    
     Arguments:
       <INSTANCE>  Name of the virtual machine instance
-
+    
     Options:
       -c, --cpus <CPUS>        Number of CPUs for the virtual machine instance
       -m, --mem <MEM>          Memory size of the virtual machine instance (e.g. 1G for 1 gigabyte)

--- a/docs/reference/ports.rst
+++ b/docs/reference/ports.rst
@@ -1,15 +1,15 @@
 .. _ref_cubic_ports:
 
 cubic ports
-===========
+=====
 
 .. code-block::
 
     $ cubic ports --help
     List forwarded ports for all virtual machine instances
-
+    
     Usage: cubic ports [OPTIONS]
-
+    
     Options:
       -v, --verbose  Increase logging output
       -q, --quiet    Reduce logging output

--- a/docs/reference/prune.rst
+++ b/docs/reference/prune.rst
@@ -1,15 +1,15 @@
 .. _ref_cubic_prune:
 
 cubic prune
-===========
+=====
 
 .. code-block::
 
     $ cubic prune --help
     Clear cache and free space
-
+    
     Usage: cubic prune [OPTIONS]
-
+    
     Options:
       -v, --verbose  Increase logging output
       -q, --quiet    Reduce logging output

--- a/docs/reference/rename.rst
+++ b/docs/reference/rename.rst
@@ -1,19 +1,20 @@
 .. _ref_cubic_rename:
 
 cubic rename
-============
+=====
 
 .. code-block::
 
     $ cubic rename --help
     Rename a virtual machine instance
-
+    
     Usage: cubic rename [OPTIONS] <OLD_NAME> <NEW_NAME>
-
+    
     Arguments:
       <OLD_NAME>  Name of the virtual machine instance to rename
       <NEW_NAME>  New name of the virtual machine instance
-
+    
     Options:
       -v, --verbose  Increase logging output
-      -q, --quiet    Reduce logging
+      -q, --quiet    Reduce logging output
+      -h, --help     Print help

--- a/docs/reference/restart.rst
+++ b/docs/reference/restart.rst
@@ -1,18 +1,18 @@
 .. _ref_cubic_restart:
 
 cubic restart
-=============
+=====
 
 .. code-block::
 
     $ cubic restart --help
     Restart virtual machine instances
-
+    
     Usage: cubic restart [OPTIONS] [INSTANCES]...
-
+    
     Arguments:
       [INSTANCES]...  Name of the virtual machine instances to restart
-
+    
     Options:
       -v, --verbose  Increase logging output
       -q, --quiet    Reduce logging output

--- a/docs/reference/run.rst
+++ b/docs/reference/run.rst
@@ -1,18 +1,18 @@
 .. _ref_cubic_run:
 
 cubic run
-=========
+=====
 
 .. code-block::
 
     $ cubic run --help
     Create, start and open a shell in a new virtual machine instance
-
-    Usage: cubic run [OPTIONS] --image <IMAGE> [INSTANCE_NAME]
-
+    
+    Usage: cubic run [OPTIONS] --image <IMAGE> <INSTANCE_NAME>
+    
     Arguments:
-      [INSTANCE_NAME]  Name of the virtual machine instance
-
+      <INSTANCE_NAME>  Name of the virtual machine instance
+    
     Options:
       -i, --image <IMAGE>  Name of the virtual machine image
       -u, --user <USER>    Name of the user [default: cubic]

--- a/docs/reference/scp.rst
+++ b/docs/reference/scp.rst
@@ -1,21 +1,20 @@
 .. _ref_cubic_scp:
 
 cubic scp
-=========
+=====
 
 .. code-block::
 
     $ cubic scp --help
     Copy a file from or to a virtual machine instance with SCP
-
+    
     Usage: cubic scp [OPTIONS] <FROM> <TO>
-
+    
     Arguments:
       <FROM>  Source of the data to copy
       <TO>    Target of the data to copy
-
+    
     Options:
-          --scp-args <SCP_ARGS>  Pass additional SCP arguments
-      -v, --verbose              Increase logging output
-      -q, --quiet                Reduce logging output
-      -h, --help                 Print help
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
+      -h, --help     Print help

--- a/docs/reference/show.rst
+++ b/docs/reference/show.rst
@@ -1,18 +1,18 @@
 .. _ref_cubic_show:
 
 cubic show
-==========
+=====
 
 .. code-block::
 
     $ cubic show --help
     Show virtual machine image or instance information
-
+    
     Usage: cubic show [OPTIONS] <NAME>
-
+    
     Arguments:
       <NAME>  Name of the virtual machine image or instance
-
+    
     Options:
       -v, --verbose  Increase logging output
       -q, --quiet    Reduce logging output

--- a/docs/reference/ssh.rst
+++ b/docs/reference/ssh.rst
@@ -1,22 +1,20 @@
 .. _ref_cubic_ssh:
 
 cubic ssh
-=========
+=====
 
 .. code-block::
 
     $ cubic ssh --help
     Connect to a virtual machine instance with SSH
-
+    
     Usage: cubic ssh [OPTIONS] <TARGET> [CMD]
-
+    
     Arguments:
       <TARGET>  Target instance (format: [username@]instance, e.g. 'cubic@mymachine' or 'mymachine')
       [CMD]     Execute a command in the virtual machine
-
+    
     Options:
-      -X                         Forward X over SSH
-          --ssh-args <SSH_ARGS>  Pass additional SSH arguments
-      -v, --verbose              Increase logging output
-      -q, --quiet                Reduce logging output
-      -h, --help                 Print help
+      -v, --verbose  Increase logging output
+      -q, --quiet    Reduce logging output
+      -h, --help     Print help

--- a/docs/reference/start.rst
+++ b/docs/reference/start.rst
@@ -1,18 +1,18 @@
 .. _ref_cubic_start:
 
 cubic start
-===========
+=====
 
 .. code-block::
 
     $ cubic start --help
     Start virtual machine instances
-
+    
     Usage: cubic start [OPTIONS] [INSTANCES]...
-
+    
     Arguments:
       [INSTANCES]...  Name of the virtual machine instances to start
-
+    
     Options:
           --qemu-args <QEMU_ARGS>  Pass additional QEMU arguments
       -w, --wait                   Wait for the virtual machine instance to be started

--- a/docs/reference/stop.rst
+++ b/docs/reference/stop.rst
@@ -1,18 +1,18 @@
 .. _ref_cubic_stop:
 
 cubic stop
-==========
+=====
 
 .. code-block::
 
     $ cubic stop --help
     Stop virtual machine instances
-
+    
     Usage: cubic stop [OPTIONS] [INSTANCES]...
-
+    
     Arguments:
       [INSTANCES]...  Name of the virtual machine instances to stop
-
+    
     Options:
       -a, --all      Stop all virtual machine instances
       -w, --wait     Wait for the virtual machine instance to be stopped


### PR DESCRIPTION
- Introduced a new 'make gen-ref' target that runs the documentation generator to produce the up‑to‑date command reference.
- Updated the command‑reference documentation files to reflect the newly generated output.

This helps to keep the command reference in sync with the code base.