### PR TITLE
feat: add CI pipeline for building .deb packages

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,0 +1,31 @@
+name: Build Debian Package
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  build-debian-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        run: rustup toolchain install stable
+
+      - name: Install Cargo Deb
+        run: cargo install cargo-deb
+
+      - name: Build Debian Package
+        run: cargo deb
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cubic-debian-amd64
+          path: target/debian/*.deb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,16 @@ lto = true
 codegen-units = 1
 panic = 'abort'
 strip = true
+
+[package.metadata.deb]
+maintainer = "Roger Knecht <rknecht@pm.me>"
+copyright = "2026, Roger Knecht <rknecht@pm.me>"
+license-file = ["LICENSE-APACHE", "0", "LICENSE-MIT", "0"]
+extended-description = """A lightweight command-line manager for virtual machines ."""
+depends = "qemu-system-x86, qemu-system-arm, genisoimage"
+section = "utility"
+priority = "optional"
+assets = [
+    ["target/release/cubic", "usr/bin/", "755"],
+    { source = "README.md", dest = "usr/share/doc/cubic/README", mode = "644"},
+]


### PR DESCRIPTION
Add a continuous integration workflow that builds a Debian (.deb) package on the main branch and on every release tag. This makes it easy to produce ready‑to‑install packages for Debian, Ubuntu, etc.