### PR TITLE
Use thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.9",
  "ssh-key",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ serde_json = "1"
 serde_yaml = "0"
 sha2 = "0"
 ssh-key = { version = "0", features = ["ed25519"]}
+thiserror = "2"
 tokio = { version = "1", default-features = false, features = ["fs", "io-std"] }
 toml = "0"
 

--- a/src/actions/create_instance_action.rs
+++ b/src/actions/create_instance_action.rs
@@ -1,5 +1,5 @@
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::fs::FS;
 use crate::image::Image;
 use crate::instance::{Instance, InstanceStore};
@@ -22,7 +22,7 @@ impl CreateInstanceAction {
         instance_store: &dyn InstanceStore,
         image: &Image,
         mut instance: Instance,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let instance_name = instance.name.clone();
         let target_dir = &env.get_instance_dir2(&instance.name);
         let tmp_dir = &format!("{target_dir}.tmp");

--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -1,6 +1,6 @@
 use crate::emulator::Emulator;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::fs::FS;
 use crate::instance::{Instance, InstanceStore};
 use crate::ssh_cmd::PortChecker;
@@ -23,7 +23,7 @@ impl StartInstanceAction {
         env: &Environment,
         qemu_args: &Option<String>,
         verbose: bool,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         if instance_dao.is_running(&self.instance) {
             return Ok(());
         }

--- a/src/actions/stop_instance_action.rs
+++ b/src/actions/stop_instance_action.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::instance::{Instance, InstanceStore};
 
 pub struct StopInstanceAction {
@@ -12,7 +12,7 @@ impl StopInstanceAction {
         }
     }
 
-    pub fn run(&mut self, instance_dao: &dyn InstanceStore) -> Result<(), Error> {
+    pub fn run(&mut self, instance_dao: &dyn InstanceStore) -> Result<()> {
         if !instance_dao.exists(&self.instance.name) {
             return Err(Error::UnknownInstance(self.instance.name.clone()));
         }

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -10,7 +10,7 @@ pub enum Arch {
 }
 
 impl Arch {
-    pub fn from_str(arch: &str) -> Result<Arch, Error> {
+    pub fn from_str(arch: &str) -> Result<Arch> {
         match arch {
             "amd64" => Ok(Arch::AMD64),
             "arm64" => Ok(Arch::ARM64),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -47,7 +47,7 @@ pub use show_image_command::*;
 pub use verbosity::*;
 
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::view::Console;
@@ -59,5 +59,5 @@ trait Command {
         env: &Environment,
         image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error>;
+    ) -> Result<()>;
 }

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -2,7 +2,7 @@ use crate::commands::{
     self, Command, InstanceCloneCommand, InstanceModifyCommand, InstanceRenameCommand,
 };
 use crate::env::EnvironmentFactory;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageDao;
 use crate::instance::InstanceDao;
 use crate::view::Console;
@@ -51,7 +51,7 @@ pub struct CommandDispatcher {
 }
 
 impl CommandDispatcher {
-    pub fn dispatch(self, console: &mut dyn Console) -> Result<(), Error> {
+    pub fn dispatch(self, console: &mut dyn Console) -> Result<()> {
         console.set_verbosity(commands::Verbosity::new(
             self.global.verbose,
             self.global.quiet,

--- a/src/commands/completions_command.rs
+++ b/src/commands/completions_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::{Command, CommandDispatcher};
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::view::Console;
@@ -22,7 +22,7 @@ impl Command for CompletionsCommand {
         _env: &Environment,
         _image_store: &dyn ImageStore,
         _instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let Some(shell) = self.shell.or_else(Shell::from_env) else {
             return Err(Error::CouldNotDetectShell);
         };

--- a/src/commands/create_instance_command.rs
+++ b/src/commands/create_instance_command.rs
@@ -4,7 +4,7 @@ use crate::commands::{
     image::{fetch_image, fetch_image_info},
 };
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::fs::FS;
 use crate::image::{ImageName, ImageStore};
 use crate::instance::{Instance, InstanceName, InstanceStore, PortForward};
@@ -50,7 +50,7 @@ impl Command for CreateInstanceCommand {
         env: &Environment,
         image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         if instance_store.exists(self.instance_name.as_str()) {
             return Result::Err(Error::InstanceAlreadyExists(self.instance_name.to_string()));
         }

--- a/src/commands/delete_instance_command.rs
+++ b/src/commands/delete_instance_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::{self, Command};
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::util;
@@ -27,7 +27,7 @@ impl Command for DeleteInstanceCommand {
         env: &Environment,
         image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         if self.force {
             commands::InstanceStopCommand {
                 all: false,

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -1,5 +1,5 @@
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::fs::FS;
 use crate::image::{Image, ImageFactory, ImageFetcher, ImageName, ImageStore};
 use crate::view::SpinnerView;
@@ -11,7 +11,7 @@ pub fn fetch_image_list(env: &Environment) -> Vec<Image> {
     images
 }
 
-pub fn fetch_image_info(env: &Environment, image: &ImageName) -> Result<Image, Error> {
+pub fn fetch_image_info(env: &Environment, image: &ImageName) -> Result<Image> {
     let mut spinner = SpinnerView::new(format!(
         "Looking up image {}:{}",
         image.get_vendor(),
@@ -22,11 +22,7 @@ pub fn fetch_image_info(env: &Environment, image: &ImageName) -> Result<Image, E
     image
 }
 
-pub fn fetch_image(
-    env: &Environment,
-    image_store: &dyn ImageStore,
-    image: &Image,
-) -> Result<(), Error> {
+pub fn fetch_image(env: &Environment, image_store: &dyn ImageStore, image: &Image) -> Result<()> {
     if !image_store.exists(image) {
         FS::new().create_dir(&env.get_image_dir())?;
         ImageFetcher::new().fetch(

--- a/src/commands/instance_clone_command.rs
+++ b/src/commands/instance_clone_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::Command;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::{InstanceName, InstanceStore};
 use crate::ssh_cmd::PortChecker;
@@ -23,7 +23,7 @@ impl Command for InstanceCloneCommand {
         _env: &Environment,
         _image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         instance_store.clone(
             &instance_store.load(self.name.as_str())?,
             self.new_name.as_str(),

--- a/src/commands/instance_console_command.rs
+++ b/src/commands/instance_console_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::{self, Command};
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 #[cfg(not(windows))]
@@ -25,7 +25,7 @@ impl Command for InstanceConsoleCommand {
         env: &Environment,
         image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         commands::InstanceStartCommand {
             qemu_args: None,
             wait: false,

--- a/src/commands/instance_modify_command.rs
+++ b/src/commands/instance_modify_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::Command;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::{InstanceStore, PortForward};
 use crate::model::DataSize;
@@ -36,7 +36,7 @@ impl Command for InstanceModifyCommand {
         _env: &Environment,
         _image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let mut instance = instance_store.load(&self.instance)?;
 
         if let Some(cpus) = &self.cpus {

--- a/src/commands/instance_rename_command.rs
+++ b/src/commands/instance_rename_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::Command;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::{InstanceName, InstanceStore};
 use crate::view::Console;
@@ -22,7 +22,7 @@ impl Command for InstanceRenameCommand {
         _env: &Environment,
         _image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         instance_store.rename(
             &mut instance_store.load(self.old_name.as_str())?,
             self.new_name.as_str(),

--- a/src/commands/instance_restart_command.rs
+++ b/src/commands/instance_restart_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::{self, Command};
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::view::Console;
@@ -20,7 +20,7 @@ impl Command for InstanceRestartCommand {
         env: &Environment,
         image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         commands::InstanceStopCommand {
             all: false,
             wait: true,

--- a/src/commands/instance_run_command.rs
+++ b/src/commands/instance_run_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::{self, Command};
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::{InstanceStore, Target};
 use crate::view::Console;
@@ -20,7 +20,7 @@ impl Command for InstanceRunCommand {
         env: &Environment,
         image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         self.create_cmd
             .run(console, env, image_store, instance_store)?;
         commands::InstanceSshCommand {

--- a/src/commands/instance_scp_command.rs
+++ b/src/commands/instance_scp_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::Command;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::fs::FS;
 use crate::image::ImageStore;
 use crate::instance::{InstanceStore, TargetPath};
@@ -9,10 +9,7 @@ use crate::view::Console;
 use clap::Parser;
 use std::env;
 
-fn check_target_is_running(
-    instance_store: &dyn InstanceStore,
-    target: &TargetPath,
-) -> Result<(), Error> {
+fn check_target_is_running(instance_store: &dyn InstanceStore, target: &TargetPath) -> Result<()> {
     if let Some(target) = target.get_target() {
         let instance = instance_store.load(target.get_instance().as_str())?;
         if !instance_store.is_running(&instance) {
@@ -38,7 +35,7 @@ impl Command for InstanceScpCommand {
         env: &Environment,
         _image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         check_target_is_running(instance_store, &self.from)?;
         check_target_is_running(instance_store, &self.to)?;
 

--- a/src/commands/instance_show_command.rs
+++ b/src/commands/instance_show_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::Command;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::image::ImageStore;
 use crate::instance::{InstanceName, InstanceStore};
 use crate::view::{Console, MapView};
@@ -20,7 +20,7 @@ impl Command for InstanceShowCommand {
         _env: &Environment,
         _image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         if !instance_store.exists(self.instance.as_str()) {
             return Result::Err(Error::UnknownInstance(self.instance.to_string()));
         }

--- a/src/commands/instance_ssh_command.rs
+++ b/src/commands/instance_ssh_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::{self, Command};
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::fs::FS;
 use crate::image::ImageStore;
 use crate::instance::{InstanceStore, Target};
@@ -24,7 +24,7 @@ impl Command for InstanceSshCommand {
         env: &Environment,
         image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let name = self.target.get_instance();
 
         commands::InstanceStartCommand {

--- a/src/commands/instance_start_command.rs
+++ b/src/commands/instance_start_command.rs
@@ -1,7 +1,7 @@
 use crate::actions::StartInstanceAction;
 use crate::commands::Command;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::ssh_cmd::{PortChecker, Russh};
@@ -32,7 +32,7 @@ impl Command for InstanceStartCommand {
         env: &Environment,
         _image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let verbosity = console.get_verbosity();
         let async_caller = util::AsyncCaller::new();
         let russh = Russh::new();

--- a/src/commands/instance_stop_command.rs
+++ b/src/commands/instance_stop_command.rs
@@ -1,7 +1,7 @@
 use crate::actions::StopInstanceAction;
 use crate::commands::Command;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::view::Console;
@@ -30,7 +30,7 @@ impl Command for InstanceStopCommand {
         _env: &Environment,
         _image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let stop_instances = if self.all {
             instance_store.get_instances()
         } else {

--- a/src/commands/list_image_command.rs
+++ b/src/commands/list_image_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::{Command, fetch_image_list};
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::{ImageStore, get_default_arch};
 use crate::instance::InstanceStore;
 use crate::model::DataSize;
@@ -22,7 +22,7 @@ impl Command for ListImageCommand {
         env: &Environment,
         image_store: &dyn ImageStore,
         _instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let images = fetch_image_list(env);
 
         let mut view = TableView::new();

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::Command;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::view::{Alignment, Console, TableView};
@@ -17,7 +17,7 @@ impl Command for ListInstanceCommand {
         _env: &Environment,
         _image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let instance_names = instance_store.get_instances();
 
         let mut view = TableView::new();

--- a/src/commands/list_port_command.rs
+++ b/src/commands/list_port_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::Command;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::view::{Alignment, Console, TableView};
@@ -17,7 +17,7 @@ impl Command for ListPortCommand {
         _env: &Environment,
         _image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let instance_names = instance_store.get_instances();
 
         let mut view = TableView::new();

--- a/src/commands/prune_command.rs
+++ b/src/commands/prune_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::Command;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::view::Console;
@@ -17,7 +17,7 @@ impl Command for PruneCommand {
         _env: &Environment,
         image_store: &dyn ImageStore,
         _instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         image_store.prune()
     }
 }

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::{self, Command};
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::model::InstanceImageName;
@@ -21,7 +21,7 @@ impl Command for ShowCommand {
         env: &Environment,
         image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         match &self.name {
             InstanceImageName::Image(name) => commands::ShowImageCommand { name: name.clone() }
                 .run(console, env, image_store, instance_store),

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -1,6 +1,6 @@
 use crate::commands::{Command, image::fetch_image_info};
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::{ImageName, ImageStore};
 use crate::instance::InstanceStore;
 use crate::view::{Console, MapView};
@@ -20,7 +20,7 @@ impl Command for ShowImageCommand {
         env: &Environment,
         _image_store: &dyn ImageStore,
         _instance_store: &dyn InstanceStore,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let image = fetch_image_info(env, &self.name)?;
         let mut view = MapView::new();
         view.add("Name", &image.get_image_names());

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1,5 +1,5 @@
 use crate::arch::Arch;
-use crate::error::Error;
+use crate::error::Result;
 use crate::instance::PortForward;
 use crate::util::SystemCommand;
 
@@ -28,7 +28,7 @@ impl Emulator {
         }
     }
 
-    pub fn from(arch: Arch) -> Result<Emulator, Error> {
+    pub fn from(arch: Arch) -> Result<Emulator> {
         let mut command = match arch {
             Arch::AMD64 => {
                 let mut command = SystemCommand::new("qemu-system-x86_64");
@@ -151,7 +151,7 @@ impl Emulator {
         self.command.arg("-pidfile").arg(path);
     }
 
-    pub fn run(&mut self) -> Result<(), Error> {
+    pub fn run(&mut self) -> Result<()> {
         self.command.arg("-daemonize");
 
         if self.verbose {

--- a/src/env/environment_factory.rs
+++ b/src/env/environment_factory.rs
@@ -1,16 +1,16 @@
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::{Error, Result};
 use std::env;
 
 pub struct EnvironmentFactory;
 
 impl EnvironmentFactory {
-    fn read_env(var: &str) -> Result<String, Error> {
+    fn read_env(var: &str) -> Result<String> {
         env::var(var).map_err(|_| Error::UnsetEnvVar(var.to_string()))
     }
 
     #[cfg(target_os = "linux")]
-    pub fn create_env() -> Result<Environment, Error> {
+    pub fn create_env() -> Result<Environment> {
         let data_dir = Self::read_env("SNAP_USER_COMMON")
             .or(Self::read_env("XDG_DATA_HOME"))
             .or_else(|_| Self::read_env("HOME").map(|home| format!("{home}/.local/share")))?;
@@ -27,7 +27,7 @@ impl EnvironmentFactory {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn create_env() -> Result<Environment, Error> {
+    pub fn create_env() -> Result<Environment> {
         let home_dir = Self::read_env("HOME")?;
 
         Ok(Environment::new(
@@ -38,7 +38,7 @@ impl EnvironmentFactory {
     }
 
     #[cfg(target_os = "windows")]
-    pub fn create_env() -> Result<Environment, Error> {
+    pub fn create_env() -> Result<Environment> {
         let local_app_data_dir = Self::read_env("LOCALAPPDATA")?;
         let temp_dir = Self::read_env("TEMP")?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,74 +1,51 @@
-use crate::view::Console;
 use std::io;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     #[cfg(test)]
+    #[error("Argument error: {0}")]
     InvalidArgument(String),
+    #[error("Unknown architecture: '{0}'")]
     UnknownArch(String),
+    #[error("Unknown instance '{0}'")]
     UnknownInstance(String),
+    #[error("Instance '{0}' is not stopped")]
     InstanceNotStopped(String),
+    #[error("Instance '{0}' is not running")]
     InstanceNotRunning(String),
+    #[error("Instance with name '{0}' already exists")]
     InstanceAlreadyExists(String),
+    #[error("IO Error: {0}")]
     Io(io::Error),
+    #[error("FS Error: {0}")]
     FS(String),
+    #[error("Unknown image name {0}")]
     UnknownImage(String),
+    #[error("Environment variable '{0}' is not set")]
     UnsetEnvVar(String),
+    #[error("Cannot parse file '{0}'")]
     CannotParseFile(String),
+    #[error("Cannot shrink the disk of the instance '{0}'")]
     CannotShrinkDisk(String),
     #[cfg(not(windows))]
+    #[error("Failed to open terminal from path: '{0}'")]
     CannotOpenTerminal(String),
+    #[error("System command execution failed\n{0}\n\nReason: {1}")]
     SystemCommandFailed(String, String),
+    #[error("Web Error: {0}")]
     Web(reqwest::Error),
+    #[error("JSON Error: {0}")]
     #[cfg(not(windows))]
     SerdeJson(serde_json::Error),
+    #[error("TOML Error: {0}")]
     SerdeToml(toml::ser::Error),
+    #[error("Verification of image failed")]
     InvalidChecksum,
+    #[error("Could not detect shell")]
     CouldNotDetectShell,
+    #[error("SSH Error: {0}")]
     Ssh(ssh_key::Error),
+    #[error("Invalid path: {0}")]
     InvalidPath(String),
-}
-
-impl Error {
-    pub fn print(&self, console: &mut dyn Console) {
-        console.error(&format!(
-            "ERROR: {} \n\n\
-            Please report bugs at https://github.com/cubic-vm/cubic/issues",
-            match self {
-                #[cfg(test)]
-                Error::InvalidArgument(err) => format!("Argument error: {err}"),
-                Error::UnknownArch(name) => format!("Unknown architecture: '{name}'"),
-                Error::UnknownInstance(instance) => format!("Unknown instance '{instance}'"),
-                Error::InstanceNotStopped(name) => format!("Instance '{name}' is not stopped"),
-                Error::InstanceNotRunning(name) => format!("Instance '{name}' is not running"),
-                Error::InstanceAlreadyExists(id) =>
-                    format!("Instance with name '{id}' already exists"),
-                Error::Io(e) => format!("{}", e),
-                Error::FS(e) => e.to_string(),
-                Error::UnknownImage(name) => format!("Unknown image name {name}"),
-                Error::UnsetEnvVar(var) => format!("Environment variable '{var}' is not set"),
-                Error::CannotParseFile(path) => format!("Cannot parse file '{path}'"),
-                Error::CannotShrinkDisk(name) => {
-                    format!("Cannot shrink the disk of the instance '{name}'")
-                }
-                #[cfg(not(windows))]
-                Error::CannotOpenTerminal(path) =>
-                    format!("Failed to open terminal from path: '{path}'"),
-                Error::SystemCommandFailed(cmd, stderr) => {
-                    format!(
-                        "System command execution failed\n{cmd}\n\nReason: {}",
-                        stderr.trim()
-                    )
-                }
-                #[cfg(not(windows))]
-                Error::SerdeJson(err) => format!("[JSON] {err}"),
-                Error::SerdeToml(err) => format!("[TOML] {err}"),
-                Error::Web(e) => format!("{e}"),
-                Error::InvalidChecksum => "Verification of image failed".to_string(),
-                Error::CouldNotDetectShell => "Could not detect shell".to_string(),
-                Error::Ssh(ssh) => format!("SSH error: {ssh}"),
-                Error::InvalidPath(path) => format!("Invalid path: {path}"),
-            }
-        ))
-    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 use std::io;
 use thiserror::Error;
 
+pub type Result<T> = std::result::Result<T, Error>;
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     #[error("Instance with name '{0}' already exists")]
     InstanceAlreadyExists(String),
     #[error("IO Error: {0}")]
-    Io(io::Error),
+    Io(#[from] io::Error),
     #[error("FS Error: {0}")]
     FS(String),
     #[error("Unknown image name {0}")]
@@ -34,18 +34,18 @@ pub enum Error {
     #[error("System command execution failed\n{0}\n\nReason: {1}")]
     SystemCommandFailed(String, String),
     #[error("Web Error: {0}")]
-    Web(reqwest::Error),
+    Web(#[from] reqwest::Error),
     #[error("JSON Error: {0}")]
     #[cfg(not(windows))]
-    SerdeJson(serde_json::Error),
+    SerdeJson(#[from] serde_json::Error),
     #[error("TOML Error: {0}")]
-    SerdeToml(toml::ser::Error),
+    SerdeToml(#[from] toml::ser::Error),
     #[error("Verification of image failed")]
     InvalidChecksum,
     #[error("Could not detect shell")]
     CouldNotDetectShell,
     #[error("SSH Error: {0}")]
-    Ssh(ssh_key::Error),
+    Ssh(#[from] ssh_key::Error),
     #[error("Invalid path: {0}")]
     InvalidPath(String),
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use std::fs;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -11,7 +11,7 @@ impl FS {
         Self {}
     }
 
-    pub fn create_dir(&self, path: &str) -> Result<(), Error> {
+    pub fn create_dir(&self, path: &str) -> Result<()> {
         if !Path::new(path).exists() {
             return fs::create_dir_all(path)
                 .map_err(|e| Error::FS(format!("Cannot create directory '{path}' ({e})")));
@@ -20,7 +20,7 @@ impl FS {
         Result::Ok(())
     }
 
-    pub fn copy_dir(&self, from: &str, to: &str) -> Result<(), Error> {
+    pub fn copy_dir(&self, from: &str, to: &str) -> Result<()> {
         Command::new("cp")
             .arg("--recursive")
             .arg(from)
@@ -38,21 +38,21 @@ impl FS {
             })
     }
 
-    pub fn read_dir(&self, path: &str) -> Result<fs::ReadDir, Error> {
+    pub fn read_dir(&self, path: &str) -> Result<fs::ReadDir> {
         fs::read_dir(path).map_err(|e| Error::FS(format!("Cannot read directory '{path}' ({e})")))
     }
 
-    pub fn read_dir_file_paths(&self, path: &str) -> Result<Vec<PathBuf>, Error> {
+    pub fn read_dir_file_paths(&self, path: &str) -> Result<Vec<PathBuf>> {
         self.read_dir(path)
             .map(|dir| dir.flatten().map(|dir| dir.path()).collect())
     }
 
-    pub fn remove_dir(&self, path: &str) -> Result<(), Error> {
+    pub fn remove_dir(&self, path: &str) -> Result<()> {
         fs::remove_dir_all(path)
             .map_err(|e| Error::FS(format!("Cannot remove directory '{path}' ({e})")))
     }
 
-    pub fn setup_directory_access(&self, path: &str) -> Result<(), Error> {
+    pub fn setup_directory_access(&self, path: &str) -> Result<()> {
         self.create_dir(path)?;
 
         let permission = fs::metadata(path)
@@ -66,7 +66,7 @@ impl FS {
         Result::Ok(())
     }
 
-    pub fn create_file(&self, path: &str) -> Result<fs::File, Error> {
+    pub fn create_file(&self, path: &str) -> Result<fs::File> {
         std::fs::OpenOptions::new()
             .write(true)
             .create(true)
@@ -75,7 +75,7 @@ impl FS {
             .map_err(|e| Error::FS(format!("Cannot create file '{path}' ({e})")))
     }
 
-    pub fn open_file(&self, path: &str) -> Result<fs::File, Error> {
+    pub fn open_file(&self, path: &str) -> Result<fs::File> {
         fs::File::open(path).map_err(|e| Error::FS(format!("Cannot open file '{path}' ({e})")))
     }
 
@@ -83,22 +83,22 @@ impl FS {
         Path::new(path).exists()
     }
 
-    pub fn write_file(&self, path: &str, data: &[u8]) -> Result<(), Error> {
+    pub fn write_file(&self, path: &str, data: &[u8]) -> Result<()> {
         self.create_file(path)?
             .write_all(data)
             .map_err(|e| Error::FS(format!("Cannot write file '{path}' ({e})")))
     }
 
-    pub fn read_file_to_string(&self, path: &str) -> Result<String, Error> {
+    pub fn read_file_to_string(&self, path: &str) -> Result<String> {
         fs::read_to_string(path).map_err(|e| Error::FS(format!("Cannot read file '{path}' ({e})")))
     }
 
-    pub fn rename_file(&self, from: &str, to: &str) -> Result<(), Error> {
+    pub fn rename_file(&self, from: &str, to: &str) -> Result<()> {
         fs::rename(from, to)
             .map_err(|e| Error::FS(format!("Cannot rename file from '{from}' to '{to}' ({e})")))
     }
 
-    pub fn remove_file(&self, path: &str) -> Result<(), Error> {
+    pub fn remove_file(&self, path: &str) -> Result<()> {
         fs::remove_file(path).map_err(|e| Error::FS(format!("Cannot delete file '{path}' ({e})")))
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -28,7 +28,7 @@ impl FS {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .map_err(Error::Io)?
+            .map_err(Error::from)?
             .wait()
             .map(|_| ())
             .map_err(|e| {

--- a/src/image/image_cache.rs
+++ b/src/image/image_cache.rs
@@ -27,21 +27,21 @@ impl ImageCache {
 
     pub fn read_from_file(path: &str) -> Option<Self> {
         File::open(path)
-            .map_err(Error::Io)
+            .map_err(Error::from)
             .and_then(|ref mut reader| ImageCache::deserialize(reader))
             .ok()
     }
 
     pub fn write_to_file(&self, path: &str) {
         File::create(path)
-            .map_err(Error::Io)
+            .map_err(Error::from)
             .and_then(|mut file| self.serialize(&mut file))
             .ok();
     }
 
     fn deserialize(reader: &mut dyn Read) -> Result<ImageCache, Error> {
         let mut data = String::new();
-        reader.read_to_string(&mut data).map_err(Error::Io)?;
+        reader.read_to_string(&mut data).map_err(Error::from)?;
         toml::from_str(&data).map_err(|_| Error::CannotParseFile(String::new()))
     }
 
@@ -49,7 +49,7 @@ impl ImageCache {
         toml::to_string(self)
             .map(|content| writer.write_all(&content.into_bytes()))
             .map(|_| ())
-            .map_err(Error::SerdeToml)
+            .map_err(Error::from)
     }
 
     fn get_timestamp() -> u64 {

--- a/src/image/image_cache.rs
+++ b/src/image/image_cache.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::image::Image;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
@@ -39,13 +39,13 @@ impl ImageCache {
             .ok();
     }
 
-    fn deserialize(reader: &mut dyn Read) -> Result<ImageCache, Error> {
+    fn deserialize(reader: &mut dyn Read) -> Result<ImageCache> {
         let mut data = String::new();
         reader.read_to_string(&mut data).map_err(Error::from)?;
         toml::from_str(&data).map_err(|_| Error::CannotParseFile(String::new()))
     }
 
-    fn serialize(&self, writer: &mut dyn Write) -> Result<(), Error> {
+    fn serialize(&self, writer: &mut dyn Write) -> Result<()> {
         toml::to_string(self)
             .map(|content| writer.write_all(&content.into_bytes()))
             .map(|_| ())

--- a/src/image/image_dao.rs
+++ b/src/image/image_dao.rs
@@ -1,5 +1,5 @@
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::fs::FS;
 use crate::image::{Image, ImageStore};
 use std::path::Path;
@@ -10,7 +10,7 @@ pub struct ImageDao {
 }
 
 impl ImageDao {
-    pub fn new(env: &Environment) -> Result<Self, Error> {
+    pub fn new(env: &Environment) -> Result<Self> {
         let fs = FS::new();
         fs.setup_directory_access(&env.get_image_dir())?;
         Result::Ok(ImageDao {
@@ -30,7 +30,7 @@ impl ImageStore for ImageDao {
         .exists()
     }
 
-    fn prune(&self) -> Result<(), Error> {
+    fn prune(&self) -> Result<()> {
         self.fs.remove_file(&self.env.get_image_cache_file()).ok();
         self.fs.remove_dir(&self.env.get_image_dir())
     }

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -1,6 +1,6 @@
 use crate::arch::Arch;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::image::{HashAlg, Image, ImageCache, ImageName};
 use crate::web::WebClient;
 use regex::Regex;
@@ -281,7 +281,7 @@ impl ImageFactory {
         images
     }
 
-    pub fn create_images(&self) -> Result<Vec<Image>, Error> {
+    pub fn create_images(&self) -> Result<Vec<Image>> {
         // Read cache
         let cache = ImageCache::read_from_file(&self.env.get_image_cache_file());
 
@@ -312,7 +312,7 @@ impl ImageFactory {
         Ok(images)
     }
 
-    pub fn get_image(&self, name: &ImageName) -> Result<Image, Error> {
+    pub fn get_image(&self, name: &ImageName) -> Result<Image> {
         // Read cache
         let cache = ImageCache::read_from_file(&self.env.get_image_cache_file());
 

--- a/src/image/image_fetcher.rs
+++ b/src/image/image_fetcher.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::image::{HashAlg, Image};
 use crate::view::{SpinnerView, TransferView};
 use crate::web::WebClient;
@@ -15,7 +15,7 @@ impl ImageFetcher {
         &self,
         client: &mut WebClient,
         image: &Image,
-    ) -> Result<Option<(HashAlg, String)>, Error> {
+    ) -> Result<Option<(HashAlg, String)>> {
         if let Some(pos) = image.image_url.rfind("/") {
             let regex = Regex::new("^[0-9A-Fa-f]+$").unwrap();
             let file_name = &image.image_url[pos + 1..image.image_url.len()];
@@ -47,7 +47,7 @@ impl ImageFetcher {
         Ok(None)
     }
 
-    pub fn fetch(&self, image: &Image, target_file: &str) -> Result<(), Error> {
+    pub fn fetch(&self, image: &Image, target_file: &str) -> Result<()> {
         let mut client = WebClient::new()?;
 
         let checksum = client.download_file(

--- a/src/image/image_store.rs
+++ b/src/image/image_store.rs
@@ -1,7 +1,7 @@
-use crate::error::Error;
+use crate::error::Result;
 use crate::image::Image;
 
 pub trait ImageStore {
     fn exists(&self, image: &Image) -> bool;
-    fn prune(&self) -> Result<(), Error>;
+    fn prune(&self) -> Result<()>;
 }

--- a/src/image/image_store_mock.rs
+++ b/src/image/image_store_mock.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 pub mod tests {
 
-    use crate::error::Error;
+    use crate::error::Result;
     use crate::image::{Image, ImageStore};
 
     #[derive(Default)]
@@ -14,7 +14,7 @@ pub mod tests {
             self.images.contains(image)
         }
 
-        fn prune(&self) -> Result<(), Error> {
+        fn prune(&self) -> Result<()> {
             Ok(())
         }
     }

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -1,5 +1,5 @@
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::fs::FS;
 use crate::instance::{
     Instance, InstanceDeserializer, InstanceName, InstanceSerializer, InstanceStore,
@@ -30,7 +30,7 @@ pub struct InstanceDao {
 }
 
 impl InstanceDao {
-    pub fn new(env: &Environment) -> Result<Self, Error> {
+    pub fn new(env: &Environment) -> Result<Self> {
         let fs = FS::new();
         fs.setup_directory_access(&env.get_instance_dir())?;
         fs.setup_directory_access(env.get_cache_dir())?;
@@ -51,7 +51,7 @@ impl InstanceStore for InstanceDao {
             .map_err(|_| ())
             .and_then(|entries| {
                 entries
-                    .collect::<Result<Vec<DirEntry>, _>>()
+                    .collect::<std::result::Result<Vec<DirEntry>, _>>()
                     .map_err(|_| ())
             })
             .map(|entries| {
@@ -70,7 +70,7 @@ impl InstanceStore for InstanceDao {
         Path::new(&self.env.get_instance_dir2(name)).exists()
     }
 
-    fn load(&self, name: &str) -> Result<Instance, Error> {
+    fn load(&self, name: &str) -> Result<Instance> {
         if !self.exists(name) {
             return Result::Err(Error::UnknownInstance(name.to_string()));
         }
@@ -106,7 +106,7 @@ impl InstanceStore for InstanceDao {
             }))
     }
 
-    fn store(&self, instance: &Instance) -> Result<(), Error> {
+    fn store(&self, instance: &Instance) -> Result<()> {
         let file_name = self.env.get_instance_toml_config_file(&instance.name);
         let temp_file_name = format!("{file_name}.tmp");
 
@@ -122,7 +122,7 @@ impl InstanceStore for InstanceDao {
         Ok(())
     }
 
-    fn clone(&self, instance: &Instance, new_name: &str) -> Result<(), Error> {
+    fn clone(&self, instance: &Instance, new_name: &str) -> Result<()> {
         if self.exists(new_name) {
             Result::Err(Error::InstanceAlreadyExists(new_name.to_string()))
         } else if self.is_running(instance) {
@@ -135,7 +135,7 @@ impl InstanceStore for InstanceDao {
         }
     }
 
-    fn rename(&self, instance: &mut Instance, new_name: &str) -> Result<(), Error> {
+    fn rename(&self, instance: &mut Instance, new_name: &str) -> Result<()> {
         if self.exists(new_name) {
             Result::Err(Error::InstanceAlreadyExists(new_name.to_string()))
         } else if self.is_running(instance) {
@@ -150,7 +150,7 @@ impl InstanceStore for InstanceDao {
         }
     }
 
-    fn resize(&self, instance: &mut Instance, size: u64) -> Result<(), Error> {
+    fn resize(&self, instance: &mut Instance, size: u64) -> Result<()> {
         if self.is_running(instance) {
             Result::Err(Error::InstanceNotStopped(instance.name.to_string()))
         } else if instance.disk_capacity.get_bytes() >= size as usize {
@@ -166,7 +166,7 @@ impl InstanceStore for InstanceDao {
         }
     }
 
-    fn delete(&self, instance: &Instance) -> Result<(), Error> {
+    fn delete(&self, instance: &Instance) -> Result<()> {
         if self.is_running(instance) {
             Result::Err(Error::InstanceNotStopped(instance.name.to_string()))
         } else {
@@ -189,7 +189,7 @@ impl InstanceStore for InstanceDao {
             .path_exists(&self.env.get_qemu_pid_file(&instance.name))
     }
 
-    fn get_pid(&self, instance: &Instance) -> Result<u64, ()> {
+    fn get_pid(&self, instance: &Instance) -> std::result::Result<u64, ()> {
         let pid = self
             .fs
             .read_file_to_string(&self.env.get_qemu_pid_file(&instance.name))
@@ -199,7 +199,7 @@ impl InstanceStore for InstanceDao {
     }
 
     #[cfg(not(windows))]
-    fn get_monitor(&self, instance: &Instance) -> Result<Monitor, Error> {
+    fn get_monitor(&self, instance: &Instance) -> Result<Monitor> {
         Monitor::new(&self.env, &instance.name)
     }
 }

--- a/src/instance/instance_deserializer.rs
+++ b/src/instance/instance_deserializer.rs
@@ -1,7 +1,7 @@
-use crate::error::Error;
+use crate::error::Result;
 use crate::instance::Instance;
 use std::io::Read;
 
 pub trait InstanceDeserializer {
-    fn deserialize(&self, name: &str, reader: &mut dyn Read) -> Result<Instance, Error>;
+    fn deserialize(&self, name: &str, reader: &mut dyn Read) -> Result<Instance>;
 }

--- a/src/instance/instance_serializer.rs
+++ b/src/instance/instance_serializer.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::instance::Instance;
 use std::io::Write;
 
@@ -10,7 +10,7 @@ impl InstanceSerializer {
         Self
     }
 
-    pub fn serialize(&self, instance: &Instance, writer: &mut dyn Write) -> Result<(), Error> {
+    pub fn serialize(&self, instance: &Instance, writer: &mut dyn Write) -> Result<()> {
         toml::to_string(instance)
             .map(|content| writer.write_all(&content.into_bytes()))
             .map(|_| ())

--- a/src/instance/instance_serializer.rs
+++ b/src/instance/instance_serializer.rs
@@ -14,7 +14,7 @@ impl InstanceSerializer {
         toml::to_string(instance)
             .map(|content| writer.write_all(&content.into_bytes()))
             .map(|_| ())
-            .map_err(Error::SerdeToml)
+            .map_err(Error::from)
     }
 }
 

--- a/src/instance/instance_store.rs
+++ b/src/instance/instance_store.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::Result;
 use crate::instance::Instance;
 #[cfg(not(windows))]
 use crate::qemu::Monitor;
@@ -7,17 +7,17 @@ use std::str;
 pub trait InstanceStore {
     fn get_instances(&self) -> Vec<String>;
     fn exists(&self, name: &str) -> bool;
-    fn load(&self, name: &str) -> Result<Instance, Error>;
-    fn store(&self, instance: &Instance) -> Result<(), Error>;
+    fn load(&self, name: &str) -> Result<Instance>;
+    fn store(&self, instance: &Instance) -> Result<()>;
 
-    fn clone(&self, instance: &Instance, new_name: &str) -> Result<(), Error>;
-    fn rename(&self, instance: &mut Instance, new_name: &str) -> Result<(), Error>;
-    fn resize(&self, instance: &mut Instance, size: u64) -> Result<(), Error>;
-    fn delete(&self, instance: &Instance) -> Result<(), Error>;
+    fn clone(&self, instance: &Instance, new_name: &str) -> Result<()>;
+    fn rename(&self, instance: &mut Instance, new_name: &str) -> Result<()>;
+    fn resize(&self, instance: &mut Instance, size: u64) -> Result<()>;
+    fn delete(&self, instance: &Instance) -> Result<()>;
 
     fn is_running(&self, instance: &Instance) -> bool;
-    fn get_pid(&self, instance: &Instance) -> Result<u64, ()>;
+    fn get_pid(&self, instance: &Instance) -> std::result::Result<u64, ()>;
 
     #[cfg(not(windows))]
-    fn get_monitor(&self, instance: &Instance) -> Result<Monitor, Error>;
+    fn get_monitor(&self, instance: &Instance) -> Result<Monitor>;
 }

--- a/src/instance/instance_store_mock.rs
+++ b/src/instance/instance_store_mock.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 pub mod tests {
 
-    use crate::error::Error;
+    use crate::error::{Error, Result};
     use crate::instance::{Instance, InstanceStore};
     #[cfg(not(windows))]
     use crate::qemu::Monitor;
@@ -25,7 +25,7 @@ pub mod tests {
             self.instances.iter().any(|i| i.name == name)
         }
 
-        fn load(&self, name: &str) -> Result<Instance, Error> {
+        fn load(&self, name: &str) -> Result<Instance> {
             self.instances
                 .iter()
                 .find(|i| i.name == name)
@@ -33,23 +33,23 @@ pub mod tests {
                 .ok_or(Error::UnknownInstance(name.to_string()))
         }
 
-        fn store(&self, _instance: &Instance) -> Result<(), Error> {
+        fn store(&self, _instance: &Instance) -> Result<()> {
             Result::Ok(())
         }
 
-        fn clone(&self, _instance: &Instance, _new_name: &str) -> Result<(), Error> {
+        fn clone(&self, _instance: &Instance, _new_name: &str) -> Result<()> {
             Result::Ok(())
         }
 
-        fn rename(&self, _instance: &mut Instance, _new_name: &str) -> Result<(), Error> {
+        fn rename(&self, _instance: &mut Instance, _new_name: &str) -> Result<()> {
             Result::Ok(())
         }
 
-        fn resize(&self, _instance: &mut Instance, _size: u64) -> Result<(), Error> {
+        fn resize(&self, _instance: &mut Instance, _size: u64) -> Result<()> {
             Result::Ok(())
         }
 
-        fn delete(&self, _instance: &Instance) -> Result<(), Error> {
+        fn delete(&self, _instance: &Instance) -> Result<()> {
             Result::Ok(())
         }
 
@@ -57,12 +57,12 @@ pub mod tests {
             false
         }
 
-        fn get_pid(&self, _instance: &Instance) -> Result<u64, ()> {
-            Result::Err(())
+        fn get_pid(&self, _instance: &Instance) -> std::result::Result<u64, ()> {
+            std::result::Result::Err(())
         }
 
         #[cfg(not(windows))]
-        fn get_monitor(&self, _instance: &Instance) -> Result<Monitor, Error> {
+        fn get_monitor(&self, _instance: &Instance) -> Result<Monitor> {
             Result::Err(Error::InvalidArgument("not supported".to_string()))
         }
     }

--- a/src/instance/target_path.rs
+++ b/src/instance/target_path.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::Result;
 use crate::instance::{InstanceStore, Target, TargetInstancePath};
 use std::fmt;
 use std::str::FromStr;
@@ -17,7 +17,7 @@ impl TargetPath {
     pub fn to_target_instance_path(
         &self,
         instance_store: &dyn InstanceStore,
-    ) -> Result<TargetInstancePath, Error> {
+    ) -> Result<TargetInstancePath> {
         if let Some(target) = self.target.as_ref() {
             let instance = instance_store.load(target.get_instance().as_str())?;
             Ok(TargetInstancePath {
@@ -38,7 +38,7 @@ impl TargetPath {
 impl FromStr for TargetPath {
     type Err = String;
 
-    fn from_str(target_path: &str) -> Result<Self, Self::Err> {
+    fn from_str(target_path: &str) -> std::result::Result<Self, Self::Err> {
         match *target_path.split(':').collect::<Vec<_>>().as_slice() {
             [path] => Ok(Self {
                 target: None,
@@ -55,7 +55,7 @@ impl FromStr for TargetPath {
 }
 
 impl fmt::Display for TargetPath {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         let mut result = Ok(());
 
         if let Some(target) = self.target.as_ref() {

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::instance::{Instance, InstanceDeserializer};
 use std::io::Read;
 use std::str;
@@ -13,7 +13,7 @@ impl TomlInstanceDeserializer {
 }
 
 impl InstanceDeserializer for TomlInstanceDeserializer {
-    fn deserialize(&self, name: &str, reader: &mut dyn Read) -> Result<Instance, Error> {
+    fn deserialize(&self, name: &str, reader: &mut dyn Read) -> Result<Instance> {
         let mut data = String::new();
         reader.read_to_string(&mut data).map_err(Error::from)?;
         toml::from_str(&data)

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -15,7 +15,7 @@ impl TomlInstanceDeserializer {
 impl InstanceDeserializer for TomlInstanceDeserializer {
     fn deserialize(&self, name: &str, reader: &mut dyn Read) -> Result<Instance, Error> {
         let mut data = String::new();
-        reader.read_to_string(&mut data).map_err(Error::Io)?;
+        reader.read_to_string(&mut data).map_err(Error::from)?;
         toml::from_str(&data)
             .map(|mut instance: Instance| {
                 instance.name = name.to_string();

--- a/src/instance/yaml_instance_deserializer.rs
+++ b/src/instance/yaml_instance_deserializer.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::instance::{Config, Instance, InstanceDeserializer};
 use std::io::Read;
 use std::str;
@@ -13,7 +13,7 @@ impl YamlInstanceDeserializer {
 }
 
 impl InstanceDeserializer for YamlInstanceDeserializer {
-    fn deserialize(&self, name: &str, reader: &mut dyn Read) -> Result<Instance, Error> {
+    fn deserialize(&self, name: &str, reader: &mut dyn Read) -> Result<Instance> {
         serde_yaml::from_reader(reader)
             .map(|config: Config| config.machine)
             .map(|mut instance: Instance| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,12 +15,13 @@ mod view;
 mod web;
 
 use crate::commands::CommandDispatcher;
+use crate::view::Console;
 use clap::Parser;
 
 fn main() {
     let console = &mut view::Stdio::new();
     CommandDispatcher::parse()
         .dispatch(console)
-        .map_err(|e| e.print(console))
+        .map_err(|e| console.error(&e.to_string()))
         .ok();
 }

--- a/src/qemu/monitor.rs
+++ b/src/qemu/monitor.rs
@@ -1,6 +1,6 @@
 use crate::commands::Verbosity;
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::qemu::Qmp;
 
 pub struct Monitor {
@@ -8,7 +8,7 @@ pub struct Monitor {
 }
 
 impl Monitor {
-    pub fn new(env: &Environment, instance: &str) -> Result<Self, Error> {
+    pub fn new(env: &Environment, instance: &str) -> Result<Self> {
         let mut monitor = Monitor {
             qmp: Qmp::new(&env.get_monitor_file(instance), Verbosity::Normal)?,
         };
@@ -16,12 +16,12 @@ impl Monitor {
         Ok(monitor)
     }
 
-    pub fn init(&mut self) -> Result<(), Error> {
+    pub fn init(&mut self) -> Result<()> {
         self.qmp.recv().map(|_| ())?;
         self.qmp.execute("qmp_capabilities").map(|_| ())
     }
 
-    pub fn shutdown(&mut self) -> Result<(), Error> {
+    pub fn shutdown(&mut self) -> Result<()> {
         self.qmp.execute("system_powerdown")
     }
 }

--- a/src/qemu/qmp.rs
+++ b/src/qemu/qmp.rs
@@ -17,39 +17,43 @@ pub struct Qmp {
 
 impl Qmp {
     pub fn new(path: &str, verbosity: Verbosity) -> Result<Self, Error> {
-        let socket = UnixStream::connect(path).map_err(Error::Io)?;
+        let socket = UnixStream::connect(path).map_err(Error::from)?;
 
         let get_timeout = || Some(Duration::from_millis(QMP_TIMEOUT_MS));
-        socket.set_read_timeout(get_timeout()).map_err(Error::Io)?;
-        socket.set_write_timeout(get_timeout()).map_err(Error::Io)?;
+        socket
+            .set_read_timeout(get_timeout())
+            .map_err(Error::from)?;
+        socket
+            .set_write_timeout(get_timeout())
+            .map_err(Error::from)?;
 
         Ok(Qmp {
             counter: 0,
             verbosity,
-            reader: BufReader::new(Box::new(socket.try_clone().map_err(Error::Io)?)),
-            writer: BufWriter::new(Box::new(socket.try_clone().map_err(Error::Io)?)),
+            reader: BufReader::new(Box::new(socket.try_clone().map_err(Error::from)?)),
+            writer: BufWriter::new(Box::new(socket.try_clone().map_err(Error::from)?)),
         })
     }
 
     pub fn send(&mut self, message: &qemu::QmpMessage) -> Result<(), Error> {
-        let request = serde_json::to_string(message).map_err(Error::SerdeJson)?;
+        let request = serde_json::to_string(message).map_err(Error::from)?;
 
         if self.verbosity.is_verbose() {
             println!("QMP send: {request}");
         }
-        self.writer.write(request.as_bytes()).map_err(Error::Io)?;
-        self.writer.flush().map_err(Error::Io)
+        self.writer.write(request.as_bytes()).map_err(Error::from)?;
+        self.writer.flush().map_err(Error::from)
     }
 
     pub fn recv(&mut self) -> Result<qemu::QmpMessage, Error> {
         let mut response = String::new();
-        self.reader.read_line(&mut response).map_err(Error::Io)?;
+        self.reader.read_line(&mut response).map_err(Error::from)?;
 
         if self.verbosity.is_verbose() {
             println!("QMP recv: {response}");
         }
 
-        serde_json::from_str(&response).map_err(Error::SerdeJson)
+        serde_json::from_str(&response).map_err(Error::from)
     }
 
     pub fn execute_with_args(

--- a/src/qemu/qmp.rs
+++ b/src/qemu/qmp.rs
@@ -1,5 +1,5 @@
 use crate::commands::Verbosity;
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::qemu;
 use serde_json::Value;
 use std::io::{BufReader, BufWriter, Read, Write, prelude::*};
@@ -16,7 +16,7 @@ pub struct Qmp {
 }
 
 impl Qmp {
-    pub fn new(path: &str, verbosity: Verbosity) -> Result<Self, Error> {
+    pub fn new(path: &str, verbosity: Verbosity) -> Result<Self> {
         let socket = UnixStream::connect(path).map_err(Error::from)?;
 
         let get_timeout = || Some(Duration::from_millis(QMP_TIMEOUT_MS));
@@ -35,7 +35,7 @@ impl Qmp {
         })
     }
 
-    pub fn send(&mut self, message: &qemu::QmpMessage) -> Result<(), Error> {
+    pub fn send(&mut self, message: &qemu::QmpMessage) -> Result<()> {
         let request = serde_json::to_string(message).map_err(Error::from)?;
 
         if self.verbosity.is_verbose() {
@@ -45,7 +45,7 @@ impl Qmp {
         self.writer.flush().map_err(Error::from)
     }
 
-    pub fn recv(&mut self) -> Result<qemu::QmpMessage, Error> {
+    pub fn recv(&mut self) -> Result<qemu::QmpMessage> {
         let mut response = String::new();
         self.reader.read_line(&mut response).map_err(Error::from)?;
 
@@ -56,11 +56,7 @@ impl Qmp {
         serde_json::from_str(&response).map_err(Error::from)
     }
 
-    pub fn execute_with_args(
-        &mut self,
-        cmd: &str,
-        arguments: Value,
-    ) -> Result<qemu::QmpMessage, Error> {
+    pub fn execute_with_args(&mut self, cmd: &str, arguments: Value) -> Result<qemu::QmpMessage> {
         let request_id = Some(self.counter.to_string());
         self.counter += 1;
 
@@ -83,7 +79,7 @@ impl Qmp {
         }
     }
 
-    pub fn execute(&mut self, cmd: &str) -> Result<(), Error> {
+    pub fn execute(&mut self, cmd: &str) -> Result<()> {
         self.execute_with_args(cmd, Value::Null).map(|_| ())
     }
 }

--- a/src/ssh_cmd/sftp_path.rs
+++ b/src/ssh_cmd/sftp_path.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use russh_sftp::{self, client::SftpSession};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -27,7 +27,7 @@ impl SftpPath {
         }
     }
 
-    pub async fn is_file(&self) -> Result<bool, Error> {
+    pub async fn is_file(&self) -> Result<bool> {
         match &self.sftp {
             None => Ok(self.path.is_file()),
             Some(sftp) => sftp
@@ -38,7 +38,7 @@ impl SftpPath {
         }
     }
 
-    pub async fn is_dir(&self) -> Result<bool, Error> {
+    pub async fn is_dir(&self) -> Result<bool> {
         match &self.sftp {
             None => Ok(self.path.is_dir()),
             Some(sftp) => sftp
@@ -111,7 +111,7 @@ impl SftpPath {
         }
     }
 
-    pub async fn recursive_copy(&self, target: SftpPath) -> Result<(), Error> {
+    pub async fn recursive_copy(&self, target: SftpPath) -> Result<()> {
         if self.is_file().await? {
             let reader = self.open_file().await;
             if target.exists().await && target.is_dir().await? {
@@ -130,7 +130,7 @@ impl SftpPath {
         Ok(())
     }
 
-    pub async fn copy(&self, target: SftpPath) -> Result<(), Error> {
+    pub async fn copy(&self, target: SftpPath) -> Result<()> {
         if target.exists().await || self.is_file().await? {
             self.recursive_copy(target).await?;
         } else if self.is_dir().await? {

--- a/src/ssh_cmd/ssh_key_generator.rs
+++ b/src/ssh_cmd/ssh_key_generator.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use rand::rngs::OsRng;
 use ssh_key::{Algorithm, LineEnding, private::PrivateKey};
 use std::path::Path;
@@ -11,7 +11,7 @@ impl SshKeyGenerator {
         Self
     }
 
-    pub fn generate_key(&self, private_key_path: &Path) -> Result<(), Error> {
+    pub fn generate_key(&self, private_key_path: &Path) -> Result<()> {
         PrivateKey::random(&mut OsRng, Algorithm::Ed25519)
             .map_err(Error::from)?
             .write_openssh_file(private_key_path, LineEnding::LF)
@@ -19,7 +19,7 @@ impl SshKeyGenerator {
             .map_err(Error::from)
     }
 
-    pub fn generate_public_key(&self, private_key_path: &Path) -> Result<String, Error> {
+    pub fn generate_public_key(&self, private_key_path: &Path) -> Result<String> {
         PrivateKey::read_openssh_file(private_key_path)
             .map_err(Error::from)?
             .public_key()

--- a/src/ssh_cmd/ssh_key_generator.rs
+++ b/src/ssh_cmd/ssh_key_generator.rs
@@ -13,17 +13,17 @@ impl SshKeyGenerator {
 
     pub fn generate_key(&self, private_key_path: &Path) -> Result<(), Error> {
         PrivateKey::random(&mut OsRng, Algorithm::Ed25519)
-            .map_err(Error::Ssh)?
+            .map_err(Error::from)?
             .write_openssh_file(private_key_path, LineEnding::LF)
             .map(|_| ())
-            .map_err(Error::Ssh)
+            .map_err(Error::from)
     }
 
     pub fn generate_public_key(&self, private_key_path: &Path) -> Result<String, Error> {
         PrivateKey::read_openssh_file(private_key_path)
-            .map_err(Error::Ssh)?
+            .map_err(Error::from)?
             .public_key()
             .to_openssh()
-            .map_err(Error::Ssh)
+            .map_err(Error::from)
     }
 }

--- a/src/util/qemu.rs
+++ b/src/util/qemu.rs
@@ -1,12 +1,12 @@
 use crate::env::Environment;
-use crate::error::Error;
+use crate::error::Result;
 use crate::fs::FS;
 use crate::instance::Instance;
 use crate::ssh_cmd::SshKeyGenerator;
 use crate::util::SystemCommand;
 use std::path::Path;
 
-pub fn setup_cloud_init(env: &Environment, instance: &Instance) -> Result<(), Error> {
+pub fn setup_cloud_init(env: &Environment, instance: &Instance) -> Result<()> {
     let fs = FS::new();
     let name = &instance.name;
     let user = &instance.user;

--- a/src/util/system_command.rs
+++ b/src/util/system_command.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use std::ffi::OsStr;
 use std::process::{Command, Output, Stdio};
 use std::str::from_utf8;
@@ -49,7 +49,7 @@ impl SystemCommand {
         self
     }
 
-    pub fn run(&mut self) -> Result<(), Error> {
+    pub fn run(&mut self) -> Result<()> {
         self.cmd
             .stdin(Stdio::null())
             .stdout(if self.stdout {
@@ -72,7 +72,7 @@ impl SystemCommand {
             })
     }
 
-    pub fn output(&mut self) -> Result<Output, Error> {
+    pub fn output(&mut self) -> Result<Output> {
         self.cmd
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/src/util/terminal.rs
+++ b/src/util/terminal.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 
 use std::io::{self, prelude::*};
 use std::net::Shutdown;
@@ -58,7 +58,7 @@ fn spawn_stream_thread(
 }
 
 impl Terminal {
-    pub fn open(path: &str) -> Result<Self, Error> {
+    pub fn open(path: &str) -> Result<Self> {
         UnixStream::connect(path)
             .map(|stream| {
                 stream.set_nonblocking(true).ok();

--- a/src/view/progress_bar.rs
+++ b/src/view/progress_bar.rs
@@ -13,7 +13,7 @@ impl ProgressBar {
 }
 
 impl fmt::Display for ProgressBar {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         write!(f, "[")?;
         let size = self.size - 2;
         let index = (size as f64 * self.percent) as usize;

--- a/src/web/web_client.rs
+++ b/src/web/web_client.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::fs::FS;
 use crate::util;
 use crate::view::TransferView;
@@ -58,7 +58,7 @@ pub struct WebClient {
 }
 
 impl WebClient {
-    pub fn new() -> Result<Self, Error> {
+    pub fn new() -> Result<Self> {
         Ok(WebClient {
             client: reqwest::blocking::Client::builder()
                 .timeout(Duration::from_secs(REQUEST_TIMEOUT_SEC))
@@ -69,7 +69,7 @@ impl WebClient {
         })
     }
 
-    pub fn get_file_size(&mut self, url: &str) -> Result<Option<u64>, Error> {
+    pub fn get_file_size(&mut self, url: &str) -> Result<Option<u64>> {
         Ok(self
             .client
             .head(url)
@@ -86,7 +86,7 @@ impl WebClient {
         url: &str,
         file_path: &str,
         view: TransferView,
-    ) -> Result<Checksum, Error> {
+    ) -> Result<Checksum> {
         let fs = FS::new();
 
         let temp_file = format!("{file_path}.tmp");
@@ -112,7 +112,7 @@ impl WebClient {
         })
     }
 
-    pub fn download_content(&mut self, url: &str) -> Result<String, Error> {
+    pub fn download_content(&mut self, url: &str) -> Result<String> {
         self.client
             .get(url)
             .send()

--- a/src/web/web_client.rs
+++ b/src/web/web_client.rs
@@ -65,7 +65,7 @@ impl WebClient {
                 .gzip(true)
                 .brotli(true)
                 .build()
-                .map_err(Error::Web)?,
+                .map_err(Error::from)?,
         })
     }
 
@@ -74,7 +74,7 @@ impl WebClient {
             .client
             .head(url)
             .send()
-            .map_err(Error::Web)?
+            .map_err(Error::from)?
             .headers()
             .get("Content-Length")
             .and_then(|value| value.to_str().ok())
@@ -98,11 +98,11 @@ impl WebClient {
             return Result::Ok(Checksum::default());
         }
 
-        let mut resp = reqwest::blocking::get(url).map_err(Error::Web)?;
+        let mut resp = reqwest::blocking::get(url).map_err(Error::from)?;
 
         let mut writer =
             ProgressWriter::new(fs.create_file(&temp_file)?, resp.content_length(), view);
-        resp.copy_to(&mut writer).map_err(Error::Web)?;
+        resp.copy_to(&mut writer).map_err(Error::from)?;
 
         fs.rename_file(&temp_file, file_path)?;
 
@@ -116,8 +116,8 @@ impl WebClient {
         self.client
             .get(url)
             .send()
-            .map_err(Error::Web)?
+            .map_err(Error::from)?
             .text()
-            .map_err(Error::Web)
+            .map_err(Error::from)
     }
 }


### PR DESCRIPTION
This PR tightens up our error‑handling code, making it both shorter and easier to read.

- Custom `Result<T>` alias – `Result<T>` now expands to `std::result::Result<T, Error>`, cleaning up function signatures.
- `thiserror` `#[from]` integration with external errors (e.g., std::io::Error, serde_json::Error) automatically convert into the Error enum.
- Overall simplification by moving the error definitions to thiserror trims code and boosts readability.
