### PR TITLE
feat: add AlmaLinux guest OS support (#337)

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -1,3 +1,4 @@
+mod almalinux_image_provider;
 mod archlinux_image_provider;
 mod debian_image_provider;
 mod fedora_image_provider;
@@ -14,6 +15,7 @@ mod rockylinux_image_provider;
 mod ubuntu_image_provider;
 
 use crate::arch::Arch;
+pub use almalinux_image_provider::*;
 pub use archlinux_image_provider::*;
 pub use debian_image_provider::*;
 pub use fedora_image_provider::*;

--- a/src/image/almalinux_image_provider.rs
+++ b/src/image/almalinux_image_provider.rs
@@ -1,0 +1,38 @@
+use crate::arch::Arch;
+use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::util;
+
+pub struct AlmaLinuxImageProvider {}
+
+impl ImageProvider for AlmaLinuxImageProvider {
+    fn get_vendor(&self) -> String {
+        "almalinux".to_string()
+    }
+
+    fn get_image_list_url(&self) -> String {
+        "https://raw.repo.almalinux.org/almalinux/".to_string()
+    }
+
+    fn get_image_names(&self, content: &str) -> Vec<String> {
+        util::find_and_extract(r#">([0-9]+)/<"#, content)
+    }
+
+    fn get_image_dir_url(&self, name: &str, arch: Arch) -> String {
+        let base_url = self.get_image_list_url();
+        let arch_name = arch.as_canonical_str();
+        format!("{base_url}{name}/cloud/{arch_name}/images/",)
+    }
+
+    fn get_image_info(&self, _content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
+        let base_url = self.get_image_dir_url(name, arch);
+        let arch_name = arch.as_canonical_str();
+        let image_url = format!("{base_url}AlmaLinux-{name}-GenericCloud-latest.{arch_name}.qcow2");
+        let checksum_url = format!("{base_url}CHECKSUM");
+        Some(ImageInfo {
+            names: vec![name.to_string()],
+            image_url,
+            checksum_url,
+            hash_alg: HashAlg::Sha256,
+        })
+    }
+}

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -5,6 +5,7 @@ use crate::image::{self, Image, ImageCache, ImageName};
 use crate::web::WebClient;
 
 const IMAGE_PROVIDERS: &[&dyn image::ImageProvider] = &[
+    &image::AlmaLinuxImageProvider {},
     &image::ArchLinuxImageProvider {},
     &image::DebianImageProvider {},
     &image::FedoraImageProvider {},


### PR DESCRIPTION
Integrate AlmaLinux into the VM image provider list to enable downloading official generic cloud images with cloud-init.