### PR TITLE
Add --isolate Flag for Network Isolation

### DIFF
--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -37,7 +37,11 @@ impl StartInstanceAction {
         emulator.set_console(&env.get_console_file(&self.instance.name));
         emulator.add_drive(&env.get_instance_image_file(&self.instance.name), "qcow2");
         emulator.add_drive(&env.get_user_data_image_file(&self.instance.name), "raw");
-        emulator.set_network(&self.instance.hostfwd, self.instance.ssh_port);
+        emulator.set_network(
+            &self.instance.hostfwd,
+            self.instance.ssh_port,
+            self.instance.isolate,
+        );
         if let Some(args) = qemu_args {
             emulator.set_qemu_args(args);
         }

--- a/src/commands/create_instance_command.rs
+++ b/src/commands/create_instance_command.rs
@@ -12,7 +12,7 @@ use crate::model::DataSize;
 use crate::ssh_cmd::PortChecker;
 use crate::view::Console;
 use crate::view::SpinnerView;
-use clap::Parser;
+use clap::{ArgAction, Parser};
 
 pub const DEFAULT_CPU_COUNT: u16 = 4;
 pub const DEFAULT_MEM_SIZE: &str = "4G";
@@ -44,6 +44,9 @@ pub struct CreateInstanceCommand {
     /// Execute a shell command on the first boot
     #[clap(short, long)]
     execute: Option<String>,
+    /// Isolate VM instance from network
+    #[clap(long, action = ArgAction::SetTrue)]
+    isolate: bool,
 }
 
 impl Command for CreateInstanceCommand {
@@ -74,6 +77,7 @@ impl Command for CreateInstanceCommand {
             ssh_port: PortChecker::new().get_new_port(),
             hostfwd: self.port.clone(),
             execute: self.execute.clone(),
+            isolate: self.isolate,
             ..Instance::default()
         };
         CreateInstanceAction::new().run(env, &FS::new(), instance_store, image, instance)?;

--- a/src/commands/instance_modify_command.rs
+++ b/src/commands/instance_modify_command.rs
@@ -32,12 +32,16 @@ pub struct InstanceModifyCommand {
 impl Command for InstanceModifyCommand {
     fn run(
         &self,
-        _console: &mut dyn Console,
+        console: &mut dyn Console,
         _env: &Environment,
         _image_store: &dyn ImageStore,
         instance_store: &dyn InstanceStore,
     ) -> Result<()> {
         let mut instance = instance_store.load(&self.instance)?;
+
+        if instance_store.is_running(&instance) {
+            console.info("Note: changes will be applied after the next restart.");
+        }
 
         if let Some(cpus) = &self.cpus {
             instance.cpus = *cpus;

--- a/src/commands/instance_modify_command.rs
+++ b/src/commands/instance_modify_command.rs
@@ -5,7 +5,7 @@ use crate::image::ImageStore;
 use crate::instance::{InstanceStore, PortForward};
 use crate::model::DataSize;
 use crate::view::Console;
-use clap::Parser;
+use clap::{ArgAction, Parser};
 
 /// Modify a virtual machine instance configuration
 #[derive(Parser)]
@@ -27,6 +27,12 @@ pub struct InstanceModifyCommand {
     /// Remove port forwarding rule (e.g. -P 8000:80)
     #[clap(short = 'P', long)]
     rm_port: Vec<PortForward>,
+    /// Isolate VM instance from network
+    #[clap(long, action = ArgAction::SetTrue)]
+    isolate: Option<bool>,
+    /// Do not isolate VM instance from network (default)
+    #[clap(long, action = ArgAction::SetTrue)]
+    no_isolate: Option<bool>,
 }
 
 impl Command for InstanceModifyCommand {
@@ -53,6 +59,14 @@ impl Command for InstanceModifyCommand {
 
         if let Some(disk) = &self.disk {
             instance_store.resize(&mut instance, disk.get_bytes() as u64)?;
+        }
+
+        if let Some(isolate) = self.isolate {
+            instance.isolate = isolate;
+        }
+
+        if let Some(no_isolate) = self.no_isolate {
+            instance.isolate = !no_isolate;
         }
 
         instance.hostfwd.append(&mut self.port.clone());

--- a/src/commands/instance_show_command.rs
+++ b/src/commands/instance_show_command.rs
@@ -40,6 +40,7 @@ impl Command for InstanceShowCommand {
         );
         view.add("Disk Total", &instance.disk_capacity.to_size());
         view.add("User", &instance.user);
+        view.add("Isolated", if instance.isolate { "yes" } else { "no" });
         view.add("SSH Port", &instance.ssh_port.to_string());
         view.add(
             "SSH",
@@ -100,6 +101,7 @@ Memory:     1.0 KiB
 Disk Used:  n/a
 Disk Total: 1.0 MiB
 User:       cubic
+Isolated:   no
 SSH Port:   9000
 SSH:        ssh -p 9000 cubic@localhost
 "
@@ -120,6 +122,7 @@ SSH:        ssh -p 9000 cubic@localhost
             disk_capacity: DataSize::new(1),
             ssh_port: 8000,
             hostfwd: Vec::new(),
+            isolate: true,
             ..Instance::default()
         }]);
 
@@ -138,6 +141,7 @@ Memory:     1   B
 Disk Used:  n/a
 Disk Total: 1   B
 User:       john
+Isolated:   yes
 SSH Port:   8000
 SSH:        ssh -p 8000 john@localhost
 "

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -115,19 +115,20 @@ impl Emulator {
             .arg("chardev:console");
     }
 
-    pub fn set_network(&mut self, hostfwd: &[PortForward], ssh_port: u16) {
+    pub fn set_network(&mut self, hostfwd: &[PortForward], ssh_port: u16, isolate: bool) {
         let mut hostfwd_options = String::new();
         for fwd in hostfwd {
             hostfwd_options.push_str(",hostfwd=");
             hostfwd_options.push_str(&fwd.to_qemu());
         }
 
+        let restrict = if isolate { "on" } else { "off" };
         self.command
             .arg("-device")
             .arg("virtio-net-pci,netdev=net0")
             .arg("-netdev")
             .arg(format!(
-                "user,id=net0,hostfwd=tcp:127.0.0.1:{ssh_port}-:22{hostfwd_options}"
+                "user,id=net0,restrict={restrict},hostfwd=tcp:127.0.0.1:{ssh_port}-:22{hostfwd_options}"
             ));
     }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -47,5 +47,8 @@ pub struct Instance {
     pub ssh_port: u16,
     #[serde(default)]
     pub hostfwd: Vec<PortForward>,
+    #[serde(default)]
     pub execute: Option<String>,
+    #[serde(default)]
+    pub isolate: bool,
 }

--- a/src/instance/instance_serializer.rs
+++ b/src/instance/instance_serializer.rs
@@ -39,7 +39,45 @@ mod tests {
                     disk_capacity: DataSize::new(1000),
                     ssh_port: 10000,
                     hostfwd: Vec::new(),
+                    execute: None,
+                    ..Instance::default()
+                },
+                &mut writer,
+            )
+            .expect("Cannot parser config");
+        let config = String::from_utf8(writer).unwrap();
+
+        assert_eq!(
+            config,
+            r#"arch = "AMD64"
+user = "tux"
+cpus = 1
+mem = 1000
+disk_capacity = 1000
+ssh_port = 10000
+hostfwd = []
+isolate = false
+"#
+        );
+    }
+
+    #[test]
+    fn test_serialize_full_config() {
+        let mut writer = Vec::new();
+
+        InstanceSerializer::new()
+            .serialize(
+                &Instance {
+                    name: "test".to_string(),
+                    arch: Arch::AMD64,
+                    user: "tux".to_string(),
+                    cpus: 1,
+                    mem: DataSize::new(1000),
+                    disk_capacity: DataSize::new(1000),
+                    ssh_port: 10000,
+                    hostfwd: Vec::new(),
                     execute: Some("echo hello world".to_string()),
+                    isolate: true,
                     ..Instance::default()
                 },
                 &mut writer,
@@ -57,6 +95,7 @@ disk_capacity = 1000
 ssh_port = 10000
 hostfwd = []
 execute = "echo hello world"
+isolate = true
 "#
         );
     }

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -60,6 +60,8 @@ ssh_port = 14357
         assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
         assert_eq!(instance.ssh_port, 14357);
         assert!(instance.hostfwd.is_empty());
+        assert_eq!(instance.execute, None);
+        assert_eq!(instance.isolate, false);
     }
 
     #[test]
@@ -72,6 +74,8 @@ mem = 1073741824
 disk_capacity = 2361393152
 ssh_port = 14357
 hostfwd = ["tcp:127.0.0.1:8000-:8000", "tcp:127.0.0.1:9000-:10000"]
+execute = "sudo apt update"
+isolate = true
 "#
             .as_bytes(),
         );
@@ -93,6 +97,8 @@ hostfwd = ["tcp:127.0.0.1:8000-:8000", "tcp:127.0.0.1:9000-:10000"]
                 .collect::<Vec<_>>(),
             ["tcp:127.0.0.1:8000-:8000", "tcp:127.0.0.1:9000-:10000"]
         );
+        assert_eq!(instance.execute, Some("sudo apt update".to_string()));
+        assert_eq!(instance.isolate, true);
     }
 
     #[test]
@@ -118,5 +124,7 @@ ssh_port = 14357
         assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
         assert_eq!(instance.ssh_port, 14357);
         assert!(instance.hostfwd.is_empty());
+        assert_eq!(instance.execute, None);
+        assert_eq!(instance.isolate, false);
     }
 }


### PR DESCRIPTION
Introduce a new --isolate flag that isolates VM instances from all network
access, including host, LAN, and internet connections.

Usage:
  - Create isolated instance:
    cubic create <instance-name> --image <image-name> --isolate

  - Enable isolation on existing instance:
    cubic modify <instance-name> --isolate

  - Disable isolation on existing instance:
    cubic modify <instance-name> --no-isolate

This feature is useful for running untrusted workloads or security-sensitive
tasks in a completely network-isolated environment.