### PR TITLE
refactor: modularize VM image provider logic

### DIFF
--- a/src/arch.rs
+++ b/src/arch.rs
@@ -17,13 +17,24 @@ impl Arch {
             _ => Result::Err(Error::UnknownArch(arch.to_string())),
         }
     }
+
+    pub fn as_vendor_str(&self) -> &str {
+        match &self {
+            Arch::AMD64 => "amd64",
+            Arch::ARM64 => "arm64",
+        }
+    }
+
+    pub fn as_canonical_str(&self) -> &str {
+        match &self {
+            Arch::AMD64 => "x86_64",
+            Arch::ARM64 => "aarch64",
+        }
+    }
 }
 
 impl fmt::Display for Arch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &self {
-            Arch::AMD64 => write!(f, "amd64"),
-            Arch::ARM64 => write!(f, "arm64"),
-        }
+        write!(f, "{}", self.as_vendor_str())
     }
 }

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -6,7 +6,7 @@ use crate::view::SpinnerView;
 
 pub fn fetch_image_list(env: &Environment) -> Vec<Image> {
     let mut spinner = SpinnerView::new("Fetching image list".to_string());
-    let images: Vec<Image> = ImageFactory::new(env).create_images().unwrap_or_default();
+    let images: Vec<Image> = ImageFactory::new(env).get_all_images().unwrap_or_default();
     spinner.stop();
     images
 }
@@ -17,7 +17,7 @@ pub fn fetch_image_info(env: &Environment, image: &ImageName) -> Result<Image> {
         image.get_vendor(),
         image.get_name()
     ));
-    let image = ImageFactory::new(env).get_image(image);
+    let image = ImageFactory::new(env).find_image(image);
     spinner.stop();
     image
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,29 +1,43 @@
+mod archlinux_image_provider;
+mod debian_image_provider;
+mod fedora_image_provider;
 mod image_cache;
 mod image_dao;
 mod image_factory;
 mod image_fetcher;
 mod image_name;
+mod image_provider;
 mod image_store;
 mod image_store_mock;
+mod opensuse_image_provider;
+mod rockylinux_image_provider;
+mod ubuntu_image_provider;
 
 use crate::arch::Arch;
+pub use archlinux_image_provider::*;
+pub use debian_image_provider::*;
+pub use fedora_image_provider::*;
 pub use image_cache::*;
 pub use image_dao::*;
 pub use image_factory::*;
 pub use image_fetcher::*;
 pub use image_name::*;
+pub use image_provider::*;
 pub use image_store::*;
 #[cfg(test)]
 pub use image_store_mock::tests::ImageStoreMock;
+pub use opensuse_image_provider::*;
+pub use rockylinux_image_provider::*;
 use serde::{Deserialize, Serialize};
+pub use ubuntu_image_provider::*;
 
-#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum HashAlg {
     Sha512,
     Sha256,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Image {
     pub vendor: String,
     pub names: Vec<String>,
@@ -65,5 +79,34 @@ impl Image {
 
     pub fn to_file_name(&self) -> String {
         format!("{}_{}_{}", self.vendor, self.get_name(), self.arch)
+    }
+}
+
+use std::cmp::{Ord, Ordering};
+
+impl Ord for Image {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let mut result = self.vendor.cmp(&other.vendor);
+
+        if result == Ordering::Equal {
+            let a = &self.names[0];
+            let b = &other.names[0];
+
+            if let Ok(a) = a.parse::<u32>()
+                && let Ok(b) = b.parse::<u32>()
+            {
+                result = a.cmp(&b);
+            } else {
+                result = a.cmp(b);
+            }
+        }
+
+        result
+    }
+}
+
+impl PartialOrd for Image {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }

--- a/src/image/archlinux_image_provider.rs
+++ b/src/image/archlinux_image_provider.rs
@@ -1,0 +1,35 @@
+use crate::arch::Arch;
+use crate::image::{HashAlg, ImageInfo, ImageProvider};
+
+pub struct ArchLinuxImageProvider {}
+
+impl ImageProvider for ArchLinuxImageProvider {
+    fn get_vendor(&self) -> String {
+        "archlinux".to_string()
+    }
+
+    fn get_image_list_url(&self) -> String {
+        "https://geo.mirror.pkgbuild.com/images/".to_string()
+    }
+
+    fn get_image_names(&self, _content: &str) -> Vec<String> {
+        vec!["latest".to_string()]
+    }
+
+    fn get_image_dir_url(&self, _name: &str, _arch: Arch) -> String {
+        format!("{}latest/", self.get_image_list_url())
+    }
+
+    fn get_image_info(&self, _content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
+        let base_url = self.get_image_dir_url(name, arch);
+        let arch_name = arch.as_canonical_str();
+        let image_url = format!("{base_url}Arch-Linux-{arch_name}-cloudimg.qcow2");
+        let checksum_url = format!("{image_url}.SHA256");
+        Some(ImageInfo {
+            names: vec![name.to_string()],
+            image_url,
+            checksum_url,
+            hash_alg: HashAlg::Sha256,
+        })
+    }
+}

--- a/src/image/debian_image_provider.rs
+++ b/src/image/debian_image_provider.rs
@@ -1,0 +1,46 @@
+use crate::arch::Arch;
+use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::util;
+
+pub struct DebianImageProvider {}
+
+impl DebianImageProvider {
+    fn get_version_from_content(&self, content: &str) -> Option<String> {
+        util::find_and_extract(r#"href=\"debian-([0-9]+)-generic-.*.qcow2\""#, content)
+            .into_iter()
+            .next()
+    }
+}
+
+impl ImageProvider for DebianImageProvider {
+    fn get_vendor(&self) -> String {
+        "debian".to_string()
+    }
+
+    fn get_image_list_url(&self) -> String {
+        "https://cloud.debian.org/images/cloud/".to_string()
+    }
+
+    fn get_image_names(&self, content: &str) -> Vec<String> {
+        util::find_and_extract(r#"<a href=\"([a-z]+)/\">[a-z]+/</a>"#, content)
+    }
+
+    fn get_image_dir_url(&self, name: &str, _arch: Arch) -> String {
+        format!("{}{name}/latest/", self.get_image_list_url(),)
+    }
+
+    fn get_image_info(&self, content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
+        self.get_version_from_content(content).map(|version| {
+            let base_url = self.get_image_dir_url(name, arch);
+            let arch_name = arch.to_string();
+            let image_url = format!("{base_url}debian-{version}-generic-{arch_name}.qcow2");
+            let checksum_url = format!("{base_url}SHA512SUMS");
+            ImageInfo {
+                names: vec![version.to_string(), name.to_string()],
+                image_url,
+                checksum_url,
+                hash_alg: HashAlg::Sha512,
+            }
+        })
+    }
+}

--- a/src/image/fedora_image_provider.rs
+++ b/src/image/fedora_image_provider.rs
@@ -1,0 +1,55 @@
+use crate::arch::Arch;
+use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::util;
+
+pub struct FedoraImageProvider {}
+
+impl FedoraImageProvider {
+    fn get_version_from_content(&self, content: &str) -> Option<String> {
+        util::find_and_extract(
+            r#"href=\"Fedora-Cloud-Base-Generic-[0-9]+-(.*)\..+\.qcow2\""#,
+            content,
+        )
+        .into_iter()
+        .next()
+    }
+}
+
+impl ImageProvider for FedoraImageProvider {
+    fn get_vendor(&self) -> String {
+        "fedora".to_string()
+    }
+
+    fn get_image_list_url(&self) -> String {
+        "https://download.fedoraproject.org/pub/fedora/linux/releases/".to_string()
+    }
+
+    fn get_image_names(&self, content: &str) -> Vec<String> {
+        util::find_and_extract(r#">([0-9]+)/<"#, content)
+            .into_iter()
+            .filter(|version| version.parse::<u32>().map(|v| v > 40).unwrap_or_default())
+            .collect()
+    }
+
+    fn get_image_dir_url(&self, name: &str, arch: Arch) -> String {
+        let base_url = self.get_image_list_url();
+        let arch_name = arch.as_canonical_str();
+        format!("{base_url}{name}/Cloud/{arch_name}/images/",)
+    }
+
+    fn get_image_info(&self, content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
+        self.get_version_from_content(content).map(|version| {
+            let base_url = self.get_image_dir_url(name, arch);
+            let arch_name = arch.as_canonical_str();
+            let image_url =
+                format!("{base_url}Fedora-Cloud-Base-Generic-{name}-{version}.{arch_name}.qcow2");
+            let checksum_url = format!("{base_url}Fedora-Cloud-{name}-{arch_name}-CHECKSUM.qcow2");
+            ImageInfo {
+                names: vec![name.to_string()],
+                image_url,
+                checksum_url,
+                hash_alg: HashAlg::Sha256,
+            }
+        })
+    }
+}

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -1,243 +1,17 @@
 use crate::arch::Arch;
 use crate::env::Environment;
 use crate::error::{Error, Result};
-use crate::image::{HashAlg, Image, ImageCache, ImageName};
+use crate::image::{self, Image, ImageCache, ImageName};
 use crate::web::WebClient;
-use regex::Regex;
-use std::collections::HashMap;
-use std::sync::LazyLock;
 
-struct ImageLocation {
-    path: &'static str,
-    pattern: LazyLock<Regex>,
-    image_name: &'static str,
-    checksum_name: &'static str,
-    hash_alg: HashAlg,
-}
-
-struct Distro {
-    vendor: &'static str,
-    name_pattern: &'static str,
-    version_pattern: &'static str,
-    overview_url: &'static str,
-    overview_pattern: LazyLock<Regex>,
-    images: HashMap<Arch, ImageLocation>,
-}
-
-static DISTROS: LazyLock<Vec<Distro>> = LazyLock::new(|| {
-    vec![
-        Distro {
-            vendor: "archlinux",
-            name_pattern: "(name)",
-            version_pattern: "(name)",
-            overview_url: "https://geo.mirror.pkgbuild.com/images/",
-            overview_pattern: LazyLock::new(|| Regex::new(r">([a-z]+)/<").unwrap()),
-            images: HashMap::from([
-                (
-                    Arch::AMD64,
-                    ImageLocation {
-                        path: "latest/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(r">(Arch-Linux-x86_64-cloudimg.qcow2)<").unwrap()
-                        }),
-                        image_name: "Arch-Linux-x86_64-cloudimg.qcow2",
-                        checksum_name: "Arch-Linux-x86_64-cloudimg.qcow2.SHA256",
-                        hash_alg: HashAlg::Sha256,
-                    },
-                ),
-                (
-                    Arch::ARM64,
-                    ImageLocation {
-                        path: "latest/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(r">(Arch-Linux-arm64-cloudimg.qcow2)<").unwrap()
-                        }),
-                        image_name: "Arch-Linux-arm64-cloudimg.qcow2",
-                        checksum_name: "Arch-Linux-arm64-cloudimg.qcow2.SHA256",
-                        hash_alg: HashAlg::Sha256,
-                    },
-                ),
-            ]),
-        },
-        Distro {
-            vendor: "debian",
-            name_pattern: "(name)",
-            version_pattern: "(version)",
-            overview_url: "https://cloud.debian.org/images/cloud/",
-            overview_pattern: LazyLock::new(|| Regex::new(r">([a-z]+)/<").unwrap()),
-            images: HashMap::from([
-                (
-                    Arch::AMD64,
-                    ImageLocation {
-                        path: "(name)/latest/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(r">debian-([0-9]+)-generic-amd64.qcow2<").unwrap()
-                        }),
-                        image_name: "debian-(version)-generic-amd64.qcow2",
-                        checksum_name: "SHA512SUMS",
-                        hash_alg: HashAlg::Sha512,
-                    },
-                ),
-                (
-                    Arch::ARM64,
-                    ImageLocation {
-                        path: "(name)/latest/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(r">debian-([0-9]+)-generic-arm64.qcow2<").unwrap()
-                        }),
-                        image_name: "debian-(version)-generic-arm64.qcow2",
-                        checksum_name: "SHA512SUMS",
-                        hash_alg: HashAlg::Sha512,
-                    },
-                ),
-            ]),
-        },
-        Distro {
-            vendor: "fedora",
-            name_pattern: "(name)",
-            version_pattern: "(name)",
-            overview_url: "https://download.fedoraproject.org/pub/fedora/linux/releases/",
-            overview_pattern: LazyLock::new(|| Regex::new(r">([4-9][0-9]+)/<").unwrap()),
-            images: HashMap::from([
-                (
-                    Arch::AMD64,
-                    ImageLocation {
-                        path: "(name)/Cloud/x86_64/images/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(
-                                r"Fedora-Cloud-Base-Generic-([0-9]+-[0-9]+.[0-9]+).x86_64.qcow2",
-                            )
-                            .unwrap()
-                        }),
-                        image_name: "Fedora-Cloud-Base-Generic-(version).x86_64.qcow2",
-                        checksum_name: "Fedora-Cloud-(version)-x86_64-CHECKSUM",
-                        hash_alg: HashAlg::Sha256,
-                    },
-                ),
-                (
-                    Arch::ARM64,
-                    ImageLocation {
-                        path: "(name)/Cloud/aarch64/images/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(
-                                r"Fedora-Cloud-Base-Generic-([0-9]+-[0-9]+.[0-9]+).aarch64.qcow2",
-                            )
-                            .unwrap()
-                        }),
-                        image_name: "Fedora-Cloud-Base-Generic-(version).aarch64.qcow2",
-                        checksum_name: "Fedora-Cloud-(version)-aarch64-CHECKSUM",
-                        hash_alg: HashAlg::Sha256,
-                    },
-                ),
-            ]),
-        },
-        Distro {
-            vendor: "opensuse",
-            name_pattern: "(name)",
-            version_pattern: "(name)",
-            overview_url: "https://download.opensuse.org/repositories/Cloud:/Images:/",
-            overview_pattern: LazyLock::new(|| Regex::new(r">Leap_([0-9]+\.[0-9]+)/<").unwrap()),
-            images: HashMap::from([
-                (
-                    Arch::AMD64,
-                    ImageLocation {
-                        path: "Leap_(name)/images/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(r">(openSUSE-Leap-[0-9]+.[0-9]+.x86_64-NoCloud.qcow2)<")
-                                .unwrap()
-                        }),
-                        image_name: "(version)",
-                        checksum_name: "(version).sha256",
-                        hash_alg: HashAlg::Sha256,
-                    },
-                ),
-                (
-                    Arch::ARM64,
-                    ImageLocation {
-                        path: "Leap_(name)/images/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(r">(openSUSE-Leap-[0-9]+.[0-9]+.aarch64-NoCloud.qcow2)<")
-                                .unwrap()
-                        }),
-                        image_name: "(version)",
-                        checksum_name: "(version).sha256",
-                        hash_alg: HashAlg::Sha256,
-                    },
-                ),
-            ]),
-        },
-        Distro {
-            vendor: "rockylinux",
-            name_pattern: "(name)",
-            version_pattern: "(name)",
-            overview_url: "https://dl.rockylinux.org/pub/rocky/",
-            overview_pattern: LazyLock::new(|| Regex::new(r">([0-9]+)/<").unwrap()),
-            images: HashMap::from([
-                (
-                    Arch::AMD64,
-                    ImageLocation {
-                        path: "(name)/images/x86_64/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(r">Rocky-([0-9]+)-GenericCloud-Base.latest.x86_64.qcow2<")
-                                .unwrap()
-                        }),
-                        image_name: "Rocky-(name)-GenericCloud-Base.latest.x86_64.qcow2",
-                        checksum_name: "Rocky-(name)-GenericCloud-Base.latest.x86_64.qcow2.CHECKSUM",
-                        hash_alg: HashAlg::Sha256,
-                    },
-                ),
-                (
-                    Arch::ARM64,
-                    ImageLocation {
-                        path: "(name)/images/aarch64/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(r">Rocky-([0-9]+)-GenericCloud-Base.latest.aarch64.qcow2<")
-                                .unwrap()
-                        }),
-                        image_name: "Rocky-(name)-GenericCloud-Base.latest.aarch64.qcow2",
-                        checksum_name: "Rocky-(name)-GenericCloud-Base.latest.aarch64.qcow2.CHECKSUM",
-                        hash_alg: HashAlg::Sha256,
-                    },
-                ),
-            ]),
-        },
-        Distro {
-            vendor: "ubuntu",
-            name_pattern: "(name)",
-            version_pattern: "(version)",
-            overview_url: "https://cloud-images.ubuntu.com/minimal/releases/",
-            overview_pattern: LazyLock::new(|| Regex::new(r">([a-z]+)/<").unwrap()),
-            images: HashMap::from([
-                (
-                    Arch::AMD64,
-                    ImageLocation {
-                        path: "(name)/release/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(r">ubuntu-([0-9]+\.[0-9]+)-minimal-cloudimg-amd64.img<")
-                                .unwrap()
-                        }),
-                        image_name: "ubuntu-(version)-minimal-cloudimg-amd64.img",
-                        checksum_name: "SHA256SUMS",
-                        hash_alg: HashAlg::Sha256,
-                    },
-                ),
-                (
-                    Arch::ARM64,
-                    ImageLocation {
-                        path: "(name)/release/",
-                        pattern: LazyLock::new(|| {
-                            Regex::new(r">ubuntu-([0-9]+\.[0-9]+)-minimal-cloudimg-arm64.img<")
-                                .unwrap()
-                        }),
-                        image_name: "ubuntu-(version)-minimal-cloudimg-arm64.img",
-                        checksum_name: "SHA256SUMS",
-                        hash_alg: HashAlg::Sha256,
-                    },
-                ),
-            ]),
-        },
-    ]
-});
+const IMAGE_PROVIDERS: &[&dyn image::ImageProvider] = &[
+    &image::ArchLinuxImageProvider {},
+    &image::DebianImageProvider {},
+    &image::FedoraImageProvider {},
+    &image::OpenSuseImageProvider {},
+    &image::RockyLinuxImageProvider {},
+    &image::UbuntuImageProvider {},
+];
 
 pub struct ImageFactory {
     env: Environment,
@@ -248,82 +22,96 @@ impl ImageFactory {
         Self { env: env.clone() }
     }
 
-    fn match_content(web: &mut WebClient, url: &str, pattern: &LazyLock<Regex>) -> Vec<String> {
-        web.download_content(url)
+    fn filter_arch(filter: Option<ImageName>) -> Vec<Arch> {
+        let mut arches = vec![Arch::AMD64, Arch::ARM64];
+
+        if let Some(filter) = filter {
+            arches.retain(|a| filter.get_arch() == *a);
+        }
+
+        arches
+    }
+
+    fn get_images_from_provider_name_arch(
+        web: &mut WebClient,
+        image_provider: &dyn image::ImageProvider,
+        name: &str,
+        arch: Arch,
+        filter: Option<ImageName>,
+    ) -> Option<Image> {
+        let image_content = web
+            .download_content(&image_provider.get_image_dir_url(name, arch))
+            .unwrap();
+
+        image_provider
+            .get_image_info(&image_content, name, arch)
+            .and_then(|image_info| {
+                web.get_file_size(&image_info.image_url)
+                    .ok()
+                    .and_then(|size| size)
+                    .and_then(|size| {
+                        if let Some(name) = &filter
+                            && image_info.names.contains(&name.get_name().to_string())
+                        {
+                            None
+                        } else {
+                            Some(Image {
+                                vendor: image_provider.get_vendor(),
+                                names: image_info.names.clone(),
+                                arch,
+                                image_url: image_info.image_url.to_string(),
+                                checksum_url: image_info.checksum_url.to_string(),
+                                hash_alg: image_info.hash_alg,
+                                size: Some(size),
+                            })
+                        }
+                    })
+            })
+    }
+
+    fn get_images_from_provider(
+        web: &mut WebClient,
+        image_provider: &dyn image::ImageProvider,
+        filter: Option<ImageName>,
+    ) -> Vec<Image> {
+        web.download_content(&image_provider.get_image_list_url())
             .map(|content| {
-                pattern
-                    .captures_iter(&content)
-                    .map(|content| content.extract::<1>())
-                    .map(|(_, values)| values[0].to_string())
+                image_provider
+                    .get_image_names(&content)
+                    .into_iter()
+                    .flat_map(|name| {
+                        Self::filter_arch(filter.clone())
+                            .into_iter()
+                            .flat_map(|arch| {
+                                Self::get_images_from_provider_name_arch(
+                                    web,
+                                    image_provider,
+                                    &name,
+                                    arch,
+                                    filter.clone(),
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                    })
                     .collect()
             })
             .unwrap_or_default()
     }
 
-    fn replace_vars(text: &str, name: &str, version: &str) -> String {
-        text.replace("(name)", name).replace("(version)", version)
-    }
-
-    fn add_images(
-        web: &mut WebClient,
-        distro: &Distro,
-        filter_name: Option<ImageName>,
-    ) -> Vec<Image> {
-        let mut images = Vec::new();
-        for name in Self::match_content(web, distro.overview_url, &distro.overview_pattern) {
-            for (arch, loc) in &distro.images {
-                if let Some(filter_name) = &filter_name
-                    && *arch != filter_name.get_arch()
-                {
-                    continue;
-                }
-
-                let loc_url = format!(
-                    "{}{}",
-                    distro.overview_url,
-                    loc.path.replace("(name)", &name)
-                );
-                for version in Self::match_content(web, &loc_url, &loc.pattern) {
-                    let image_url = format!(
-                        "{loc_url}{}",
-                        Self::replace_vars(loc.image_name, &name, &version)
-                    );
-                    let checksum_url = format!(
-                        "{loc_url}{}",
-                        Self::replace_vars(loc.checksum_name, &name, &version)
-                    );
-                    let version = Self::replace_vars(distro.version_pattern, &name, &version);
-                    let codename = Self::replace_vars(distro.name_pattern, &name, &version);
-                    let mut names = vec![version.clone()];
-                    if version != codename {
-                        names.push(codename);
-                    }
-
-                    if let Some(filter_name) = &filter_name
-                        && !names.contains(&filter_name.get_name().to_string())
-                    {
-                        continue;
-                    }
-
-                    if let Ok(size) = web.get_file_size(&image_url) {
-                        images.push(Image {
-                            vendor: distro.vendor.to_string(),
-                            names,
-                            arch: *arch,
-                            image_url,
-                            checksum_url,
-                            hash_alg: loc.hash_alg,
-                            size,
-                        })
-                    }
-                }
-            }
-        }
-
+    fn get_images(web: &mut WebClient, filter: Option<ImageName>) -> Vec<Image> {
+        let mut images = IMAGE_PROVIDERS
+            .iter()
+            .filter(|p| filter.is_none() || filter.as_ref().unwrap().get_vendor() == p.get_vendor())
+            .flat_map(|provider| {
+                Self::get_images_from_provider(web, *provider, filter.clone())
+                //.sort_by(|a, b| provider.compare(a, b))
+            })
+            .collect::<Vec<_>>();
+        images.sort();
         images
     }
 
-    pub fn create_images(&self) -> Result<Vec<Image>> {
+    fn read_images(&self, filter: Option<ImageName>) -> Result<Vec<Image>> {
         // Read cache
         let cache = ImageCache::read_from_file(&self.env.get_image_cache_file());
 
@@ -331,56 +119,50 @@ impl ImageFactory {
         if let Some(cache) = &cache
             && cache.is_valid()
         {
-            return Ok(cache.images.clone());
-        }
-
-        // Fetch images
-        let web = &mut WebClient::new()?;
-        let images: Vec<Image> = DISTROS
-            .iter()
-            .flat_map(|distro| Self::add_images(web, distro, None))
-            .collect();
-
-        // Return cache if fetching failed
-        if images.is_empty() {
-            if let Some(cache) = &cache {
+            if let Some(name) = filter {
+                if let Some(image) = cache.images.iter().find(|image| {
+                    (image.vendor == name.get_vendor())
+                        && (image.arch == name.get_arch())
+                        && image.names.contains(&name.get_name().to_string())
+                }) {
+                    return Ok(vec![image.clone()]);
+                } else {
+                    return Ok(Vec::new());
+                }
+            } else {
                 return Ok(cache.images.clone());
             }
-        } else {
-            // Write cache
-            ImageCache::new(images.clone()).write_to_file(&self.env.get_image_cache_file());
         }
 
-        Ok(images)
+        // Fetch image info
+        let images = Self::get_images(&mut WebClient::new()?, filter.clone());
+
+        // Return cache if fetching failed
+        Ok(
+            if images.is_empty()
+                && let Some(cache) = &cache
+            {
+                cache.images.clone()
+            } else {
+                // Write cache
+                if filter.is_none() {
+                    ImageCache::new(images.clone()).write_to_file(&self.env.get_image_cache_file());
+                }
+                images
+            },
+        )
     }
 
-    pub fn get_image(&self, name: &ImageName) -> Result<Image> {
-        // Read cache
-        let cache = ImageCache::read_from_file(&self.env.get_image_cache_file());
+    pub fn get_all_images(&self) -> Result<Vec<Image>> {
+        self.read_images(None)
+    }
 
-        // Use cache if valid
-        if let Some(cache) = &cache
-            && cache.is_valid()
-            && let Some(image) = cache.images.iter().find(|image| {
-                (image.vendor == name.get_vendor())
-                    && (image.arch == name.get_arch())
-                    && image.names.contains(&name.get_name().to_string())
-            })
-        {
-            return Ok(image.clone());
-        }
-
-        // Fetch image
-        let web = &mut WebClient::new()?;
-        DISTROS
-            .iter()
-            .filter(|distro| distro.vendor == name.get_vendor())
-            .flat_map(|distro| Self::add_images(web, distro, Some(name.clone())))
-            .find(|image| {
-                (image.vendor == name.get_vendor())
-                    && (image.arch == name.get_arch())
-                    && image.names.contains(&name.get_name().to_string())
-            })
-            .ok_or(Error::UnknownImage(name.to_string()))
+    pub fn find_image(&self, name: &ImageName) -> Result<Image> {
+        self.read_images(Some(name.clone())).and_then(|images| {
+            images
+                .into_iter()
+                .next()
+                .ok_or(Error::UnknownImage(name.to_string()))
+        })
     }
 }

--- a/src/image/image_provider.rs
+++ b/src/image/image_provider.rs
@@ -1,0 +1,19 @@
+use crate::arch::Arch;
+use crate::image::HashAlg;
+
+pub struct ImageInfo {
+    pub names: Vec<String>,
+    pub image_url: String,
+    pub checksum_url: String,
+    pub hash_alg: HashAlg,
+}
+
+pub trait ImageProvider {
+    fn get_vendor(&self) -> String;
+
+    fn get_image_list_url(&self) -> String;
+    fn get_image_names(&self, content: &str) -> Vec<String>;
+
+    fn get_image_dir_url(&self, name: &str, arch: Arch) -> String;
+    fn get_image_info(&self, content: &str, name: &str, arch: Arch) -> Option<ImageInfo>;
+}

--- a/src/image/opensuse_image_provider.rs
+++ b/src/image/opensuse_image_provider.rs
@@ -1,0 +1,37 @@
+use crate::arch::Arch;
+use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::util;
+
+pub struct OpenSuseImageProvider {}
+
+impl ImageProvider for OpenSuseImageProvider {
+    fn get_vendor(&self) -> String {
+        "opensuse".to_string()
+    }
+
+    fn get_image_list_url(&self) -> String {
+        "https://download.opensuse.org/repositories/Cloud:/Images:/".to_string()
+    }
+
+    fn get_image_names(&self, content: &str) -> Vec<String> {
+        util::find_and_extract(r#">Leap_([0-9]+\.[0-9]+)/<"#, content)
+    }
+
+    fn get_image_dir_url(&self, name: &str, _arch: Arch) -> String {
+        let base_url = self.get_image_list_url();
+        format!("{base_url}Leap_{name}/images/",)
+    }
+
+    fn get_image_info(&self, _content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
+        let base_url = self.get_image_dir_url(name, arch);
+        let arch_name = arch.as_canonical_str();
+        let image_url = format!("{base_url}openSUSE-Leap-{name}.{arch_name}-NoCloud.qcow2");
+        let checksum_url = format!("{image_url}.sha256");
+        Some(ImageInfo {
+            names: vec![name.to_string()],
+            image_url,
+            checksum_url,
+            hash_alg: HashAlg::Sha256,
+        })
+    }
+}

--- a/src/image/rockylinux_image_provider.rs
+++ b/src/image/rockylinux_image_provider.rs
@@ -1,0 +1,39 @@
+use crate::arch::Arch;
+use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::util;
+
+pub struct RockyLinuxImageProvider {}
+
+impl ImageProvider for RockyLinuxImageProvider {
+    fn get_vendor(&self) -> String {
+        "rockylinux".to_string()
+    }
+
+    fn get_image_list_url(&self) -> String {
+        "https://dl.rockylinux.org/pub/rocky/".to_string()
+    }
+
+    fn get_image_names(&self, content: &str) -> Vec<String> {
+        util::find_and_extract(r#">([0-9]+)/<"#, content)
+    }
+
+    fn get_image_dir_url(&self, name: &str, arch: Arch) -> String {
+        let base_url = self.get_image_list_url();
+        let arch_name = arch.as_canonical_str();
+        format!("{base_url}{name}/images/{arch_name}/",)
+    }
+
+    fn get_image_info(&self, _content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
+        let base_url = self.get_image_dir_url(name, arch);
+        let arch_name = arch.as_canonical_str();
+        let image_url =
+            format!("{base_url}Rocky-{name}-GenericCloud-Base.latest.{arch_name}.qcow2");
+        let checksum_url = format!("{image_url}.CHECKSUM");
+        Some(ImageInfo {
+            names: vec![name.to_string()],
+            image_url,
+            checksum_url,
+            hash_alg: HashAlg::Sha256,
+        })
+    }
+}

--- a/src/image/ubuntu_image_provider.rs
+++ b/src/image/ubuntu_image_provider.rs
@@ -1,0 +1,49 @@
+use crate::arch::Arch;
+use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::util;
+
+pub struct UbuntuImageProvider {}
+
+impl UbuntuImageProvider {
+    fn get_version_from_content(&self, content: &str) -> Option<String> {
+        util::find_and_extract(
+            r#"href=\"ubuntu-([0-9]+\.[0-9]+)-minimal-cloudimg-.*.img\""#,
+            content,
+        )
+        .into_iter()
+        .next()
+    }
+}
+
+impl ImageProvider for UbuntuImageProvider {
+    fn get_vendor(&self) -> String {
+        "ubuntu".to_string()
+    }
+
+    fn get_image_list_url(&self) -> String {
+        "https://cloud-images.ubuntu.com/minimal/releases/".to_string()
+    }
+
+    fn get_image_names(&self, content: &str) -> Vec<String> {
+        util::find_and_extract(r#"href=\"([a-z]+)/\""#, content)
+    }
+
+    fn get_image_dir_url(&self, name: &str, _arch: Arch) -> String {
+        format!("{}{name}/release/", self.get_image_list_url(),)
+    }
+
+    fn get_image_info(&self, content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
+        self.get_version_from_content(content).map(|version| {
+            let base_url = self.get_image_dir_url(name, arch);
+            let arch_name = arch.to_string();
+            let image_url = format!("{base_url}ubuntu-{version}-minimal-cloudimg-{arch_name}.img");
+            let checksum_url = format!("{base_url}SHA256SUMS");
+            ImageInfo {
+                names: vec![version.to_string(), name.to_string()],
+                image_url,
+                checksum_url,
+                hash_alg: HashAlg::Sha256,
+            }
+        })
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 mod async_caller;
 mod hex;
 mod input;
+mod string;
 mod system_command;
 #[cfg(not(windows))]
 mod terminal;
@@ -8,6 +9,7 @@ mod terminal;
 pub use async_caller::*;
 pub use hex::*;
 pub use input::*;
+pub use string::*;
 pub use system_command::*;
 #[cfg(not(windows))]
 pub use terminal::*;

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -1,0 +1,26 @@
+use regex::Regex;
+
+pub fn find_and_extract(regex: &str, input: &str) -> Vec<String> {
+    Regex::new(regex)
+        .unwrap()
+        .captures_iter(input)
+        .map(|content| content.extract::<1>())
+        .map(|(_, values)| values[0].to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_extract() {
+        assert_eq!(
+            &find_and_extract(
+                ">([a-z]+)/<",
+                "<p>buster/</p>\n<p>bookworm/</p>\n<p>trixie/</p>\n"
+            ),
+            &["buster", "bookworm", "trixie"]
+        )
+    }
+}


### PR DESCRIPTION
Split the single VM image source file into multiple provider-specific files. This improves extensibility and simplifies the process of adding new image providers.