### PR TITLE
chore: build snaps on release‑tag creation

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
 
 jobs:
   build-snap-amd64:
@@ -50,7 +52,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
           snap: ${{ needs.build-snap-amd64.outputs.snap-file }}
-          release: 'edge'
+          release: ${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}
   publish-snap-arm64:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -65,4 +67,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
           snap: ${{ needs.build-snap-arm64.outputs.snap-file }}
-          release: 'edge'
+          release: ${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}


### PR DESCRIPTION
In addition to building snaps on the main branch, also build the snap when a release tag is created and publish it to the latest/candidate channel.