### PR TITLE
Add Creation Execute Flag Feature

### DIFF
--- a/src/commands/create_instance_command.rs
+++ b/src/commands/create_instance_command.rs
@@ -41,6 +41,9 @@ pub struct CreateInstanceCommand {
     /// Forward ports from guest to host (e.g. -p 8000:80 or -p 127.0.0.1:9000:90/tcp)
     #[clap(short, long)]
     port: Vec<PortForward>,
+    /// Execute a shell command on the first boot
+    #[clap(short, long)]
+    execute: Option<String>,
 }
 
 impl Command for CreateInstanceCommand {
@@ -70,6 +73,7 @@ impl Command for CreateInstanceCommand {
             disk_capacity: self.disk.clone(),
             ssh_port: PortChecker::new().get_new_port(),
             hostfwd: self.port.clone(),
+            execute: self.execute.clone(),
             ..Instance::default()
         };
         CreateInstanceAction::new().run(env, &FS::new(), instance_store, image, instance)?;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,6 +1,5 @@
 use crate::error::{Error, Result};
 use std::fs;
-use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -81,12 +80,6 @@ impl FS {
 
     pub fn path_exists(&self, path: &str) -> bool {
         Path::new(path).exists()
-    }
-
-    pub fn write_file(&self, path: &str, data: &[u8]) -> Result<()> {
-        self.create_file(path)?
-            .write_all(data)
-            .map_err(|e| Error::FS(format!("Cannot write file '{path}' ({e})")))
     }
 
     pub fn read_file_to_string(&self, path: &str) -> Result<String> {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -47,4 +47,5 @@ pub struct Instance {
     pub ssh_port: u16,
     #[serde(default)]
     pub hostfwd: Vec<PortForward>,
+    pub execute: Option<String>,
 }

--- a/src/instance/instance_serializer.rs
+++ b/src/instance/instance_serializer.rs
@@ -39,6 +39,7 @@ mod tests {
                     disk_capacity: DataSize::new(1000),
                     ssh_port: 10000,
                     hostfwd: Vec::new(),
+                    execute: Some("echo hello world".to_string()),
                     ..Instance::default()
                 },
                 &mut writer,
@@ -55,6 +56,7 @@ mem = 1000
 disk_capacity = 1000
 ssh_port = 10000
 hostfwd = []
+execute = "echo hello world"
 "#
         );
     }

--- a/src/util/qemu.rs
+++ b/src/util/qemu.rs
@@ -12,7 +12,26 @@ fn write_meta_data(out: &mut dyn Write, name: &str) -> Result<()> {
         .map_err(Error::from)
 }
 
-fn write_user_data(out: &mut dyn Write, user: &str, pubkey: &str) -> Result<()> {
+fn write_user_data(
+    out: &mut dyn Write,
+    user: &str,
+    pubkey: &str,
+    execute: Option<&str>,
+) -> Result<()> {
+    let execute = execute
+        .map(|execute| {
+            format!(
+                "\u{20}\u{20}- \"{}\"\n",
+                execute
+                    .replace('\\', "\\\\")
+                    .replace('"', "\\\"")
+                    .replace('\n', "\\n")
+                    .replace('\r', "\\r")
+                    .replace('\t', "\\t")
+            )
+        })
+        .unwrap_or_default();
+
     out.write_all(
         format!(
             "\
@@ -28,7 +47,7 @@ fn write_user_data(out: &mut dyn Write, user: &str, pubkey: &str) -> Result<()> 
             packages:\n\
             \u{20}\u{20}- openssh\n\
             \u{20}\u{20}- qemu-guest-agent\n\
-            bootcmd:\n\
+            bootcmd:\n{execute}\
             \u{20}\u{20}- systemctl enable --now qemu-guest-agent\n\
             runcmd:\n\
             \u{20}\u{20}- \
@@ -65,7 +84,12 @@ pub fn setup_cloud_init(env: &Environment, instance: &Instance) -> Result<()> {
                 .and_then(|key| key.ok())
                 .unwrap_or_default();
 
-            write_user_data(&mut fs.create_file(&user_data_path)?, user, &pubkey)?;
+            write_user_data(
+                &mut fs.create_file(&user_data_path)?,
+                user,
+                &pubkey,
+                instance.execute.as_deref(),
+            )?;
         }
 
         SystemCommand::new("mkisofs")
@@ -101,9 +125,9 @@ mod tests {
     }
 
     #[test]
-    fn test_write_user_data() {
+    fn test_write_user_data_without_execute() {
         let mut buffer = BufWriter::new(Vec::new());
-        write_user_data(&mut buffer, "tux", "pubkey").unwrap();
+        write_user_data(&mut buffer, "tux", "pubkey", None).unwrap();
         let actual = String::from_utf8(buffer.into_inner().unwrap()).unwrap();
 
         let expected = r#"#cloud-config
@@ -119,6 +143,42 @@ packages:
   - openssh
   - qemu-guest-agent
 bootcmd:
+  - systemctl enable --now qemu-guest-agent
+runcmd:
+  - systemctl enable --now qemu-guest-agent
+"#;
+        assert_eq!(
+            actual, expected,
+            "\nActual: {actual}\nExpected: {expected}\n"
+        )
+    }
+
+    #[test]
+    fn test_write_user_data_with_execute() {
+        let mut buffer = BufWriter::new(Vec::new());
+        write_user_data(
+            &mut buffer,
+            "tux",
+            "pubkey",
+            Some("\"sudo apt install vim\"").as_deref(),
+        )
+        .unwrap();
+        let actual = String::from_utf8(buffer.into_inner().unwrap()).unwrap();
+
+        let expected = r#"#cloud-config
+users:
+  - name: tux
+    lock_passwd: false
+    hashed_passwd: $y$j9T$wifmOLBedd7NSaH2IqG4L.$2J.8E.qE57lxapsWosOFod37djHePHg7Go03iDNsRe4
+    ssh-authorized-keys: [pubkey]
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+package_update: true
+packages:
+  - openssh
+  - qemu-guest-agent
+bootcmd:
+  - "\"sudo apt install vim\""
   - systemctl enable --now qemu-guest-agent
 runcmd:
   - systemctl enable --now qemu-guest-agent

--- a/src/util/qemu.rs
+++ b/src/util/qemu.rs
@@ -21,7 +21,7 @@ fn write_user_data(
     let execute = execute
         .map(|execute| {
             format!(
-                "\u{20}\u{20}- \"{}\"\n",
+                "bootcmd:\n\u{20}\u{20}- \"{}\"\n",
                 execute
                     .replace('\\', "\\\\")
                     .replace('"', "\\\"")
@@ -43,16 +43,7 @@ fn write_user_data(
             \u{20}\u{20}\u{20}\u{20}ssh-authorized-keys: [{pubkey}]\n\
             \u{20}\u{20}\u{20}\u{20}shell: /bin/bash\n\
             \u{20}\u{20}\u{20}\u{20}sudo: ALL=(ALL) NOPASSWD:ALL\n\
-            package_update: true\n\
-            packages:\n\
-            \u{20}\u{20}- openssh\n\
-            \u{20}\u{20}- qemu-guest-agent\n\
-            bootcmd:\n{execute}\
-            \u{20}\u{20}- systemctl enable --now qemu-guest-agent\n\
-            runcmd:\n\
-            \u{20}\u{20}- \
-                systemctl enable --now qemu-guest-agent\n\
-        "
+            {execute}"
         )
         .as_bytes(),
     ).map_err(Error::from)
@@ -138,14 +129,6 @@ users:
     ssh-authorized-keys: [pubkey]
     shell: /bin/bash
     sudo: ALL=(ALL) NOPASSWD:ALL
-package_update: true
-packages:
-  - openssh
-  - qemu-guest-agent
-bootcmd:
-  - systemctl enable --now qemu-guest-agent
-runcmd:
-  - systemctl enable --now qemu-guest-agent
 "#;
         assert_eq!(
             actual, expected,
@@ -173,15 +156,8 @@ users:
     ssh-authorized-keys: [pubkey]
     shell: /bin/bash
     sudo: ALL=(ALL) NOPASSWD:ALL
-package_update: true
-packages:
-  - openssh
-  - qemu-guest-agent
 bootcmd:
   - "\"sudo apt install vim\""
-  - systemctl enable --now qemu-guest-agent
-runcmd:
-  - systemctl enable --now qemu-guest-agent
 "#;
         assert_eq!(
             actual, expected,

--- a/src/util/qemu.rs
+++ b/src/util/qemu.rs
@@ -1,10 +1,43 @@
 use crate::env::Environment;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::fs::FS;
 use crate::instance::Instance;
 use crate::ssh_cmd::SshKeyGenerator;
 use crate::util::SystemCommand;
+use std::io::Write;
 use std::path::Path;
+
+fn write_meta_data(out: &mut dyn Write, name: &str) -> Result<()> {
+    out.write_all(format!("instance-id: {name}\nlocal-hostname: {name}\n").as_bytes())
+        .map_err(Error::from)
+}
+
+fn write_user_data(out: &mut dyn Write, user: &str, pubkey: &str) -> Result<()> {
+    out.write_all(
+        format!(
+            "\
+            #cloud-config\n\
+            users:\n\
+            \u{20}\u{20}- name: {user}\n\
+            \u{20}\u{20}\u{20}\u{20}lock_passwd: false\n\
+            \u{20}\u{20}\u{20}\u{20}hashed_passwd: $y$j9T$wifmOLBedd7NSaH2IqG4L.$2J.8E.qE57lxapsWosOFod37djHePHg7Go03iDNsRe4\n\
+            \u{20}\u{20}\u{20}\u{20}ssh-authorized-keys: [{pubkey}]\n\
+            \u{20}\u{20}\u{20}\u{20}shell: /bin/bash\n\
+            \u{20}\u{20}\u{20}\u{20}sudo: ALL=(ALL) NOPASSWD:ALL\n\
+            package_update: true\n\
+            packages:\n\
+            \u{20}\u{20}- openssh\n\
+            \u{20}\u{20}- qemu-guest-agent\n\
+            bootcmd:\n\
+            \u{20}\u{20}- systemctl enable --now qemu-guest-agent\n\
+            runcmd:\n\
+            \u{20}\u{20}- \
+                systemctl enable --now qemu-guest-agent\n\
+        "
+        )
+        .as_bytes(),
+    ).map_err(Error::from)
+}
 
 pub fn setup_cloud_init(env: &Environment, instance: &Instance) -> Result<()> {
     let fs = FS::new();
@@ -20,10 +53,7 @@ pub fn setup_cloud_init(env: &Environment, instance: &Instance) -> Result<()> {
         fs.create_dir(&env.get_instance_cache_dir(&instance.name))?;
 
         if !Path::new(&meta_data_path).exists() {
-            fs.write_file(
-                &meta_data_path,
-                format!("instance-id: {name}\nlocal-hostname: {name}\n").as_bytes(),
-            )?;
+            write_meta_data(&mut fs.create_file(&meta_data_path)?, name)?;
         }
 
         if !Path::new(&user_data_path).exists() {
@@ -35,29 +65,7 @@ pub fn setup_cloud_init(env: &Environment, instance: &Instance) -> Result<()> {
                 .and_then(|key| key.ok())
                 .unwrap_or_default();
 
-            fs.write_file(
-                &user_data_path,
-                format!(
-                    "\
-                    #cloud-config\n\
-                    users:\n\
-                    \u{20}\u{20}- name: {user}\n\
-                    \u{20}\u{20}\u{20}\u{20}lock_passwd: false\n\
-                    \u{20}\u{20}\u{20}\u{20}hashed_passwd: $y$j9T$wifmOLBedd7NSaH2IqG4L.$2J.8E.qE57lxapsWosOFod37djHePHg7Go03iDNsRe4\n\
-                    \u{20}\u{20}\u{20}\u{20}ssh-authorized-keys: [{pubkey}]\n\
-                    \u{20}\u{20}\u{20}\u{20}shell: /bin/bash\n\
-                    \u{20}\u{20}\u{20}\u{20}sudo: ALL=(ALL) NOPASSWD:ALL\n\
-                    package_update: true\n\
-                    packages:\n\
-                    \u{20}\u{20}- openssh\n\
-                    \u{20}\u{20}- qemu-guest-agent\n\
-                    runcmd:\n\
-                    \u{20}\u{20}- \
-                        systemctl enable --now qemu-guest-agent\n\
-                "
-                )
-                .as_bytes(),
-            )?;
+            write_user_data(&mut fs.create_file(&user_data_path)?, user, &pubkey)?;
         }
 
         SystemCommand::new("mkisofs")
@@ -73,4 +81,51 @@ pub fn setup_cloud_init(env: &Environment, instance: &Instance) -> Result<()> {
     }
 
     Result::Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    pub use super::*;
+    use std::io::BufWriter;
+
+    #[test]
+    fn test_meta_user_data() {
+        let mut buffer = BufWriter::new(Vec::new());
+        write_meta_data(&mut buffer, "myinstance").unwrap();
+        let actual = String::from_utf8(buffer.into_inner().unwrap()).unwrap();
+
+        assert_eq!(
+            actual,
+            "instance-id: myinstance\nlocal-hostname: myinstance\n"
+        );
+    }
+
+    #[test]
+    fn test_write_user_data() {
+        let mut buffer = BufWriter::new(Vec::new());
+        write_user_data(&mut buffer, "tux", "pubkey").unwrap();
+        let actual = String::from_utf8(buffer.into_inner().unwrap()).unwrap();
+
+        let expected = r#"#cloud-config
+users:
+  - name: tux
+    lock_passwd: false
+    hashed_passwd: $y$j9T$wifmOLBedd7NSaH2IqG4L.$2J.8E.qE57lxapsWosOFod37djHePHg7Go03iDNsRe4
+    ssh-authorized-keys: [pubkey]
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+package_update: true
+packages:
+  - openssh
+  - qemu-guest-agent
+bootcmd:
+  - systemctl enable --now qemu-guest-agent
+runcmd:
+  - systemctl enable --now qemu-guest-agent
+"#;
+        assert_eq!(
+            actual, expected,
+            "\nActual: {actual}\nExpected: {expected}\n"
+        )
+    }
 }


### PR DESCRIPTION
# VM Instance Creation Enhancements

## Overview
This PR introduces improvements to the VM instance creation workflow, including a new command execution feature, cleanup of unnecessary dependencies, and expanded test coverage for cloud-init configuration.

## Key Changes

### 1. New Feature: Execute Command on First Boot
Added `-e` / `--execute` flag to the instance creation command, allowing users to run arbitrary shell commands during the first boot of a VM instance. This provides greater flexibility for initial setup and configuration automation.

### 2. Dependency Cleanup
Removed manual installation of two packages from the cloud-init configuration:
- **openssh-server**: Already included in the base VM image.
- **qemu-guest-agent**: Not used in the current configuration.

### 3. Test Coverage Expansion
Added unit tests for cloud-init configuration generation:
- Metadata file generation tests.
- User data file generation tests.

## Benefits

| Impact | Description |
| :--- | :--- |
| **Reduced Build Time** | Eliminates redundant package installations. |
| **Smaller Image Size** | Removes unnecessary dependencies. |
| **Better Automation** | First-boot command execution enables streamlined provisioning. |
| **Improved Reliability** | Additional test coverage catches configuration issues earlier. |

## Testing
Unit tests have been added for cloud-init meta and user data generation.