### PR TITLE
fix: show error when SCP path does not exist

### DIFF
--- a/src/commands/instance_scp_command.rs
+++ b/src/commands/instance_scp_command.rs
@@ -63,7 +63,7 @@ impl Command for InstanceScpCommand {
             &root_dir,
             &self.from.to_target_instance_path(instance_store)?,
             &self.to.to_target_instance_path(instance_store)?,
-        );
+        )?;
         Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,7 @@ pub enum Error {
     InvalidChecksum,
     CouldNotDetectShell,
     Ssh(ssh_key::Error),
+    InvalidPath(String),
 }
 
 impl Error {
@@ -66,6 +67,7 @@ impl Error {
                 Error::InvalidChecksum => "Verification of image failed".to_string(),
                 Error::CouldNotDetectShell => "Could not detect shell".to_string(),
                 Error::Ssh(ssh) => format!("SSH error: {ssh}"),
+                Error::InvalidPath(path) => format!("Invalid path: {path}"),
             }
         ))
     }

--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -1,3 +1,4 @@
+use crate::error::Error;
 use crate::instance::{Instance, TargetInstancePath};
 use crate::ssh_cmd::SftpPath;
 use crate::util;
@@ -284,12 +285,11 @@ impl Russh {
         _root_dir: &str,
         from: &TargetInstancePath,
         to: &TargetInstancePath,
-    ) -> Result<(), ()> {
+    ) -> Result<(), Error> {
         let source = self.open_target_fs(console, from).await;
         let target = self.open_target_fs(console, to).await;
 
-        source.copy(target).await;
-        Ok(())
+        source.copy(target).await
     }
 
     pub fn set_private_keys(&mut self, private_keys: Vec<String>) {
@@ -315,9 +315,7 @@ impl Russh {
         root_dir: &str,
         from: &TargetInstancePath,
         to: &TargetInstancePath,
-    ) -> bool {
-        util::AsyncCaller::new()
-            .call(self.async_copy(console, root_dir, from, to))
-            .is_ok()
+    ) -> Result<(), Error> {
+        util::AsyncCaller::new().call(self.async_copy(console, root_dir, from, to))
     }
 }


### PR DESCRIPTION
The Russh implementation previously panicked when an SCP file path did not exist. This change now returns a proper error message instead.