### PR TITLE
fix: resolve CI build errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Build Dependencies
-        run: sudo apt-get install -y ${{ matrix.packages }}
+        run: sudo apt-get update && sudo apt-get install -y ${{ matrix.packages }}
 
       - name: Setup Rust
         run: rustup target add ${{ matrix.target }}


### PR DESCRIPTION
Run apt-get update before installing packages to ensure that the package index is up-to-date.