### PR TITLE
docs: fix cubic command typo (cmd -> exec)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ Open a shell in the virtual machine instance:
 $ cubic ssh <instance>
 
 Execute a command in a virtual machine instance:
-$ cubic cmd <instance> "<shell cmd>"
+$ cubic exec <instance> "<shell cmd>"
 
 Copy files and directories between host and virtual machine instance:
 $ cubic scp <path/to/host/file> <instance>:<path/to/guest/file>

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Open a shell in the virtual machine instance:
 $ cubic ssh <instance>
 
 Execute a command in a virtual machine instance:
-$ cubic cmd <instance> "<shell cmd>"
+$ cubic exec <instance> "<shell cmd>"
 
 Copy files and directories between host and virtual machine instance:
 $ cubic scp <path/to/host/file> <instance>:<path/to/guest/file>


### PR DESCRIPTION
Corrected documentation showing "cubic cmd" to the proper "cubic exec" syntax.