### PR TITLE
Fixes for Issues with (Ru)SSH

### DIFF
--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use tokio::{io::AsyncReadExt, sync::Mutex};
 
-async fn read_password(user: &str) -> Result<String, ()> {
+async fn read_password(console: &mut dyn Console, user: &str) -> Result<String, ()> {
     let mut stdout = std::io::stdout();
     let mut stdin = tokio::io::stdin();
 
@@ -25,6 +25,7 @@ async fn read_password(user: &str) -> Result<String, ()> {
 
     stdout.flush().map_err(|_| ())?;
 
+    console.raw_mode();
     loop {
         // read character from stdin
         if stdin.read(c).await.map_err(|_| ())? == 0 {
@@ -33,7 +34,11 @@ async fn read_password(user: &str) -> Result<String, ()> {
 
         match c[0] {
             // Ctrl+C
-            0x03 => std::process::exit(1),
+            0x03 => {
+                console.reset();
+                println!();
+                std::process::exit(1)
+            }
 
             // Carriage return and line feed
             0x0A | 0x0D => break,
@@ -48,6 +53,7 @@ async fn read_password(user: &str) -> Result<String, ()> {
             }
         };
     }
+    console.reset();
 
     print!("\r\n");
     str::from_utf8(&password)
@@ -176,11 +182,12 @@ impl Russh {
 
     async fn authenticate_with_password(
         &self,
+        console: &mut dyn Console,
         session: &mut russh::client::Handle<Client>,
         user: &str,
     ) -> Result<(), ()> {
         loop {
-            let password = read_password(user).await?;
+            let password = read_password(console, user).await?;
 
             if session
                 .authenticate_password(user, password)
@@ -197,6 +204,7 @@ impl Russh {
 
     async fn authenticate(
         &self,
+        console: &mut dyn Console,
         session: &mut russh::client::Handle<Client>,
         user: &str,
     ) -> Result<(), ()> {
@@ -212,7 +220,8 @@ impl Russh {
             return Ok(());
         }
 
-        self.authenticate_with_password(session, user).await
+        self.authenticate_with_password(console, session, user)
+            .await
     }
 
     async fn open_channel(
@@ -239,7 +248,7 @@ impl Russh {
             s.stop()
         }
 
-        self.authenticate(&mut session, user).await?;
+        self.authenticate(console, &mut session, user).await?;
 
         session.channel_open_session().await.map_err(|_| ())
     }
@@ -276,6 +285,7 @@ impl Russh {
 
         let ssh_out = Arc::new(Mutex::new(ssh_out));
 
+        console.raw_mode();
         tokio::select!(
             _ = ssh_geometry(console, ssh_out.clone()) => { console.reset(); std::process::exit(0); },
             _ = ssh_output(ssh_out.clone()) => { console.reset(); std::process::exit(0); },
@@ -338,12 +348,9 @@ impl Russh {
     }
 
     pub fn shell(&mut self, console: &mut dyn Console, user: &str, port: u16) -> bool {
-        console.raw_mode();
-        let result = util::AsyncCaller::new()
+        util::AsyncCaller::new()
             .call(self.handle_interactive_shell(console, user, port))
-            .is_ok();
-        console.reset();
-        result
+            .is_ok()
     }
 
     pub fn copy(

--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -12,6 +12,49 @@ use std::rc::Rc;
 use std::sync::Arc;
 use tokio::{io::AsyncReadExt, sync::Mutex};
 
+async fn read_password(user: &str) -> Result<String, ()> {
+    let mut stdout = std::io::stdout();
+    let mut stdin = tokio::io::stdin();
+
+    let mut password = Vec::new();
+    let c: &mut [u8] = &mut [0];
+
+    stdout
+        .write_all(format!("{user}@localhost's password: ").as_bytes())
+        .map_err(|_| ())?;
+
+    stdout.flush().map_err(|_| ())?;
+
+    loop {
+        // read character from stdin
+        if stdin.read(c).await.map_err(|_| ())? == 0 {
+            continue;
+        }
+
+        match c[0] {
+            // Ctrl+C
+            0x03 => std::process::exit(1),
+
+            // Carriage return and line feed
+            0x0A | 0x0D => break,
+
+            // Delete and backspace
+            0x7E | 0x7F => {
+                password.pop();
+            }
+
+            byte => {
+                password.push(byte);
+            }
+        };
+    }
+
+    print!("\r\n");
+    str::from_utf8(&password)
+        .map(|password| password.to_string())
+        .map_err(|_| ())
+}
+
 async fn ssh_geometry(
     console: &mut dyn Console,
     output: Arc<Mutex<ChannelWriteHalf<client::Msg>>>,
@@ -137,20 +180,14 @@ impl Russh {
         user: &str,
     ) -> Result<(), ()> {
         loop {
-            let mut stdout = std::io::stdout();
-            stdout
-                .write_all(format!("{user}@localhost's password: ").as_bytes())
-                .map_err(|_| ())?;
-            stdout.flush().map_err(|_| ())?;
-            let mut password = String::new();
-            std::io::stdin().read_line(&mut password).map_err(|_| ())?;
-            println!();
-            let auth_res = session
-                .authenticate_password(user, &password[..password.len() - 1])
-                .await
-                .map_err(|_| ())?;
+            let password = read_password(user).await?;
 
-            if auth_res.success() {
+            if session
+                .authenticate_password(user, password)
+                .await
+                .map_err(|_| ())?
+                .success()
+            {
                 break;
             }
         }
@@ -198,11 +235,11 @@ impl Russh {
             }
         }
 
-        self.authenticate(&mut session, user).await?;
-
         if let Some(mut s) = spinner {
             s.stop()
         }
+
+        self.authenticate(&mut session, user).await?;
 
         session.channel_open_session().await.map_err(|_| ())
     }


### PR DESCRIPTION
This PR addresses two regressions introduced after migrating to the Russh implementation:

1. SSH password entry fix
Problem: Switching to Russh and Crossterm broke manual password entry when a custom password was supplied.
    Solution: Restores the original behavior so users can input passwords interactively again.

1. Graceful exit during SSH connection
 Problem: The terminal is placed into raw mode during the SSH connection phase, causing Ctrl‑C to be ignored and preventing users from aborting a hanging connection.
    Solution: Adjusts the raw‑mode handling so Ctrl‑C correctly terminates the connection attempt.

Together, these changes improve the usability and reliability of the SSH workflow after the Russh migration.