### PR TITLE
chore: manage RustSec suppressions in audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,4 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2023-0071", # No fix available so far
+]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo install cargo-audit
 
       - name: Audit Source Code
-        run: cargo audit --ignore RUSTSEC-2023-0071
+        run: cargo audit
 
   linux:
     name: Build on Linux

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: build-image
 	${DOCKER_CMD} ${IMAGE} cargo test
 
 audit: build-image
-	${DOCKER_CMD} ${IMAGE} cargo audit --ignore RUSTSEC-2023-0071 # no fix available so far
+	${DOCKER_CMD} ${IMAGE} cargo audit
 
 update: build-image
 	${DOCKER_CMD} ${IMAGE} cargo update


### PR DESCRIPTION
- Add vulnerability suppressions to .cargo/audit.toml
- Centralize the configuration so the Makefile and CI no longer need duplicate entries