### PR TITLE
Add Rust ISO9660 Implementation for Cloud Init

### DIFF
--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -1,4 +1,5 @@
 use crate::cloudinit::UserDataImageFactory;
+use crate::commands::Iso9660;
 use crate::emulator::Emulator;
 use crate::env::Environment;
 use crate::error::Result;
@@ -23,13 +24,17 @@ impl StartInstanceAction {
         env: &Environment,
         qemu_args: &Option<String>,
         verbose: bool,
+        iso9660: Iso9660,
     ) -> Result<()> {
         if instance_dao.is_running(&self.instance) {
             return Ok(());
         }
 
         FS::new().setup_directory_access(&env.get_instance_runtime_dir(&self.instance.name))?;
-        UserDataImageFactory.create(env, &self.instance)?;
+        match iso9660 {
+            Iso9660::Rust => UserDataImageFactory.create_rust(env, &self.instance)?,
+            Iso9660::System => UserDataImageFactory.create_native(env, &self.instance)?,
+        };
 
         let mut emulator = Emulator::from(self.instance.arch)?;
         emulator.set_cpus(self.instance.cpus);

--- a/src/cloudinit/user_data_image_factory.rs
+++ b/src/cloudinit/user_data_image_factory.rs
@@ -3,6 +3,7 @@ use crate::env::Environment;
 use crate::error::Result;
 use crate::fs::FS;
 use crate::instance::Instance;
+use crate::iso9660::IsoWriter;
 use crate::ssh_cmd::SshKeyGenerator;
 use crate::util::SystemCommand;
 use std::io::Write;
@@ -12,12 +13,46 @@ use std::path::Path;
 pub struct UserDataImageFactory;
 
 impl UserDataImageFactory {
-    pub fn create(&self, env: &Environment, instance: &Instance) -> Result<()> {
-        let fs = FS::new();
-        let name = &instance.name;
-        let user = &instance.user;
-
+    pub fn create_rust(&self, env: &Environment, instance: &Instance) -> Result<()> {
         let user_data_img_path = env.get_user_data_image_file(&instance.name);
+        let fs = FS::new();
+
+        if Path::new(&user_data_img_path).exists() {
+            return Ok(());
+        }
+
+        // Generate SSH public key
+        let privatekey = Path::new(&env.get_instance_dir2(&instance.name)).join("ssh_client_key");
+        let pubkey = privatekey
+            .exists()
+            .then(|| SshKeyGenerator::new().generate_public_key(&privatekey))
+            .and_then(|key| key.ok())
+            .unwrap_or_default();
+
+        // Generate Cloud Init files
+        let meta_data = MetaDataFactory.create(&instance.name);
+        let user_data =
+            UserDataFactory.create(&instance.user, &pubkey, instance.execute.as_deref());
+
+        // Generate ISO file
+        fs.create_dir(&env.get_instance_cache_dir(&instance.name))?;
+        let mut iso_writer = IsoWriter::new();
+        iso_writer.pvd.system_id = "LINUX".to_string();
+        iso_writer.pvd.volume_id = "cidata".to_string();
+        iso_writer.pvd.application_id = "Cubic".to_string();
+        iso_writer
+            .files
+            .insert("meta-data".to_string(), meta_data.into_bytes());
+        iso_writer
+            .files
+            .insert("user-data".to_string(), user_data.into_bytes());
+        iso_writer.create_iso(&user_data_img_path)?;
+        Ok(())
+    }
+
+    pub fn create_native(&self, env: &Environment, instance: &Instance) -> Result<()> {
+        let user_data_img_path = env.get_user_data_image_file(&instance.name);
+        let fs = FS::new();
 
         if !Path::new(&user_data_img_path).exists() {
             let meta_data_path = env.get_meta_data_file(&instance.name);
@@ -27,7 +62,7 @@ impl UserDataImageFactory {
 
             if !Path::new(&meta_data_path).exists() {
                 fs.create_file(&meta_data_path)?
-                    .write_all(MetaDataFactory.create(name).as_bytes())?;
+                    .write_all(MetaDataFactory.create(&instance.name).as_bytes())?;
             }
 
             if !Path::new(&user_data_path).exists() {
@@ -41,7 +76,7 @@ impl UserDataImageFactory {
 
                 fs.create_file(&user_data_path)?.write_all(
                     UserDataFactory
-                        .create(user, &pubkey, instance.execute.as_deref())
+                        .create(&instance.user, &pubkey, instance.execute.as_deref())
                         .as_bytes(),
                 )?;
             }
@@ -58,6 +93,6 @@ impl UserDataImageFactory {
                 .run()?;
         }
 
-        Result::Ok(())
+        Ok(())
     }
 }

--- a/src/commands/instance_console_command.rs
+++ b/src/commands/instance_console_command.rs
@@ -1,4 +1,4 @@
-use crate::commands::{self, Command};
+use crate::commands::{self, Command, Iso9660};
 use crate::env::Environment;
 use crate::error::Result;
 use crate::image::ImageStore;
@@ -27,6 +27,10 @@ use std::time::Duration;
 pub struct InstanceConsoleCommand {
     /// Name of the virtual machine instance
     instance: String,
+    /// Switch for Rust and system ISO9600 implementation
+    #[clap(hide = true)]
+    #[arg(value_enum, long, default_value_t = Iso9660::System)]
+    pub iso9660: Iso9660,
 }
 
 impl Command for InstanceConsoleCommand {
@@ -41,6 +45,7 @@ impl Command for InstanceConsoleCommand {
             qemu_args: None,
             wait: false,
             instances: vec![self.instance.to_string()],
+            iso9660: self.iso9660.clone(),
         }
         .run(console, env, image_store, instance_store)?;
 

--- a/src/commands/instance_exec_command.rs
+++ b/src/commands/instance_exec_command.rs
@@ -1,4 +1,4 @@
-use crate::commands::{self, Command};
+use crate::commands::{self, Command, Iso9660};
 use crate::env::Environment;
 use crate::error::Result;
 use crate::fs::FS;
@@ -22,6 +22,10 @@ pub struct InstanceExecCommand {
     pub target: Target,
     /// Command to execute in the virtual machine instance
     pub cmd: String,
+    /// Switch for Rust and system ISO9600 implementation
+    #[clap(hide = true)]
+    #[arg(value_enum, default_value_t = Iso9660::System)]
+    pub iso9660: Iso9660,
 }
 
 impl Command for InstanceExecCommand {
@@ -38,6 +42,7 @@ impl Command for InstanceExecCommand {
             qemu_args: None,
             wait: true,
             instances: vec![name.to_string()],
+            iso9660: self.iso9660.clone(),
         }
         .run(console, env, image_store, instance_store)?;
 

--- a/src/commands/instance_restart_command.rs
+++ b/src/commands/instance_restart_command.rs
@@ -1,4 +1,4 @@
-use crate::commands::{self, Command};
+use crate::commands::{self, Command, Iso9660};
 use crate::env::Environment;
 use crate::error::Result;
 use crate::image::ImageStore;
@@ -21,6 +21,10 @@ use clap::Parser;
 pub struct InstanceRestartCommand {
     /// Name of the virtual machine instances to restart
     instances: Vec<String>,
+    /// Switch for Rust and system ISO9600 implementation
+    #[clap(hide = true)]
+    #[arg(value_enum, long, default_value_t = Iso9660::System)]
+    pub iso9660: Iso9660,
 }
 
 impl Command for InstanceRestartCommand {
@@ -41,6 +45,7 @@ impl Command for InstanceRestartCommand {
             qemu_args: None,
             wait: true,
             instances: self.instances.to_vec(),
+            iso9660: self.iso9660.clone(),
         }
         .run(console, env, image_store, instance_store)
     }

--- a/src/commands/instance_run_command.rs
+++ b/src/commands/instance_run_command.rs
@@ -1,4 +1,4 @@
-use crate::commands::{self, Command};
+use crate::commands::{self, Command, Iso9660};
 use crate::env::Environment;
 use crate::error::Result;
 use crate::image::ImageStore;
@@ -35,6 +35,10 @@ use clap::{self, Parser};
 pub struct InstanceRunCommand {
     #[clap(flatten)]
     create_cmd: commands::CreateInstanceCommand,
+    /// Switch for Rust and system ISO9600 implementation
+    #[clap(hide = true)]
+    #[arg(value_enum, long, default_value_t = Iso9660::System)]
+    pub iso9660: Iso9660,
 }
 
 impl Command for InstanceRunCommand {
@@ -50,6 +54,7 @@ impl Command for InstanceRunCommand {
         commands::InstanceSshCommand {
             target: Target::from_instance_name(self.create_cmd.instance_name.clone()),
             cmd: None,
+            iso9660: self.iso9660.clone(),
         }
         .run(console, env, image_store, instance_store)
     }

--- a/src/commands/instance_ssh_command.rs
+++ b/src/commands/instance_ssh_command.rs
@@ -1,4 +1,4 @@
-use crate::commands::{self, Command};
+use crate::commands::{self, Command, Iso9660};
 use crate::env::Environment;
 use crate::error::Result;
 use crate::fs::FS;
@@ -24,6 +24,10 @@ pub struct InstanceSshCommand {
     /// Command to execute in the virtual machine instance
     #[clap(hide = true)]
     pub cmd: Option<String>,
+    /// Switch for Rust and system ISO9600 implementation
+    #[clap(hide = true)]
+    #[arg(value_enum, long, default_value_t = Iso9660::System)]
+    pub iso9660: Iso9660,
 }
 
 impl Command for InstanceSshCommand {
@@ -46,6 +50,7 @@ impl Command for InstanceSshCommand {
             qemu_args: None,
             wait: true,
             instances: vec![name.to_string()],
+            iso9660: self.iso9660.clone(),
         }
         .run(console, env, image_store, instance_store)?;
 

--- a/src/commands/instance_start_command.rs
+++ b/src/commands/instance_start_command.rs
@@ -8,9 +8,15 @@ use crate::ssh_cmd::{PortChecker, Russh};
 use crate::util;
 use crate::view::Console;
 use crate::view::SpinnerView;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use std::thread::sleep;
 use std::time::Duration;
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum Iso9660 {
+    System,
+    Rust,
+}
 
 /// Start VM instances
 ///
@@ -39,6 +45,10 @@ pub struct InstanceStartCommand {
     pub wait: bool,
     /// Name of the virtual machine instances to start
     pub instances: Vec<String>,
+    /// Switch for Rust and system ISO9600 implementation
+    #[clap(hide = true)]
+    #[arg(value_enum, long, default_value_t = Iso9660::System)]
+    pub iso9660: Iso9660,
 }
 
 impl Command for InstanceStartCommand {
@@ -65,7 +75,13 @@ impl Command for InstanceStartCommand {
                 }
 
                 let mut action = StartInstanceAction::new(instance);
-                action.run(instance_store, env, &self.qemu_args, verbosity.is_verbose())?;
+                action.run(
+                    instance_store,
+                    env,
+                    &self.qemu_args,
+                    verbosity.is_verbose(),
+                    self.iso9660.clone(),
+                )?;
 
                 actions.push(action);
             }

--- a/src/iso9660.rs
+++ b/src/iso9660.rs
@@ -1,0 +1,15 @@
+mod binary_writer;
+mod dir_record;
+mod dir_record_factory;
+mod iso_writer;
+mod primary_volume_desc;
+mod term_volume_desc;
+mod volume_desc;
+
+pub use binary_writer::{BinaryWriter, SECTOR_SIZE};
+pub use dir_record::DirRecord;
+pub use dir_record_factory::DirRecordFactory;
+pub use iso_writer::IsoWriter;
+pub use primary_volume_desc::PrimaryVolumeDesc;
+pub use term_volume_desc::TermVolumeDesc;
+pub use volume_desc::VolumeDesc;

--- a/src/iso9660/binary_writer.rs
+++ b/src/iso9660/binary_writer.rs
@@ -1,0 +1,214 @@
+use std::cmp::min;
+use std::io::{self, Seek, SeekFrom, Write};
+
+pub const SECTOR_SIZE: usize = 2048;
+
+pub struct BinaryWriter<T: Write + Seek> {
+    out: T,
+}
+
+impl<T: Write + Seek> BinaryWriter<T> {
+    pub fn new(out: T) -> Self {
+        Self { out }
+    }
+
+    pub fn write_byte(&mut self, byte: u8) -> io::Result<u64> {
+        self.out.write_all(&[byte])?;
+        self.out.stream_position()
+    }
+
+    pub fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<u64> {
+        self.out.write_all(bytes)?;
+        self.out.stream_position()
+    }
+
+    pub fn write_padded_string(&mut self, string: &str, len: usize) -> io::Result<u64> {
+        let string_len = min(string.len(), len);
+        self.out
+            .write_all(format!("{:<len$}", &string[..string_len]).as_bytes())?;
+        self.out.stream_position()
+    }
+
+    pub fn write_u32_le(&mut self, value: u32) -> io::Result<u64> {
+        self.out.write_all(&value.to_le_bytes())?;
+        self.out.stream_position()
+    }
+
+    pub fn write_u32_be(&mut self, value: u32) -> io::Result<u64> {
+        self.out.write_all(&value.to_be_bytes())?;
+        self.out.stream_position()
+    }
+
+    pub fn write_u32_le_be(&mut self, value: u32) -> io::Result<u64> {
+        self.write_u32_le(value)?;
+        self.write_u32_be(value)?;
+        self.out.stream_position()
+    }
+
+    pub fn write_u16_le_be(&mut self, value: u16) -> io::Result<u64> {
+        self.out.write_all(&value.to_le_bytes())?;
+        self.out.write_all(&value.to_be_bytes())?;
+        self.out.stream_position()
+    }
+
+    pub fn skip(&mut self, bytes: u32) -> io::Result<u64> {
+        self.out.seek(SeekFrom::Current(bytes as i64))?;
+        self.out.stream_position()
+    }
+
+    pub fn pad_to_sector_end(&mut self) -> io::Result<u64> {
+        let padding = SECTOR_SIZE as u64 - (self.out.stream_position()? % SECTOR_SIZE as u64);
+
+        if padding > 0 {
+            if padding > 1 {
+                self.skip(padding as u32 - 1)?;
+            }
+            self.write_byte(0x00)?;
+        }
+        self.out.stream_position()
+    }
+
+    #[cfg(test)]
+    pub fn get_writer(&mut self) -> &mut T {
+        &mut self.out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_write_one_byte() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_byte(1).unwrap(), 1);
+        assert_eq!(writer.get_writer().get_ref(), &[1]);
+    }
+
+    #[test]
+    fn test_write_two_bytes() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_byte(1).unwrap(), 1);
+        assert_eq!(writer.write_byte(2).unwrap(), 2);
+        assert_eq!(writer.get_writer().get_ref(), &[1, 2]);
+    }
+
+    #[test]
+    fn test_write_empty_chunk() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_bytes(&[]).unwrap(), 0);
+        assert_eq!(writer.get_writer().get_ref(), &[0u8; 0]);
+    }
+
+    #[test]
+    fn test_write_one_chunk() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_bytes(&[1, 2, 3, 4, 5]).unwrap(), 5);
+        assert_eq!(writer.get_writer().get_ref(), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_write_two_chunks() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_bytes(&[1, 2, 3, 4, 5]).unwrap(), 5);
+        assert_eq!(writer.write_bytes(&[5, 4, 3, 2, 1]).unwrap(), 10);
+        assert_eq!(
+            writer.get_writer().get_ref(),
+            &[1, 2, 3, 4, 5, 5, 4, 3, 2, 1]
+        );
+    }
+
+    #[test]
+    fn test_write_empty_padded_string() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_padded_string("", 0).unwrap(), 0);
+        assert_eq!(writer.get_writer().get_ref(), &[0u8; 0]);
+    }
+
+    #[test]
+    fn test_write_one_padded_string() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_padded_string("foo", 3).unwrap(), 3);
+        assert_eq!(writer.get_writer().get_ref(), &[102, 111, 111]);
+    }
+
+    #[test]
+    fn test_write_two_padded_strings() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_padded_string("foo", 3).unwrap(), 3);
+        assert_eq!(writer.write_padded_string("bar", 3).unwrap(), 6);
+        assert_eq!(writer.get_writer().get_ref(), &[102, 111, 111, 98, 97, 114]);
+    }
+
+    #[test]
+    fn test_write_three_letters_padded_to_ten() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_padded_string("foo", 10).unwrap(), 10);
+        assert_eq!(
+            writer.get_writer().get_ref(),
+            &[102, 111, 111, 32, 32, 32, 32, 32, 32, 32]
+        );
+    }
+
+    #[test]
+    fn test_write_six_letters_padded_to_three() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_padded_string("foobar", 3).unwrap(), 3);
+        assert_eq!(writer.get_writer().get_ref(), &[102, 111, 111]);
+    }
+
+    #[test]
+    fn test_write_u32_le() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_u32_le(0x12345678).unwrap(), 4);
+        assert_eq!(writer.get_writer().get_ref(), &[0x78, 0x56, 0x34, 0x12]);
+    }
+
+    #[test]
+    fn test_write_u32_be() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_u32_be(0x12345678).unwrap(), 4);
+        assert_eq!(writer.get_writer().get_ref(), &[0x12, 0x34, 0x56, 0x78]);
+    }
+
+    #[test]
+    fn test_write_u32_le_be() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_u32_le_be(0x12345678).unwrap(), 8);
+        assert_eq!(
+            writer.get_writer().get_ref(),
+            &[0x78, 0x56, 0x34, 0x12, 0x12, 0x34, 0x56, 0x78]
+        );
+    }
+
+    #[test]
+    fn test_write_u16_le_be() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_u16_le_be(0x1234).unwrap(), 4);
+        assert_eq!(writer.get_writer().get_ref(), &[0x34, 0x12, 0x12, 0x34]);
+    }
+
+    #[test]
+    fn test_skip() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.skip(1).unwrap(), 1);
+        assert_eq!(writer.skip(1).unwrap(), 2);
+        assert_eq!(writer.skip(0).unwrap(), 2);
+        assert_eq!(writer.skip(500).unwrap(), 502);
+    }
+
+    #[test]
+    fn test_write_one_byte_and_pad_sector() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.write_byte(1).unwrap(), 1);
+        assert_eq!(writer.pad_to_sector_end().unwrap(), 2048);
+    }
+
+    #[test]
+    fn test_skip_3000_bytes_and_pad_sector() {
+        let mut writer = BinaryWriter::new(Cursor::new(Vec::new()));
+        assert_eq!(writer.skip(3000).unwrap(), 3000);
+        assert_eq!(writer.pad_to_sector_end().unwrap(), 4096);
+    }
+}

--- a/src/iso9660/dir_record.rs
+++ b/src/iso9660/dir_record.rs
@@ -1,0 +1,79 @@
+use crate::iso9660::BinaryWriter;
+use std::io::{self, Seek, Write};
+
+#[derive(Clone, Default)]
+pub struct DirRecord {
+    pub len: u8,
+    pub extend_attr_len: u8,
+    pub extend_loc: u32,
+    pub data_len: u32,
+    pub file_flags: u8,
+    pub file_unit_size: u8,
+    pub interleave_gap_size: u8,
+    pub volume_sequence_number: u16,
+    pub file_id_len: u8,
+    pub file_id: String,
+}
+
+impl DirRecord {
+    pub fn write<T: Write + Seek>(&self, writer: &mut BinaryWriter<T>) -> io::Result<()> {
+        writer.write_byte(self.len)?;
+        writer.write_byte(self.extend_attr_len)?;
+        writer.write_u32_le_be(self.extend_loc)?;
+        writer.write_u32_le_be(self.data_len)?;
+        writer.skip(7)?; // Recording date and time
+        writer.write_byte(self.file_flags)?;
+        writer.write_byte(self.file_unit_size)?;
+        writer.write_byte(self.interleave_gap_size)?;
+        writer.write_u16_le_be(self.volume_sequence_number)?;
+        writer.write_byte(self.file_id_len)?;
+        writer.write_bytes(self.file_id.as_bytes())?;
+
+        // Padding
+        if self.file_id_len.is_multiple_of(2) {
+            writer.write_byte(0x00)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_write_dir_record() {
+        let writer = &mut BinaryWriter::new(Cursor::new(Vec::new()));
+        let mut dir = DirRecord::default();
+        dir.len = 34;
+        dir.extend_attr_len = 1;
+        dir.extend_loc = 0xABCDEF01;
+        dir.data_len = 0x98765432;
+        dir.file_flags = 0x12;
+        dir.file_unit_size = 0x23;
+        dir.interleave_gap_size = 0xAB;
+        dir.volume_sequence_number = 0xFEDC;
+        dir.file_id_len = 6;
+        dir.file_id = "foobar".to_string();
+        dir.write(writer).unwrap();
+
+        let result = writer.get_writer().get_ref();
+        assert_eq!(result[0], 34);
+        assert_eq!(result[1], 1);
+        assert_eq!(&result[2..6], &[0x01, 0xEF, 0xCD, 0xAB]);
+        assert_eq!(&result[6..10], &[0xAB, 0xCD, 0xEF, 0x01]);
+        assert_eq!(&result[10..14], &[0x32, 0x54, 0x76, 0x98]);
+        assert_eq!(&result[14..18], &[0x98, 0x76, 0x54, 0x32]);
+        assert_eq!(&result[18..25], &[0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(result[25], 0x12);
+        assert_eq!(result[26], 0x23);
+        assert_eq!(result[27], 0xAB);
+        assert_eq!(&result[28..30], &[0xDC, 0xFE]);
+        assert_eq!(&result[30..32], &[0xFE, 0xDC]);
+        assert_eq!(result[32], 6);
+        assert_eq!(&result[33..39], &[102, 111, 111, 98, 97, 114]);
+        assert_eq!(result[39], 0);
+    }
+}

--- a/src/iso9660/dir_record_factory.rs
+++ b/src/iso9660/dir_record_factory.rs
@@ -1,0 +1,65 @@
+use crate::iso9660::DirRecord;
+
+#[derive(Default)]
+pub struct DirRecordFactory;
+
+impl DirRecordFactory {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn create_file(&self, name: &str, sector: u32, size: u32) -> DirRecord {
+        let mut dir = DirRecord::default();
+        dir.file_id = name.to_string();
+        dir.file_id_len = dir.file_id.len() as u8;
+        dir.len = 33 + dir.file_id.len() as u8;
+        if name.len().is_multiple_of(2) {
+            dir.len += 1;
+        }
+        dir.volume_sequence_number = 1;
+        dir.extend_loc = sector;
+        dir.data_len = size;
+        dir
+    }
+
+    pub fn create_dir(&self, name: &str, sector: u32, size: u32) -> DirRecord {
+        let mut dir = self.create_file(name, sector, size);
+        dir.file_flags = 0x02;
+        dir
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_dir() {
+        let dir = DirRecordFactory::new().create_dir("testdir", 20, 1024);
+        assert_eq!(dir.len, 40);
+        assert_eq!(dir.extend_attr_len, 0);
+        assert_eq!(dir.extend_loc, 20);
+        assert_eq!(dir.data_len, 1024);
+        assert_eq!(dir.file_flags, 0x02);
+        assert_eq!(dir.file_unit_size, 0);
+        assert_eq!(dir.interleave_gap_size, 0);
+        assert_eq!(dir.volume_sequence_number, 1);
+        assert_eq!(dir.file_id_len, 7);
+        assert_eq!(dir.file_id, "testdir");
+    }
+
+    #[test]
+    fn test_create_file() {
+        let dir = DirRecordFactory::new().create_file("testfile", 21, 500);
+        assert_eq!(dir.len, 42);
+        assert_eq!(dir.extend_attr_len, 0);
+        assert_eq!(dir.extend_loc, 21);
+        assert_eq!(dir.data_len, 500);
+        assert_eq!(dir.file_flags, 0);
+        assert_eq!(dir.file_unit_size, 0);
+        assert_eq!(dir.interleave_gap_size, 0);
+        assert_eq!(dir.volume_sequence_number, 1);
+        assert_eq!(dir.file_id_len, 8);
+        assert_eq!(dir.file_id, "testfile");
+    }
+}

--- a/src/iso9660/iso_writer.rs
+++ b/src/iso9660/iso_writer.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+use crate::iso9660::{
+    BinaryWriter, DirRecordFactory, PrimaryVolumeDesc, SECTOR_SIZE, TermVolumeDesc,
+};
+use std::fs::File;
+use std::io::{self, BufWriter};
+
+pub struct IsoWriter {
+    pub pvd: PrimaryVolumeDesc,
+    pub files: HashMap<String, Vec<u8>>,
+}
+
+impl IsoWriter {
+    pub fn new() -> Self {
+        Self {
+            pvd: PrimaryVolumeDesc::new(),
+            files: HashMap::new(),
+        }
+    }
+
+    pub fn create_iso(&self, output_path: &str) -> io::Result<()> {
+        let file = File::create(output_path)?;
+        let writer = &mut BinaryWriter::new(BufWriter::new(file));
+
+        // Sectors 0 - 15: Boot sector
+        writer.skip(16u32 * SECTOR_SIZE as u32)?;
+
+        // Sector 16: Primary Volume Descriptor
+        let mut pvd = self.pvd.clone();
+        pvd.volume_space_size = 21;
+        pvd.volume_set_size = 1;
+        pvd.volume_sequence_number = 1;
+        pvd.root_dir.len = 34;
+        pvd.root_dir.file_flags = 0x02;
+        pvd.root_dir.extend_loc = 18;
+        pvd.root_dir.data_len = SECTOR_SIZE as u32;
+        pvd.root_dir.volume_sequence_number = 1;
+        pvd.write(writer)?;
+
+        // Sector 17: Volume Descriptor Set Terminator
+        TermVolumeDesc::new().write(writer)?;
+
+        // Sector 18: Root Directory Entries
+        let fac = DirRecordFactory::new();
+
+        fac.create_dir("\x00", 18, SECTOR_SIZE as u32)
+            .write(writer)?;
+        fac.create_dir("\x01", 18, SECTOR_SIZE as u32)
+            .write(writer)?;
+
+        for (index, (name, content)) in self.files.iter().enumerate() {
+            fac.create_file(
+                &format!("{name};1"),
+                19 + index as u32,
+                content.len() as u32,
+            )
+            .write(writer)?;
+        }
+
+        writer.pad_to_sector_end()?;
+
+        // Sector 19+: File Data
+        for content in self.files.values() {
+            writer.write_bytes(content)?;
+            writer.pad_to_sector_end()?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/iso9660/primary_volume_desc.rs
+++ b/src/iso9660/primary_volume_desc.rs
@@ -1,0 +1,164 @@
+use crate::iso9660::{BinaryWriter, DirRecord, SECTOR_SIZE, VolumeDesc};
+use std::io::{self, Seek, Write};
+
+#[derive(Clone, Default)]
+pub struct PrimaryVolumeDesc {
+    pub vd: VolumeDesc,
+    pub system_id: String,
+    pub volume_id: String,
+    pub volume_space_size: u32,
+    pub volume_set_size: u16,
+    pub volume_sequence_number: u16,
+    pub logical_block_size: u16,
+    pub path_table_size: u32,
+    pub lpath_table_loc: u32,
+    pub optional_lpath_table_loc: u32,
+    pub mpath_table_loc: u32,
+    pub optional_mpath_table_loc: u32,
+    pub root_dir: DirRecord,
+    pub volume_set_id: String,
+    pub publisher_id: String,
+    pub data_prepare_id: String,
+    pub application_id: String,
+    pub copyright_file_id: String,
+    pub abstract_file_id: String,
+    pub bibliographic_file_id: String,
+    pub file_structure_version: u8,
+}
+
+impl PrimaryVolumeDesc {
+    pub fn new() -> Self {
+        Self {
+            vd: VolumeDesc::new(0x01),
+            logical_block_size: SECTOR_SIZE as u16,
+            file_structure_version: 1,
+            ..Default::default()
+        }
+    }
+
+    pub fn write<T: Write + Seek>(&self, writer: &mut BinaryWriter<T>) -> io::Result<()> {
+        self.vd.write(writer)?;
+        writer.skip(1)?; // Unused
+        writer.write_padded_string(&self.system_id, 32)?;
+        writer.write_padded_string(&self.volume_id, 32)?;
+        writer.skip(8)?; // Unused
+        writer.write_u32_le_be(self.volume_space_size)?;
+        writer.skip(32)?; // Unused
+        writer.write_u16_le_be(self.volume_set_size)?;
+        writer.write_u16_le_be(self.volume_sequence_number)?;
+        writer.write_u16_le_be(self.logical_block_size)?;
+        writer.write_u32_le_be(self.path_table_size)?;
+        writer.write_u32_le(self.lpath_table_loc)?;
+        writer.write_u32_le(self.optional_lpath_table_loc)?;
+        writer.write_u32_be(self.mpath_table_loc)?;
+        writer.write_u32_be(self.optional_mpath_table_loc)?;
+        self.root_dir.write(writer)?;
+        writer.write_padded_string(&self.volume_set_id, 128)?;
+        writer.write_padded_string(&self.publisher_id, 128)?;
+        writer.write_padded_string(&self.data_prepare_id, 128)?;
+        writer.write_padded_string(&self.application_id, 128)?;
+        writer.write_padded_string(&self.copyright_file_id, 37)?;
+        writer.write_padded_string(&self.abstract_file_id, 37)?;
+        writer.write_padded_string(&self.bibliographic_file_id, 37)?;
+        writer.skip(17)?; // Volume Creation Date and Time
+        writer.skip(17)?; // Volume Modification Date and Time
+        writer.skip(17)?; // Volume Expiration Date and Time
+        writer.skip(17)?; // Volume Effective Date and Time
+        writer.write_byte(self.file_structure_version)?;
+        writer.skip(1)?; // Unused
+        writer.skip(512)?; // Application Unused
+        writer.skip(652)?; // Reserved
+        writer.write_byte(0)?; // Reserved
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_write() {
+        let mut pvd = PrimaryVolumeDesc::default();
+        pvd.vd = VolumeDesc::new(0x01);
+        pvd.system_id = "system id".to_string();
+        pvd.volume_id = "volume id".to_string();
+        pvd.volume_space_size = 0x12345678;
+        pvd.volume_set_size = 0x2345;
+        pvd.volume_sequence_number = 0x3456;
+        pvd.logical_block_size = 0x4567;
+        pvd.path_table_size = 0x56789ABC;
+        pvd.lpath_table_loc = 0x6789ABCD;
+        pvd.optional_lpath_table_loc = 0x789ABCDE;
+        pvd.mpath_table_loc = 0x89ABCDEF;
+        pvd.optional_mpath_table_loc = 0x9ABCDEF0;
+        pvd.root_dir = DirRecord::default();
+        pvd.volume_set_id = "volume set id".to_string();
+        pvd.publisher_id = "publisher id".to_string();
+        pvd.data_prepare_id = "data prepare id".to_string();
+        pvd.application_id = "application id".to_string();
+        pvd.copyright_file_id = "copyright file id".to_string();
+        pvd.abstract_file_id = "abstract file id".to_string();
+        pvd.bibliographic_file_id = "bibliographic file id".to_string();
+        pvd.file_structure_version = 0xAB;
+
+        let writer = &mut BinaryWriter::new(Cursor::new(Vec::new()));
+        pvd.write(writer).unwrap();
+
+        let result = writer.get_writer().get_ref();
+        assert_eq!(result[0], 1);
+        assert_eq!(&result[1..6], "CD001".as_bytes());
+        assert_eq!(result[6], 1);
+        assert_eq!(result[7], 0);
+        assert_eq!(
+            &result[8..40],
+            "system id                       ".as_bytes()
+        );
+        assert_eq!(
+            &result[40..72],
+            "volume id                       ".as_bytes()
+        );
+        assert_eq!(&result[72..80], &[0u8; 8]);
+        assert_eq!(&result[80..84], &[0x78, 0x56, 0x34, 0x12]);
+        assert_eq!(&result[84..88], &[0x12, 0x34, 0x56, 0x78]);
+        assert_eq!(&result[88..120], &[0u8; 32]);
+        assert_eq!(&result[120..122], &[0x45, 0x23]);
+        assert_eq!(&result[122..124], &[0x23, 0x45]);
+        assert_eq!(&result[124..126], &[0x56, 0x34]);
+        assert_eq!(&result[126..128], &[0x34, 0x56]);
+        assert_eq!(&result[128..130], &[0x67, 0x45]);
+        assert_eq!(&result[130..132], &[0x45, 0x67]);
+        assert_eq!(&result[132..136], &[0xBC, 0x9A, 0x78, 0x56]);
+        assert_eq!(&result[136..140], &[0x56, 0x78, 0x9A, 0xBC]);
+        assert_eq!(&result[140..144], &[0xCD, 0xAB, 0x89, 0x67]);
+        assert_eq!(&result[144..148], &[0xDE, 0xBC, 0x9A, 0x78]);
+        assert_eq!(&result[148..152], &[0x89, 0xAB, 0xCD, 0xEF]);
+        assert_eq!(&result[152..156], &[0x9A, 0xBC, 0xDE, 0xF0]);
+        //assert_eq!(&result[156..190], ...);
+        assert_eq!(&result[190..318], "volume set id                                                                                                                   ".as_bytes());
+        assert_eq!(&result[318..446], "publisher id                                                                                                                    ".as_bytes());
+        assert_eq!(&result[446..574], "data prepare id                                                                                                                 ".as_bytes());
+        assert_eq!(&result[574..702], "application id                                                                                                                  ".as_bytes());
+        assert_eq!(
+            &result[702..739],
+            "copyright file id                    ".as_bytes()
+        );
+        assert_eq!(
+            &result[739..776],
+            "abstract file id                     ".as_bytes()
+        );
+        assert_eq!(
+            &result[776..813],
+            "bibliographic file id                ".as_bytes()
+        );
+        assert_eq!(&result[813..830], &[0u8; 17]);
+        assert_eq!(&result[830..847], &[0u8; 17]);
+        assert_eq!(&result[847..864], &[0u8; 17]);
+        assert_eq!(&result[864..881], &[0u8; 17]);
+        assert_eq!(result[881], 0xAB);
+        assert_eq!(result[882], 0);
+        assert_eq!(&result[883..1395], &[0u8; 512]);
+        assert_eq!(&result[1395..2048], &[0u8; 653]);
+    }
+}

--- a/src/iso9660/term_volume_desc.rs
+++ b/src/iso9660/term_volume_desc.rs
@@ -1,0 +1,39 @@
+use crate::iso9660::{BinaryWriter, VolumeDesc};
+use std::io::{self, Seek, Write};
+
+#[derive(Default)]
+pub struct TermVolumeDesc {
+    pub vd: VolumeDesc,
+}
+
+impl TermVolumeDesc {
+    pub fn new() -> Self {
+        Self {
+            vd: VolumeDesc::new(0xFF),
+        }
+    }
+
+    pub fn write<T: Write + Seek>(&self, writer: &mut BinaryWriter<T>) -> io::Result<()> {
+        self.vd.write(writer)?;
+        writer.pad_to_sector_end()?; // Unused
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_write() {
+        let writer = &mut BinaryWriter::new(Cursor::new(Vec::new()));
+        TermVolumeDesc::new().write(writer).unwrap();
+
+        let result = writer.get_writer().get_ref();
+        assert_eq!(result[0], 255);
+        assert_eq!(&result[1..6], "CD001".as_bytes());
+        assert_eq!(result[6], 1);
+        assert_eq!(&result[7..2048], &[0u8; 2041]);
+    }
+}

--- a/src/iso9660/volume_desc.rs
+++ b/src/iso9660/volume_desc.rs
@@ -1,0 +1,42 @@
+use crate::iso9660::BinaryWriter;
+use std::io::{self, Seek, Write};
+
+#[derive(Clone, Default)]
+pub struct VolumeDesc {
+    pub typ: u8,
+    pub id: String,
+    pub version: u8,
+}
+
+impl VolumeDesc {
+    pub fn new(typ: u8) -> Self {
+        Self {
+            typ,
+            id: "CD001".to_string(),
+            version: 1,
+        }
+    }
+
+    pub fn write<T: Write + Seek>(&self, writer: &mut BinaryWriter<T>) -> io::Result<u64> {
+        writer.write_byte(self.typ)?;
+        writer.write_padded_string(&self.id, 5)?;
+        writer.write_byte(self.version)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_volume_desc_write() {
+        let writer = &mut BinaryWriter::new(Cursor::new(Vec::new()));
+        VolumeDesc::new(2).write(writer).unwrap();
+
+        let result = writer.get_writer().get_ref();
+        assert_eq!(result[0], 2);
+        assert_eq!(&result[1..6], &[67, 68, 48, 48, 49]);
+        assert_eq!(result[6], 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod error;
 mod fs;
 mod image;
 mod instance;
+mod iso9660;
 mod model;
 mod qemu;
 mod ssh_cmd;


### PR DESCRIPTION
Introduces a new ISO9660 writer in pure Rust to generate cloud-init disks. This is an initial step toward replacing the `mkisofs` system call dependency.

By default, the existing `mkisofs` implementation remains active to ensure stability. The new Rust implementation is opt-in via the CLI flag:
```
  cubic create --iso9660=rust [...]
```

This feature is marked as experimental and may change in future releases.