### PR TITLE
Spinner minutes

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -5,6 +5,7 @@ pub mod progress_bar;
 pub mod spinner_view;
 pub mod stdio;
 pub mod table_view;
+pub mod time_duration;
 pub mod transfer_view;
 
 pub use console::*;
@@ -13,4 +14,5 @@ pub use progress_bar::*;
 pub use spinner_view::*;
 pub use stdio::*;
 pub use table_view::*;
+pub use time_duration::*;
 pub use transfer_view::*;

--- a/src/view/spinner_view.rs
+++ b/src/view/spinner_view.rs
@@ -1,3 +1,4 @@
+use crate::view::TimeDuration;
 use std::cmp::max;
 use std::io::{Write, stdout};
 use std::sync::mpsc::{self, TryRecvError};
@@ -18,14 +19,14 @@ impl SpinnerView {
         let thread = thread::spawn(move || {
             let mut index = 0;
             let mut line_length = 0;
-            let start = time::Instant::now();
+            let duration = TimeDuration::new();
             while let Err(TryRecvError::Empty) = rx.try_recv() {
                 let text = format!(
-                    "{}{}.. {} ({:.1?}s)",
+                    "{}{}.. {} ({})",
                     if index > 0 { "\r" } else { "" },
                     &text,
                     SPINNER_VIEW_CHARS[index % SPINNER_VIEW_CHARS.len()],
-                    start.elapsed().as_secs_f32()
+                    duration
                 );
 
                 line_length = max(line_length, text.len());

--- a/src/view/time_duration.rs
+++ b/src/view/time_duration.rs
@@ -1,0 +1,63 @@
+use std::fmt;
+use std::time::{Duration, Instant};
+
+pub struct TimeDuration {
+    start: Instant,
+}
+
+impl TimeDuration {
+    pub fn new() -> Self {
+        Self {
+            start: Instant::now(),
+        }
+    }
+
+    fn format_duration_string(duration: Duration) -> String {
+        let minutes = duration.as_secs() / 60;
+        let secondes = duration.as_secs() % 60;
+        let millis = duration.as_millis() % 1000 / 100;
+
+        let output_secs = format!("{secondes:2}.{millis}s");
+
+        if minutes > 0 {
+            format!("{minutes}m {output_secs}")
+        } else {
+            output_secs
+        }
+    }
+}
+
+impl fmt::Display for TimeDuration {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", Self::format_duration_string(self.start.elapsed()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_seconds() {
+        assert_eq!(
+            TimeDuration::format_duration_string(Duration::from_millis(3_123)),
+            " 3.1s"
+        )
+    }
+
+    #[test]
+    fn test_half_minute() {
+        assert_eq!(
+            TimeDuration::format_duration_string(Duration::from_secs(30)),
+            "30.0s"
+        )
+    }
+
+    #[test]
+    fn test_minutes() {
+        assert_eq!(
+            TimeDuration::format_duration_string(Duration::from_millis(127_512)),
+            "2m  7.5s"
+        )
+    }
+}


### PR DESCRIPTION
When the seconds counter overflows, the spinner now also shows minutes, providing a clearer and more usable experience for users.