### PR TITLE
Fix: Set the correct Version for Snap and Documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,8 +106,6 @@ jobs:
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Download Executable
         uses: actions/download-artifact@v4
@@ -118,8 +116,14 @@ jobs:
       - name: Set File Permissions
         run: chmod +x cubic
 
-      - name: Set Version
-        run: sed "s/^\\(version:\\).*$$/\\1 '$(git describe --tags)'/g" -i snapcraft.yaml
+      - name: Define Snap Version
+        run: echo "SNAP_VERSION=${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'dev' }}" >> $GITHUB_ENV
+
+      - name: Override Snap Version
+        run: 'sed "s/^version: .*$/version: $SNAP_VERSION/g" -i snapcraft.yaml'
+
+      - name: Show Snap Version
+        run: 'grep "version: " snapcraft.yaml'
 
       - name: Package Snap
         uses: snapcore/action-build@v1

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,11 +27,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Generate Docs
-        run: ./scripts/generate-docs.sh
+        run: ./scripts/generate-docs.sh ${{ github.ref_name }}
 
       - name: Generate HTML
         run: sphinx-build docs target/doc

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ build: build-image
 	${DOCKER_CMD} ${IMAGE} cargo build
 
 doc: build-image
-	@${DOCKER_CMD} -it ${IMAGE} ./scripts/generate-docs.sh
+	@${DOCKER_CMD} -it ${IMAGE} ./scripts/generate-docs.sh dev
 	@${DOCKER_CMD} -it ${IMAGE} sphinx-build docs target/doc
 	@${DOCKER_CMD} -it ${IMAGE} python3 -m http.server -d target/doc 4000
 

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+version="$1"
+
 CMDS="run create instances images ports show modify console ssh scp exec start \
     stop restart rename clone delete prune completions"
 
@@ -14,7 +16,7 @@ function generate_cmd_doc() {
 }
 
 # Set version
-sed "s/^release = .*$/release = '$(git describe --tags)'/g" -i docs/conf.py
+sed "s/^release = .*$/release = '$version'/g" -i docs/conf.py
 
 # Create Reference Doc Directory
 mkdir -p docs/reference


### PR DESCRIPTION
### Changes:

- Configure documentation version to display "dev" on main branch and the
corresponding tag version (e.g., v0.19.0) on release branches.

- Configure Snap package version to display the git version on main branch and the
corresponding tag version (e.g., v0.19.0) on release branches.