### PR TITLE
chore: fix snap and doc version in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,8 @@ jobs:
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Download Executable
         uses: actions/download-artifact@v4

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Generate Docs
         run: ./scripts/generate-docs.sh


### PR DESCRIPTION
The CI pipeline didn't fetch git tags during Snap packaging and documentation generation, causing the inferred version to be incorrect.