### PR TITLE
chore: automate version management in snapcraft.yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,9 @@ jobs:
       - name: Set File Permissions
         run: chmod +x cubic
 
+      - name: Set Version
+        run: sed "s/^\\(version:\\).*$$/\\1 '$(git describe --tags)'/g" -i snapcraft.yaml
+
       - name: Package Snap
         uses: snapcore/action-build@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,4 @@ doc: build-image
 
 release: build-image
 	sed "s/^\(version =\).*$$/\1 \"${version}\"/g" -i Cargo.toml
-	sed "s/^\\(version:\\).*$$/\\1 '${version}'/g" -i snapcraft.yaml
 	make build

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 ---
 name: cubic
-version: '0.19.0'
+version: git
 license: MIT OR Apache-2.0
 website: https://cubic-vm.org
 source-code: https://github.com/cubic-vm/cubic


### PR DESCRIPTION
Automate version injection before Snap packaging to eliminate manual updates in snapcraft.yaml. The version is now derived from Git, ensuring consistency across releases.