### PR TITLE
Improve Help Output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,50 +5,37 @@ authors = ["Roger Knecht <rknecht@pm.me>"]
 license = "MIT OR Apache-2.0"
 description = """\
 Cubic is a lightweight command line manager for virtual machines. It has a 
-simple, daemon-less and rootless design. All Cubic virtual machines run isolated
+simple, daemonless and rootless design. All Cubic virtual machines run isolated
 in the user context. Cubic is built on top of QEMU, KVM and cloud-init.
+
+Examples:
+
+  Create a new VM instance with:
+  $ cubic create example --image ubuntu:noble
+  Open a shell in the VM instance:
+  $ cubic ssh example
+
+  Alternatively, use `run` to execute the above commands in a single command:
+  $ cubic run example --image ubuntu:noble
+
+  Show all supported VM images:
+  $ cubic images
+
+  List previously created VM instances:
+  $ cubic instances
+
+  Show information about a VM instance:
+  $ cubic show <instance>
+
+  Execute a command in a VM instance:
+  $ cubic exec <instance> <shell command>
+
+  Transfer files and directories between host and VM instance:
+  $ cubic scp <path/to/host/file> <instance>:<path/to/guest/file>
+  See `cubic scp --help` for more examples
 
 For more information, visit: https://cubic-vm.org/
 The source code is located at: https://github.com/cubic-vm/cubic
-
-Create your first virtual machine instance with:
-$ cubic create my-instance --image ubuntu:noble
-$ cubic ssh my-instance
-
-Alternatively, you can use `run` to create and connect a new virtual machine
-instance in a single command:
-$ cubic run my-instance --image ubuntu:noble
-
-Show all supported virtual machine images:
-$ cubic images
-
-Run, create, clone, rename and delete virtual machine instances:
-$ cubic run <instance> --image <image>
-$ cubic create <instance> --image <image>
-$ cubic rename <instance> <new instance name>
-$ cubic clone  <instance> <instance clone name>
-$ cubic delete <instance>
-
-List all virtual machine instances:
-$ cubic instances
-
-Show information about a virtual machine instance:
-$ cubic show <instance>
-
-Open a shell in the virtual machine instance:
-$ cubic ssh <instance>
-
-Execute a command in a virtual machine instance:
-$ cubic exec <instance> "<shell cmd>"
-
-Copy files and directories between host and virtual machine instance:
-$ cubic scp <path/to/host/file> <instance>:<path/to/guest/file>
-$ cubic scp <instance>:<path/to/guest/file> <path/to/host/file>
-
-Start, restart and stop virtual machine instances:
-$ cubic start   <instance>
-$ cubic restart <instance>
-$ cubic stop    <instance>
 """
 readme = "README.md"
 homepage = "https://cubic-vm.org"

--- a/README.md
+++ b/README.md
@@ -75,76 +75,62 @@ See the [install](https://cubic-vm.org/install.html) instructions for more infor
 Cubic has a simple CLI:
 ```
 $ cubic --help
-Cubic is a lightweight command line manager for virtual machines. It has a 
-simple, daemon-less and rootless design. All Cubic virtual machines run isolated
+Cubic is a lightweight command line manager for virtual machines. It has a
+simple, daemonless and rootless design. All Cubic virtual machines run isolated
 in the user context. Cubic is built on top of QEMU, KVM and cloud-init.
+
+Examples:
+
+  Create a new VM instance with:
+  $ cubic create example --image ubuntu:noble
+  Open a shell in the VM instance:
+  $ cubic ssh example
+
+  Alternatively, use `run` to execute the above commands in a single command:
+  $ cubic run example --image ubuntu:noble
+
+  Show all supported VM images:
+  $ cubic images
+
+  List previously created VM instances:
+  $ cubic instances
+
+  Show information about a VM instance:
+  $ cubic show <instance>
+
+  Execute a command in a VM instance:
+  $ cubic exec <instance> <shell command>
+
+  Transfer files and directories between host and VM instance:
+  $ cubic scp <path/to/host/file> <instance>:<path/to/guest/file>
+  See `cubic scp --help` for more examples
 
 For more information, visit: https://cubic-vm.org/
 The source code is located at: https://github.com/cubic-vm/cubic
-
-Create your first virtual machine instance with:
-$ cubic create my-instance --image ubuntu:noble
-$ cubic ssh my-instance
-
-Alternatively, you can use `run` to create and connect a new virtual machine
-instance in a single command:
-$ cubic run my-instance --image ubuntu:noble
-
-Show all supported virtual machine images:
-$ cubic images
-
-Run, create, clone, rename and delete virtual machine instances:
-$ cubic run <instance> --image <image>
-$ cubic create <instance> --image <image>
-$ cubic rename <instance> <new instance name>
-$ cubic clone  <instance> <instance clone name>
-$ cubic delete <instance>
-
-List all virtual machine instances:
-$ cubic instances
-
-Show information about a virtual machine instance:
-$ cubic show <instance>
-
-Open a shell in the virtual machine instance:
-$ cubic ssh <instance>
-
-Execute a command in a virtual machine instance:
-$ cubic exec <instance> "<shell cmd>"
-
-Copy files and directories between host and virtual machine instance:
-$ cubic scp <path/to/host/file> <instance>:<path/to/guest/file>
-$ cubic scp <instance>:<path/to/guest/file> <path/to/host/file>
-
-Start, restart and stop virtual machine instances:
-$ cubic start   <instance>
-$ cubic restart <instance>
-$ cubic stop    <instance>
 
 
 Usage: cubic [OPTIONS] <COMMAND>
 
 Commands:
-  run          Create, start and open a shell in a new virtual machine instance
-  create       Create a new virtual machine instance
-  instances    List all virtual machine instances
-  images       List all supported virtual machine images
-  ports        List forwarded ports for all virtual machine instances
-  show         Show virtual machine image or instance information
-  modify       Modify a virtual machine instance configuration
-  console      Open the console of a virtual machine instance
-  ssh          Connect to a virtual machine instance with SSH
-  scp          Copy a file from or to a virtual machine instance with SCP
-  exec         Execute a command in the virtual machine instance
-  start        Start virtual machine instances
-  stop         Stop virtual machine instances
-  restart      Restart virtual machine instances
-  rename       Rename a virtual machine instance
-  clone        Clone a virtual machine instance
-  delete       Delete one or more virtual machine instances
-  prune        Clear cache and free space
-  completions  Generate command completions for your shell
-  help         Print this message or the help of the given subcommand(s)
+  run          Create and start VM instances
+  create       Create VM instances
+  instances    List VM instances
+  images       List VM images
+  ports        List ports for VM instances
+  show         Show VM images and instances
+  modify       Modify VM instances
+  console      Open VM instance console
+  ssh          Connect to VM instances
+  scp          Copy data between host and VM instances
+  exec         Execute commands on VM instances
+  start        Start VM instances
+  stop         Stop VM instances
+  restart      Restart VM instances
+  rename       Rename VM instances
+  clone        Clone VM instances
+  delete       Delete VM instances
+  prune        Clear caches
+  completions  Generate shell completion scripts
 
 Options:
   -v, --verbose  Increase logging output

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -42,7 +42,14 @@ pub struct GlobalOptions {
 }
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None, arg_required_else_help = true, infer_subcommands = true)]
+#[command(
+    author,
+    version,
+    about,
+    arg_required_else_help = true,
+    infer_subcommands = true,
+    disable_help_subcommand = true
+)]
 pub struct CommandDispatcher {
     #[command(subcommand)]
     pub command: Commands,

--- a/src/commands/completions_command.rs
+++ b/src/commands/completions_command.rs
@@ -7,9 +7,18 @@ use crate::view::Console;
 use clap::{CommandFactory, Parser};
 use clap_complete::Shell;
 
-/// Generate command completions for your shell
+/// Generate shell completion scripts
+///
+/// Examples:
+///
+///   Generate Bash auto completion script:
+///   $ cubic completions bash > /etc/bash_completion.d/cubic.bash
+///
+///   Generate Fish auto completion script:
+///   $ cubic completions fish > ~/.config/fish/completions/cubic.fish
+///
 #[derive(Parser)]
-#[clap(alias = "completion")]
+#[clap(alias = "completion", verbatim_doc_comment)]
 pub struct CompletionsCommand {
     /// The shell to generate completions for
     shell: Option<Shell>,

--- a/src/commands/create_instance_command.rs
+++ b/src/commands/create_instance_command.rs
@@ -18,33 +18,58 @@ pub const DEFAULT_CPU_COUNT: u16 = 4;
 pub const DEFAULT_MEM_SIZE: &str = "4G";
 pub const DEFAULT_DISK_SIZE: &str = "100G";
 
-/// Create a new virtual machine instance
+/// Create VM instances
+///
+/// This command only creates the VM instance. Use cubic start <instance> to power
+/// it on and cubic ssh <instance> to connect to it.
+///
+/// Examples:
+///
+///   Create a VM instance with 8 vCPUs, 10G of RAM, 200G of storage:
+///   $ cubic create example1 --cpus 8 --mem 10G --disk 200G -i debian:trixie
+///
+///   Create a VM instance and forward the instance's HTTP port to the host port 8000:
+///   $ cubic create example2 --port 8000:80 -i ubuntu:noble
+///
+///   Create a VM instance and forward the instance's DNS port to the host port 5353:
+///   $ cubic create example3 --port 5353:53/udp -i ubuntu:noble
+///
+///   Create a VM instance with multiple port forwarding rules:
+///   $ cubic create example4 -p 8000:80/tcp -p 5353:53/udp -i ubuntu:noble
+///
+///   Create a VM instance and install Vim:
+///   $ cubic create example5 -e "sudo apt install -y vim" -i ubuntu:noble
+///
+///   Create a VM instance without network access:
+///   $ cubic create example6 --isolate ubuntu:noble
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct CreateInstanceCommand {
-    /// Name of the virtual machine instance
+    /// VM instance name (e.g. 'my-instance')
     pub instance_name: InstanceName,
-    /// Name of the virtual machine image
+    /// VM image name (e.g. 'debian:trixie')
     #[clap(short, long)]
     image: ImageName,
-    /// Name of the user
+    /// Username (default: 'cubic')
     #[clap(short, long, default_value = "cubic")]
     user: String,
-    /// Number of CPUs for the virtual machine instance
+    /// Number of vCPUs for the VM instance
     #[clap(short, long, default_value_t = DEFAULT_CPU_COUNT)]
     cpus: u16,
-    /// Memory size of the virtual machine instance (e.g. 1G for 1 gigabyte)
+    /// Memory amount of the VM instance
     #[clap(short, long, default_value = DEFAULT_MEM_SIZE)]
     mem: DataSize,
-    /// Disk size of the virtual machine instance (e.g. 10G for 10 gigabytes)
+    /// Disk size of the VM instance
     #[clap(short, long, default_value = DEFAULT_DISK_SIZE)]
     disk: DataSize,
-    /// Forward ports from guest to host (e.g. -p 8000:80 or -p 127.0.0.1:9000:90/tcp)
+    /// Forward ports from guest to host (e.g. -p 8000:80 or -p 9000:90/tcp)
     #[clap(short, long)]
     port: Vec<PortForward>,
-    /// Execute a shell command on the first boot
+    /// Execute a command once on the first boot (e.g. "sudo apt install ...")
     #[clap(short, long)]
     execute: Option<String>,
-    /// Isolate VM instance from network
+    /// Isolate the VM instance from network
     #[clap(long, action = ArgAction::SetTrue)]
     isolate: bool,
 }

--- a/src/commands/create_instance_command.rs
+++ b/src/commands/create_instance_command.rs
@@ -26,7 +26,7 @@ pub const DEFAULT_DISK_SIZE: &str = "100G";
 /// Examples:
 ///
 ///   Create a VM instance with 8 vCPUs, 10G of RAM, 200G of storage:
-///   $ cubic create example1 --cpus 8 --mem 10G --disk 200G -i debian:trixie
+///   $ cubic create example1 --cpus 8 --memory 10G --disk 200G -i debian:trixie
 ///
 ///   Create a VM instance and forward the instance's HTTP port to the host port 8000:
 ///   $ cubic create example2 --port 8000:80 -i ubuntu:noble
@@ -58,8 +58,8 @@ pub struct CreateInstanceCommand {
     #[clap(short, long, default_value_t = DEFAULT_CPU_COUNT)]
     cpus: u16,
     /// Memory amount of the VM instance
-    #[clap(short, long, default_value = DEFAULT_MEM_SIZE)]
-    mem: DataSize,
+    #[clap(alias = "mem", short, long, default_value = DEFAULT_MEM_SIZE)]
+    memory: DataSize,
     /// Disk size of the VM instance
     #[clap(short, long, default_value = DEFAULT_DISK_SIZE)]
     disk: DataSize,
@@ -97,7 +97,7 @@ impl Command for CreateInstanceCommand {
             arch: image.arch,
             user: self.user.to_string(),
             cpus: self.cpus,
-            mem: self.mem.clone(),
+            mem: self.memory.clone(),
             disk_capacity: self.disk.clone(),
             ssh_port: PortChecker::new().get_new_port(),
             hostfwd: self.port.clone(),

--- a/src/commands/delete_instance_command.rs
+++ b/src/commands/delete_instance_command.rs
@@ -7,8 +7,18 @@ use crate::util;
 use crate::view::Console;
 use clap::Parser;
 
-/// Delete one or more virtual machine instances
+/// Delete VM instances
+///
+/// Examples:
+///
+///   Delete the VM instance 'my-instance':
+///   $ cubic delete my-instance
+///
+///   Delete multiple VM instances:
+///   $ cubic delete trixie noble
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct DeleteInstanceCommand {
     /// Delete the virtual machine instances even when running
     #[clap(short, long, default_value_t = false)]

--- a/src/commands/instance_clone_command.rs
+++ b/src/commands/instance_clone_command.rs
@@ -7,8 +7,15 @@ use crate::ssh_cmd::PortChecker;
 use crate::view::Console;
 use clap::Parser;
 
-/// Clone a virtual machine instance
+/// Clone VM instances
+///
+/// Examples:
+///
+///   Clone the VM instance 'my-instance' as 'my-instance2':
+///   $ cubic clone my-instance my-instance2
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceCloneCommand {
     /// Name of the virtual machine instance to clone
     name: InstanceName,

--- a/src/commands/instance_console_command.rs
+++ b/src/commands/instance_console_command.rs
@@ -11,8 +11,19 @@ use std::path::Path;
 use std::thread;
 use std::time::Duration;
 
-/// Open the console of a virtual machine instance
+/// Open VM instance console
+///
+/// Examples:
+///
+///   Connect to the console of 'my-instance'
+///   $ cubic console my-instance
+///   Default credentials: cubic / cubic
+///   Press CTRL+W to exit the console.
+///
+///   [...]
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceConsoleCommand {
     /// Name of the virtual machine instance
     instance: String,
@@ -33,7 +44,7 @@ impl Command for InstanceConsoleCommand {
         }
         .run(console, env, image_store, instance_store)?;
 
-        console.info("Default user login: cubic / cubic");
+        console.info("Default credentials: cubic / cubic");
         console.info("Press CTRL+W to exit the console.");
         let console_path = env.get_console_file(&self.instance);
         while !Path::new(&console_path).exists() {

--- a/src/commands/instance_exec_command.rs
+++ b/src/commands/instance_exec_command.rs
@@ -8,8 +8,15 @@ use crate::ssh_cmd::Russh;
 use crate::view::Console;
 use clap::Parser;
 
-/// Execute a command in the virtual machine instance
+/// Execute commands on VM instances
+///
+/// Examples:
+///
+///   Update a VM instance:
+///   $ cubic exec noble "sudo apt update && sudo apt full-upgrade -y"
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceExecCommand {
     /// Target instance (format: [username@]instance, e.g. 'myinstance' or 'cubic@myinstance')
     pub target: Target,

--- a/src/commands/instance_modify_command.rs
+++ b/src/commands/instance_modify_command.rs
@@ -19,7 +19,7 @@ use clap::{ArgAction, Parser};
 ///   $ cubic modify example1 --cpus 8
 ///
 ///   Assign 10 GiB of RAM to a VM instance:
-///   $ cubic modify example2 --mem 10G
+///   $ cubic modify example2 --memory 10G
 ///
 ///   Assign 200 GiB of storage to a VM instance:
 ///   $ cubic modify example3 --disk 200G
@@ -48,8 +48,8 @@ pub struct InstanceModifyCommand {
     #[clap(short, long)]
     cpus: Option<u16>,
     /// Memory size of the virtual machine instance (e.g. 1G for 1 gigabyte)
-    #[clap(short, long)]
-    mem: Option<DataSize>,
+    #[clap(alias = "mem", short, long)]
+    memory: Option<DataSize>,
     /// Disk size of the virtual machine instance  (e.g. 10G for 10 gigabytes)
     #[clap(short, long)]
     disk: Option<DataSize>,
@@ -85,8 +85,8 @@ impl Command for InstanceModifyCommand {
             instance.cpus = *cpus;
         }
 
-        if let Some(mem) = &self.mem {
-            instance.mem = mem.clone();
+        if let Some(memory) = &self.memory {
+            instance.mem = memory.clone();
         }
 
         if let Some(disk) = &self.disk {

--- a/src/commands/instance_modify_command.rs
+++ b/src/commands/instance_modify_command.rs
@@ -7,8 +7,40 @@ use crate::model::DataSize;
 use crate::view::Console;
 use clap::{ArgAction, Parser};
 
-/// Modify a virtual machine instance configuration
+/// Modify VM instances
+///
+/// Use this command to change the settings of an existing VM instance (CPU, memory,
+/// disk, etc.). The changes will be applied on the next (re-)start of the VM
+/// instance.
+///
+/// Examples:
+///
+///   Assign 8 virtual CPUs to a VM instance:
+///   $ cubic modify example1 --cpus 8
+///
+///   Assign 10 GiB of RAM to a VM instance:
+///   $ cubic modify example2 --mem 10G
+///
+///   Assign 200 GiB of storage to a VM instance:
+///   $ cubic modify example3 --disk 200G
+///
+///   Forward the VM instance's SSH port (TCP port 22) to the host on port 2222:
+///   $ cubic modify example4 --port 2222:22
+///
+///   Forward the VM instance's DNS port (UDP port 53) to the host on port 5353:
+///   $ cubic modify example5 --port 127.0.0.1:5353:53/udp
+///
+///   Remove DNS port forwarding rule:
+///   $ cubic modify example6 --rm-port 127.0.0.1:5353:53/udp
+///
+///   Deny network access (host, LAN, internet, ...) of a VM instance:
+///   $ cubic modify example7 --isolate
+///
+///   Allow network connection of a VM instance:
+///   $ cubic modify example8 --no-isolate
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceModifyCommand {
     /// Name of the virtual machine instance
     instance: String,
@@ -21,7 +53,7 @@ pub struct InstanceModifyCommand {
     /// Disk size of the virtual machine instance  (e.g. 10G for 10 gigabytes)
     #[clap(short, long)]
     disk: Option<DataSize>,
-    /// Add port forwarding rule (e.g. -p 8000:80)
+    /// Add port forwarding rule (format: [host_ip:]host_port:guest_port[/(udp|tcp)], e.g. -p 8000:80/tcp)
     #[clap(short, long)]
     port: Vec<PortForward>,
     /// Remove port forwarding rule (e.g. -P 8000:80)

--- a/src/commands/instance_rename_command.rs
+++ b/src/commands/instance_rename_command.rs
@@ -6,8 +6,15 @@ use crate::instance::{InstanceName, InstanceStore};
 use crate::view::Console;
 use clap::Parser;
 
-/// Rename a virtual machine instance
+/// Rename VM instances
+///
+/// Examples:
+///
+///   Rename the VM instance 'noble' in 'ubuntu':
+///   $ cubic rename noble ubuntu
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceRenameCommand {
     /// Name of the virtual machine instance to rename
     old_name: InstanceName,

--- a/src/commands/instance_restart_command.rs
+++ b/src/commands/instance_restart_command.rs
@@ -6,8 +6,18 @@ use crate::instance::InstanceStore;
 use crate::view::Console;
 use clap::Parser;
 
-/// Restart virtual machine instances
+/// Restart VM instances
+///
+/// Examples:
+///
+///   Restart the VM instance 'my-instance':
+///   $ cubic restart my-instance
+///
+///   Restart multiple VM instances:
+///   $ cubic restart trixie noble
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceRestartCommand {
     /// Name of the virtual machine instances to restart
     instances: Vec<String>,

--- a/src/commands/instance_run_command.rs
+++ b/src/commands/instance_run_command.rs
@@ -13,7 +13,7 @@ use clap::{self, Parser};
 /// Examples:
 ///
 ///   Run a VM instance with 8 vCPUs, 10G of RAM, 200G of storage:
-///   $ cubic run example1 --cpus 8 --mem 10G --disk 200G -i debian:trixie
+///   $ cubic run example1 --cpus 8 --memory 10G --disk 200G -i debian:trixie
 ///
 ///   Run a VM instance and forward the instance's HTTP port to the host port 8000:
 ///   $ cubic run example2 --port 8000:80 -i ubuntu:noble

--- a/src/commands/instance_run_command.rs
+++ b/src/commands/instance_run_command.rs
@@ -6,8 +6,32 @@ use crate::instance::{InstanceStore, Target};
 use crate::view::Console;
 use clap::{self, Parser};
 
-/// Create, start and open a shell in a new virtual machine instance
+/// Create and start VM instances
+///
+/// This command is a shortcut for the three subcommands `create`, `start` and `ssh`.
+///
+/// Examples:
+///
+///   Run a VM instance with 8 vCPUs, 10G of RAM, 200G of storage:
+///   $ cubic run example1 --cpus 8 --mem 10G --disk 200G -i debian:trixie
+///
+///   Run a VM instance and forward the instance's HTTP port to the host port 8000:
+///   $ cubic run example2 --port 8000:80 -i ubuntu:noble
+///
+///   Run a VM instance and forward the instance's DNS port to the host port 5353:
+///   $ cubic run example3 --port 5353:53/udp -i ubuntu:noble
+///
+///   Run a VM instance with multiple port forwarding rules:
+///   $ cubic run example4 -p 8000:80/tcp -p 5353:53/udp -i ubuntu:noble
+///
+///   Run a VM instance and install Vim:
+///   $ cubic run example5 -e "sudo apt install -y vim" -i ubuntu:noble
+///
+///   Run a VM instance without network access:
+///   $ cubic run example6 --isolate ubuntu:noble
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceRunCommand {
     #[clap(flatten)]
     create_cmd: commands::CreateInstanceCommand,

--- a/src/commands/instance_scp_command.rs
+++ b/src/commands/instance_scp_command.rs
@@ -19,8 +19,27 @@ fn check_target_is_running(instance_store: &dyn InstanceStore, target: &TargetPa
     Ok(())
 }
 
-/// Copy a file from or to a virtual machine instance with SCP
+/// Copy data between host and VM instances
+///
+/// Data can be copied from host to VM instance, from VM instance to host, and
+/// between VM instances:
+/// $ cubic scp <path/to/host/file> <instance>:<path/to/guest/file>
+/// $ cubic scp <instance>:<path/to/guest/file> <path/to/host/file>
+/// $ cubic scp <instance>:<path/to/guest/file> <instance>:<path/to/guest/file>
+///
+/// Examples:
+///
+///   Upload a file from host to the VM instance 'trixie':
+///   $ cubic scp ./cubic.tar.gz trixie:~/
+///
+///   Download a directory from the VM instance 'trixie' to host:
+///   $ cubic scp trixie:~/Downloads .
+///
+///   Copy a file from the VM instance 'trixie' to 'noble':
+///   $ cubic scp trixie:~/cubic.tar.gz noble:~/
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceScpCommand {
     /// Source of the data to copy
     from: TargetPath,

--- a/src/commands/instance_show_command.rs
+++ b/src/commands/instance_show_command.rs
@@ -6,7 +6,7 @@ use crate::instance::{InstanceName, InstanceStore};
 use crate::view::{Console, MapView};
 use clap::Parser;
 
-/// Show a virtual machine instance
+/// Show VM instances
 #[derive(Parser)]
 pub struct InstanceShowCommand {
     /// Name of the virtual machine instance

--- a/src/commands/instance_ssh_command.rs
+++ b/src/commands/instance_ssh_command.rs
@@ -8,8 +8,16 @@ use crate::ssh_cmd::Russh;
 use crate::view::Console;
 use clap::Parser;
 
-/// Connect to a virtual machine instance with SSH
+/// Connect to VM instances
+///
+/// Examples:
+///
+///   Connect to VM instance 'my-instance':
+///   $ cubic ssh my-instance
+///   [...]
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceSshCommand {
     /// Target instance (format: [username@]instance, e.g. 'myinstance' or 'cubic@myinstance')
     pub target: Target,

--- a/src/commands/instance_start_command.rs
+++ b/src/commands/instance_start_command.rs
@@ -12,13 +12,29 @@ use clap::Parser;
 use std::thread::sleep;
 use std::time::Duration;
 
-/// Start virtual machine instances
+/// Start VM instances
+///
+/// Examples:
+///
+///   Start the VM instance 'my-instance'
+///   $ cubic start my-instance
+///
+///   Start and wait for the VM instance 'my-instance' to start
+///   $ cubic start --wait my-instance
+///
+///   Start multiple VM instances
+///   $ cubic start trixie noble
+///
+///   Pass additional arguments to QEMU
+///   $ cubic start trixie --qemu-args="-sandbox on"
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceStartCommand {
     /// Pass additional QEMU arguments
     #[clap(long)]
     pub qemu_args: Option<String>,
-    /// Wait for the virtual machine instance to be started
+    /// Wait until the VM instance has started
     #[clap(short, long, default_value_t = false)]
     pub wait: bool,
     /// Name of the virtual machine instances to start

--- a/src/commands/instance_stop_command.rs
+++ b/src/commands/instance_stop_command.rs
@@ -10,8 +10,21 @@ use clap::Parser;
 use std::thread;
 use std::time::Duration;
 
-/// Stop virtual machine instances
+/// Stop VM instances
+///
+/// Examples:
+///
+///   Stop the VM instance 'my-instance':
+///   $ cubic stop my-instace
+///
+///   Stop and wait until the VM instance 'my-instance' has stopped:
+///   $ cubic stop --wait my-instace
+///
+///   Stop all VM instances:
+///   $ cubic stop --all --wait
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct InstanceStopCommand {
     /// Stop all virtual machine instances
     #[clap(short, long, default_value_t = false)]

--- a/src/commands/list_image_command.rs
+++ b/src/commands/list_image_command.rs
@@ -7,8 +7,34 @@ use crate::model::DataSize;
 use crate::view::{Alignment, Console, TableView};
 use clap::Parser;
 
-/// List all supported virtual machine images
+/// List VM images
+///
+/// Examples:
+///
+///   $ cubic images
+///   Name                       Arch         Size   Cached
+///   archlinux:latest           amd64   518.7 MiB       no
+///   debian:{12, bookworm}      amd64   424.2 MiB       no
+///   debian:{11, bullseye}      amd64   343.8 MiB       no
+///   debian:{10, buster}        amd64   301.7 MiB       no
+///   debian:{13, trixie}        amd64   412.0 MiB      yes
+///   fedora:41                  amd64   468.9 MiB       no
+///   fedora:42                  amd64   507.6 MiB       no
+///   fedora:43                  amd64   556.3 MiB       no
+///   opensuse:15.5              amd64   643.1 MiB       no
+///   [...]
+///   opensuse:15.6              amd64   682.7 MiB       no
+///   [...]
+///   rockylinux:10              amd64   548.8 MiB       no
+///   rockylinux:8               amd64     1.9 GiB       no
+///   rockylinux:9               amd64   618.8 MiB       no
+///   [...]
+///   ubuntu:{24.04, noble}      amd64   250.4 MiB      yes
+///   [...]
+///
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct ListImageCommand {
     /// Show all images
     #[clap(short, long, action, global = true)]

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -6,8 +6,19 @@ use crate::instance::InstanceStore;
 use crate::view::{Alignment, Console, TableView};
 use clap::Parser;
 
-/// List all virtual machine instances
+/// List VM instances
+///
+/// Examples:
+///
+///   $ cubic instances
+///   PID     Name           Arch    CPUs     Memory   Disk Used   Disk Total   State
+///           noble-arm64    arm64      8    8.0 GiB     4.4 GiB    100.0 GiB   stopped
+///   1059    trixie         amd64      6   16.0 GiB         n/a    100.0 GiB   running
+///           fedora         amd64      4    4.0 GiB    10.0 GiB    100.0 GiB   stopped
+///
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct ListInstanceCommand;
 
 impl Command for ListInstanceCommand {

--- a/src/commands/list_port_command.rs
+++ b/src/commands/list_port_command.rs
@@ -6,8 +6,23 @@ use crate::instance::InstanceStore;
 use crate::view::{Alignment, Console, TableView};
 use clap::Parser;
 
-/// List forwarded ports for all virtual machine instances
+/// List ports for VM instances
+///
+/// Shows port forwarding rules from VM instance to host. Use cubic modify <instance>
+/// to configure the forwarding.
+///
+/// Examples:
+///
+///   $ cubic ports
+///   Instance       Host              Guest   Protocol   In Use
+///   noble-arm64    127.0.0.1:30612   :22     /tcp       no
+///   noble-arm64    127.0.0.1:2222    :22     /tcp       no
+///   trixie         127.0.0.1:30200   :22     /tcp       yes
+///   trixie         127.0.0.1:4000    :4000   /tcp       yes
+///   fedora         127.0.0.1:59153   :22     /tcp       no
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct ListPortCommand;
 
 impl Command for ListPortCommand {

--- a/src/commands/prune_command.rs
+++ b/src/commands/prune_command.rs
@@ -6,8 +6,12 @@ use crate::instance::InstanceStore;
 use crate::view::Console;
 use clap::Parser;
 
-/// Clear cache and free space
+/// Clear caches
+///
+/// This commands removes cached VM images files.
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct PruneCommand;
 
 impl Command for PruneCommand {

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -7,8 +7,34 @@ use crate::model::InstanceImageName;
 use crate::view::Console;
 use clap::Parser;
 
-/// Show virtual machine image or instance information
+/// Show VM images and instances
+///
+/// Use this command to inspect VM instance configuration and VM image details.
+///
+/// Examples:
+///
+///   Show information of a VM instance
+///   $ cubic show trixie
+///   Arch:       amd64
+///   CPUs:       6
+///   Memory:     16.0 GiB
+///   Disk Used:  5.2 GiB
+///   Disk Total: 100.0 GiB
+///   User:       cubic
+///   Isolated:   no
+///   SSH Port:   54315
+///   SSH:        ssh -p 54315 cubic@localhost
+///   Forward:    127.0.0.1:4000:4000/tcp
+///
+///   Show information of a VM image
+///   $ cubic show ubuntu:noble
+///   Name:         ubuntu:{24.04, noble}
+///   Image URL:    https://cloud-images.ubuntu.com/minimal/releases/noble/release/...
+///   Checksum URL: https://cloud-images.ubuntu.com/minimal/releases/noble/release/...
+///
+///
 #[derive(Parser)]
+#[clap(verbatim_doc_comment)]
 pub struct ShowCommand {
     /// Name of the virtual machine image or instance
     name: InstanceImageName,

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -6,7 +6,7 @@ use crate::instance::InstanceStore;
 use crate::view::{Console, MapView};
 use clap::Parser;
 
-/// Show image information
+/// Show VM images
 #[derive(Parser)]
 pub struct ShowImageCommand {
     /// Name of the virtual machine image


### PR DESCRIPTION
Enhance help output across the CLI, including detailed descriptions for each
subcommand accessible via `cubic <cmd> --help`.