### PR TITLE
Simplify ImageProvider Interface

### DIFF
--- a/src/image/almalinux_image_provider.rs
+++ b/src/image/almalinux_image_provider.rs
@@ -1,38 +1,41 @@
 use crate::arch::Arch;
-use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::image::{HashAlg, ImageProvider};
 use crate::util;
 
 pub struct AlmaLinuxImageProvider {}
 
 impl ImageProvider for AlmaLinuxImageProvider {
-    fn get_vendor(&self) -> String {
-        "almalinux".to_string()
+    fn get_vendor(&self) -> &str {
+        "almalinux"
     }
 
-    fn get_image_list_url(&self) -> String {
-        "https://raw.repo.almalinux.org/almalinux/".to_string()
+    fn get_base_url(&self) -> &str {
+        "https://raw.repo.almalinux.org/almalinux/"
     }
 
-    fn get_image_names(&self, content: &str) -> Vec<String> {
+    fn find_image_names(&self, content: &str) -> Vec<String> {
         util::find_and_extract(r#">([0-9]+)/<"#, content)
     }
 
-    fn get_image_dir_url(&self, name: &str, arch: Arch) -> String {
-        let base_url = self.get_image_list_url();
+    fn get_image_dir_path(&self, name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
-        format!("{base_url}{name}/cloud/{arch_name}/images/",)
+        format!("{name}/cloud/{arch_name}/images/",)
     }
 
-    fn get_image_info(&self, _content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
-        let base_url = self.get_image_dir_url(name, arch);
+    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
+        vec![name.to_string()]
+    }
+
+    fn get_image_file_pattern(&self, name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
-        let image_url = format!("{base_url}AlmaLinux-{name}-GenericCloud-latest.{arch_name}.qcow2");
-        let checksum_url = format!("{base_url}CHECKSUM");
-        Some(ImageInfo {
-            names: vec![name.to_string()],
-            image_url,
-            checksum_url,
-            hash_alg: HashAlg::Sha256,
-        })
+        format!("AlmaLinux-{name}-GenericCloud-latest.{arch_name}.qcow2")
+    }
+
+    fn get_checksum_file(&self, _image_file: &str, _name: &str, _arch: Arch) -> String {
+        "CHECKSUM".to_string()
+    }
+
+    fn get_checksum_alg(&self) -> HashAlg {
+        HashAlg::Sha256
     }
 }

--- a/src/image/archlinux_image_provider.rs
+++ b/src/image/archlinux_image_provider.rs
@@ -1,35 +1,39 @@
 use crate::arch::Arch;
-use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::image::{HashAlg, ImageProvider};
 
 pub struct ArchLinuxImageProvider {}
 
 impl ImageProvider for ArchLinuxImageProvider {
-    fn get_vendor(&self) -> String {
-        "archlinux".to_string()
+    fn get_vendor(&self) -> &str {
+        "archlinux"
     }
 
-    fn get_image_list_url(&self) -> String {
-        "https://geo.mirror.pkgbuild.com/images/".to_string()
+    fn get_base_url(&self) -> &str {
+        "https://geo.mirror.pkgbuild.com/images/"
     }
 
-    fn get_image_names(&self, _content: &str) -> Vec<String> {
+    fn find_image_names(&self, _content: &str) -> Vec<String> {
         vec!["latest".to_string()]
     }
 
-    fn get_image_dir_url(&self, _name: &str, _arch: Arch) -> String {
-        format!("{}latest/", self.get_image_list_url())
+    fn get_image_dir_path(&self, _name: &str, _arch: Arch) -> String {
+        "latest/".to_string()
     }
 
-    fn get_image_info(&self, _content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
-        let base_url = self.get_image_dir_url(name, arch);
+    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
+        vec![name.to_string()]
+    }
+
+    fn get_image_file_pattern(&self, _name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
-        let image_url = format!("{base_url}Arch-Linux-{arch_name}-cloudimg.qcow2");
-        let checksum_url = format!("{image_url}.SHA256");
-        Some(ImageInfo {
-            names: vec![name.to_string()],
-            image_url,
-            checksum_url,
-            hash_alg: HashAlg::Sha256,
-        })
+        format!("Arch-Linux-{arch_name}-cloudimg.qcow2")
+    }
+
+    fn get_checksum_file(&self, image_file: &str, _name: &str, _arch: Arch) -> String {
+        format!("{image_file}.SHA256")
+    }
+
+    fn get_checksum_alg(&self) -> HashAlg {
+        HashAlg::Sha256
     }
 }

--- a/src/image/debian_image_provider.rs
+++ b/src/image/debian_image_provider.rs
@@ -1,5 +1,5 @@
 use crate::arch::Arch;
-use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::image::{HashAlg, ImageProvider};
 use crate::util;
 
 pub struct DebianImageProvider {}
@@ -13,34 +13,41 @@ impl DebianImageProvider {
 }
 
 impl ImageProvider for DebianImageProvider {
-    fn get_vendor(&self) -> String {
-        "debian".to_string()
+    fn get_vendor(&self) -> &str {
+        "debian"
     }
 
-    fn get_image_list_url(&self) -> String {
-        "https://cloud.debian.org/images/cloud/".to_string()
+    fn get_base_url(&self) -> &str {
+        "https://cloud.debian.org/images/cloud/"
     }
 
-    fn get_image_names(&self, content: &str) -> Vec<String> {
+    fn find_image_names(&self, content: &str) -> Vec<String> {
         util::find_and_extract(r#"<a href=\"([a-z]+)/\">[a-z]+/</a>"#, content)
     }
 
-    fn get_image_dir_url(&self, name: &str, _arch: Arch) -> String {
-        format!("{}{name}/latest/", self.get_image_list_url(),)
+    fn get_image_dir_path(&self, name: &str, _arch: Arch) -> String {
+        format!("{name}/latest/")
     }
 
-    fn get_image_info(&self, content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
-        self.get_version_from_content(content).map(|version| {
-            let base_url = self.get_image_dir_url(name, arch);
-            let arch_name = arch.to_string();
-            let image_url = format!("{base_url}debian-{version}-generic-{arch_name}.qcow2");
-            let checksum_url = format!("{base_url}SHA512SUMS");
-            ImageInfo {
-                names: vec![version.to_string(), name.to_string()],
-                image_url,
-                checksum_url,
-                hash_alg: HashAlg::Sha512,
-            }
-        })
+    fn get_image_names(&self, image_file: &str, name: &str) -> Vec<String> {
+        let mut names = Vec::new();
+        if let Some(version) = self.get_version_from_content(image_file) {
+            names.push(version);
+        }
+        names.push(name.to_string());
+        names
+    }
+
+    fn get_image_file_pattern(&self, _name: &str, arch: Arch) -> String {
+        let arch_name = arch.as_vendor_str();
+        format!("debian-[0-9]+-generic-{arch_name}.qcow2")
+    }
+
+    fn get_checksum_file(&self, _image_file: &str, _name: &str, _arch: Arch) -> String {
+        "SHA512SUMS".to_string()
+    }
+
+    fn get_checksum_alg(&self) -> HashAlg {
+        HashAlg::Sha512
     }
 }

--- a/src/image/fedora_image_provider.rs
+++ b/src/image/fedora_image_provider.rs
@@ -1,55 +1,48 @@
 use crate::arch::Arch;
-use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::image::{HashAlg, ImageProvider};
 use crate::util;
 
 pub struct FedoraImageProvider {}
 
-impl FedoraImageProvider {
-    fn get_version_from_content(&self, content: &str) -> Option<String> {
-        util::find_and_extract(
-            r#"href=\"Fedora-Cloud-Base-Generic-[0-9]+-(.*)\..+\.qcow2\""#,
-            content,
-        )
-        .into_iter()
-        .next()
-    }
-}
-
 impl ImageProvider for FedoraImageProvider {
-    fn get_vendor(&self) -> String {
-        "fedora".to_string()
+    fn get_vendor(&self) -> &str {
+        "fedora"
     }
 
-    fn get_image_list_url(&self) -> String {
-        "https://download.fedoraproject.org/pub/fedora/linux/releases/".to_string()
+    fn get_base_url(&self) -> &str {
+        "https://download.fedoraproject.org/pub/fedora/linux/releases/"
     }
 
-    fn get_image_names(&self, content: &str) -> Vec<String> {
+    fn find_image_names(&self, content: &str) -> Vec<String> {
         util::find_and_extract(r#">([0-9]+)/<"#, content)
             .into_iter()
             .filter(|version| version.parse::<u32>().map(|v| v > 40).unwrap_or_default())
             .collect()
     }
 
-    fn get_image_dir_url(&self, name: &str, arch: Arch) -> String {
-        let base_url = self.get_image_list_url();
+    fn get_image_dir_path(&self, name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
-        format!("{base_url}{name}/Cloud/{arch_name}/images/",)
+        format!("{name}/Cloud/{arch_name}/images/",)
     }
 
-    fn get_image_info(&self, content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
-        self.get_version_from_content(content).map(|version| {
-            let base_url = self.get_image_dir_url(name, arch);
-            let arch_name = arch.as_canonical_str();
-            let image_url =
-                format!("{base_url}Fedora-Cloud-Base-Generic-{name}-{version}.{arch_name}.qcow2");
-            let checksum_url = format!("{base_url}Fedora-Cloud-{name}-{arch_name}-CHECKSUM.qcow2");
-            ImageInfo {
-                names: vec![name.to_string()],
-                image_url,
-                checksum_url,
-                hash_alg: HashAlg::Sha256,
-            }
-        })
+    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
+        vec![name.to_string()]
+    }
+
+    fn get_image_file_pattern(&self, name: &str, arch: Arch) -> String {
+        let arch_name = arch.as_canonical_str();
+        format!("Fedora-Cloud-Base-Generic-{name}-.*.{arch_name}.qcow2")
+    }
+
+    fn get_checksum_file(&self, image_file: &str, _name: &str, arch: Arch) -> String {
+        let arch_name = arch.as_canonical_str();
+        image_file.replace("-Base-Generic", "").replace(
+            &format!(".{arch_name}.qcow2"),
+            &format!("-{arch_name}-CHECKSUM"),
+        )
+    }
+
+    fn get_checksum_alg(&self) -> HashAlg {
+        HashAlg::Sha256
     }
 }

--- a/src/image/gentoo_image_provider.rs
+++ b/src/image/gentoo_image_provider.rs
@@ -1,53 +1,40 @@
 use crate::arch::Arch;
-use crate::image::{HashAlg, ImageInfo, ImageProvider};
-use crate::util;
+use crate::image::{HashAlg, ImageProvider};
 
 pub struct GentooImageProvider {}
 
-impl GentooImageProvider {
-    fn get_timestamp(&self, content: &str) -> Option<String> {
-        util::find_and_extract(
-            r#"href=\"di-[A-Za-z0-9]+-cloudinit-([A-Za-z0-9]+).qcow2\""#,
-            content,
-        )
-        .into_iter()
-        .next()
-    }
-}
-
 impl ImageProvider for GentooImageProvider {
-    fn get_vendor(&self) -> String {
-        "gentoo".to_string()
+    fn get_vendor(&self) -> &str {
+        "gentoo"
     }
 
-    fn get_image_list_url(&self) -> String {
-        "https://distfiles.gentoo.org/releases/".to_string()
+    fn get_base_url(&self) -> &str {
+        "https://distfiles.gentoo.org/releases/"
     }
 
-    fn get_image_names(&self, _content: &str) -> Vec<String> {
+    fn find_image_names(&self, _content: &str) -> Vec<String> {
         vec!["latest".to_string()]
     }
 
-    fn get_image_dir_url(&self, _name: &str, arch: Arch) -> String {
+    fn get_image_dir_path(&self, _name: &str, arch: Arch) -> String {
         let arch_name = arch.as_vendor_str();
-        format!(
-            "{}/{arch_name}/autobuilds/current-di-{arch_name}-cloudinit/",
-            self.get_image_list_url()
-        )
+        format!("{arch_name}/autobuilds/current-di-{arch_name}-cloudinit/")
     }
 
-    fn get_image_info(&self, content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
-        self.get_timestamp(content).map(|timestamp| {
-            let base_url = self.get_image_dir_url(name, arch);
-            let arch_name = arch.as_vendor_str();
-            let image_url = format!("{base_url}di-{arch_name}-cloudinit-{timestamp}.qcow2");
-            let checksum_url = format!("{image_url}.sha256");
-            ImageInfo {
-                names: vec![name.to_string()],
-                image_url,
-                checksum_url,
-                hash_alg: HashAlg::Sha256,
-            }
-        })
+    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
+        vec![name.to_string()]
+    }
+
+    fn get_image_file_pattern(&self, _name: &str, arch: Arch) -> String {
+        let arch_name = arch.as_vendor_str();
+        format!("di-{arch_name}-cloudinit-[A-Za-z0-9]+.qcow2")
+    }
+
+    fn get_checksum_file(&self, image_file: &str, _name: &str, _arch: Arch) -> String {
+        format!("{image_file}.sha256")
+    }
+
+    fn get_checksum_alg(&self) -> HashAlg {
+        HashAlg::Sha256
     }
 }

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -2,6 +2,7 @@ use crate::arch::Arch;
 use crate::env::Environment;
 use crate::error::{Error, Result};
 use crate::image::{self, Image, ImageCache, ImageName};
+use crate::util;
 use crate::web::WebClient;
 
 const IMAGE_PROVIDERS: &[&dyn image::ImageProvider] = &[
@@ -41,34 +42,52 @@ impl ImageFactory {
         arch: Arch,
         filter: Option<ImageName>,
     ) -> Option<Image> {
-        let image_content = web
-            .download_content(&image_provider.get_image_dir_url(name, arch))
-            .unwrap();
+        let image_dir_url = format!(
+            "{}{}",
+            image_provider.get_base_url(),
+            &image_provider.get_image_dir_path(name, arch)
+        );
+        let image_content = web.download_content(&image_dir_url).unwrap();
 
-        image_provider
-            .get_image_info(&image_content, name, arch)
-            .and_then(|image_info| {
-                web.get_file_size(&image_info.image_url)
-                    .ok()
-                    .and_then(|size| size)
-                    .and_then(|size| {
-                        if let Some(name) = &filter
-                            && image_info.names.contains(&name.get_name().to_string())
-                        {
-                            None
-                        } else {
-                            Some(Image {
-                                vendor: image_provider.get_vendor(),
-                                names: image_info.names.clone(),
-                                arch,
-                                image_url: image_info.image_url.to_string(),
-                                checksum_url: image_info.checksum_url.to_string(),
-                                hash_alg: image_info.hash_alg,
-                                size: Some(size),
-                            })
-                        }
-                    })
-            })
+        let image_file = util::find_and_extract(
+            &format!(
+                "href=\"({})\"",
+                image_provider.get_image_file_pattern(name, arch)
+            ),
+            &image_content,
+        );
+        let image_file = image_file.first();
+
+        if let Some(image_file) = image_file {
+            let image_url = format!("{image_dir_url}{image_file}");
+            let names = image_provider.get_image_names(image_file, name);
+            web.get_file_size(&image_url)
+                .ok()
+                .and_then(|size| size)
+                .and_then(|size| {
+                    if filter
+                        .map(|name| names.contains(&name.get_name().to_string()))
+                        .unwrap_or(true)
+                    {
+                        Some(Image {
+                            vendor: image_provider.get_vendor().to_string(),
+                            names,
+                            arch,
+                            image_url,
+                            checksum_url: format!(
+                                "{image_dir_url}{}",
+                                image_provider.get_checksum_file(image_file, name, arch)
+                            ),
+                            hash_alg: image_provider.get_checksum_alg(),
+                            size: Some(size),
+                        })
+                    } else {
+                        None
+                    }
+                })
+        } else {
+            None
+        }
     }
 
     fn get_images_from_provider(
@@ -76,10 +95,10 @@ impl ImageFactory {
         image_provider: &dyn image::ImageProvider,
         filter: Option<ImageName>,
     ) -> Vec<Image> {
-        web.download_content(&image_provider.get_image_list_url())
+        web.download_content(image_provider.get_base_url())
             .map(|content| {
                 image_provider
-                    .get_image_names(&content)
+                    .find_image_names(&content)
                     .into_iter()
                     .flat_map(|name| {
                         Self::filter_arch(filter.clone())
@@ -104,10 +123,7 @@ impl ImageFactory {
         let mut images = IMAGE_PROVIDERS
             .iter()
             .filter(|p| filter.is_none() || filter.as_ref().unwrap().get_vendor() == p.get_vendor())
-            .flat_map(|provider| {
-                Self::get_images_from_provider(web, *provider, filter.clone())
-                //.sort_by(|a, b| provider.compare(a, b))
-            })
+            .flat_map(|provider| Self::get_images_from_provider(web, *provider, filter.clone()))
             .collect::<Vec<_>>();
         images.sort();
         images

--- a/src/image/image_provider.rs
+++ b/src/image/image_provider.rs
@@ -1,19 +1,16 @@
 use crate::arch::Arch;
 use crate::image::HashAlg;
 
-pub struct ImageInfo {
-    pub names: Vec<String>,
-    pub image_url: String,
-    pub checksum_url: String,
-    pub hash_alg: HashAlg,
-}
-
 pub trait ImageProvider {
-    fn get_vendor(&self) -> String;
+    fn get_vendor(&self) -> &str;
 
-    fn get_image_list_url(&self) -> String;
-    fn get_image_names(&self, content: &str) -> Vec<String>;
+    fn get_base_url(&self) -> &str;
+    fn find_image_names(&self, content: &str) -> Vec<String>;
 
-    fn get_image_dir_url(&self, name: &str, arch: Arch) -> String;
-    fn get_image_info(&self, content: &str, name: &str, arch: Arch) -> Option<ImageInfo>;
+    fn get_image_dir_path(&self, name: &str, arch: Arch) -> String;
+    fn get_image_names(&self, image_file: &str, name: &str) -> Vec<String>;
+    fn get_image_file_pattern(&self, name: &str, arch: Arch) -> String;
+
+    fn get_checksum_file(&self, image_file: &str, name: &str, arch: Arch) -> String;
+    fn get_checksum_alg(&self) -> HashAlg;
 }

--- a/src/image/opensuse_image_provider.rs
+++ b/src/image/opensuse_image_provider.rs
@@ -1,37 +1,40 @@
 use crate::arch::Arch;
-use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::image::{HashAlg, ImageProvider};
 use crate::util;
 
 pub struct OpenSuseImageProvider {}
 
 impl ImageProvider for OpenSuseImageProvider {
-    fn get_vendor(&self) -> String {
-        "opensuse".to_string()
+    fn get_vendor(&self) -> &str {
+        "opensuse"
     }
 
-    fn get_image_list_url(&self) -> String {
-        "https://download.opensuse.org/repositories/Cloud:/Images:/".to_string()
+    fn get_base_url(&self) -> &str {
+        "https://download.opensuse.org/repositories/Cloud:/Images:/"
     }
 
-    fn get_image_names(&self, content: &str) -> Vec<String> {
+    fn find_image_names(&self, content: &str) -> Vec<String> {
         util::find_and_extract(r#">Leap_([0-9]+\.[0-9]+)/<"#, content)
     }
 
-    fn get_image_dir_url(&self, name: &str, _arch: Arch) -> String {
-        let base_url = self.get_image_list_url();
-        format!("{base_url}Leap_{name}/images/",)
+    fn get_image_dir_path(&self, name: &str, _arch: Arch) -> String {
+        format!("Leap_{name}/images/",)
     }
 
-    fn get_image_info(&self, _content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
-        let base_url = self.get_image_dir_url(name, arch);
+    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
+        vec![name.to_string()]
+    }
+
+    fn get_image_file_pattern(&self, name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
-        let image_url = format!("{base_url}openSUSE-Leap-{name}.{arch_name}-NoCloud.qcow2");
-        let checksum_url = format!("{image_url}.sha256");
-        Some(ImageInfo {
-            names: vec![name.to_string()],
-            image_url,
-            checksum_url,
-            hash_alg: HashAlg::Sha256,
-        })
+        format!("openSUSE-Leap-{name}.{arch_name}-NoCloud.qcow2")
+    }
+
+    fn get_checksum_file(&self, image_file: &str, _name: &str, _arch: Arch) -> String {
+        format!("{image_file}.sha256")
+    }
+
+    fn get_checksum_alg(&self) -> HashAlg {
+        HashAlg::Sha256
     }
 }

--- a/src/image/rockylinux_image_provider.rs
+++ b/src/image/rockylinux_image_provider.rs
@@ -1,39 +1,41 @@
 use crate::arch::Arch;
-use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::image::{HashAlg, ImageProvider};
 use crate::util;
 
 pub struct RockyLinuxImageProvider {}
 
 impl ImageProvider for RockyLinuxImageProvider {
-    fn get_vendor(&self) -> String {
-        "rockylinux".to_string()
+    fn get_vendor(&self) -> &str {
+        "rockylinux"
     }
 
-    fn get_image_list_url(&self) -> String {
-        "https://dl.rockylinux.org/pub/rocky/".to_string()
+    fn get_base_url(&self) -> &str {
+        "https://dl.rockylinux.org/pub/rocky/"
     }
 
-    fn get_image_names(&self, content: &str) -> Vec<String> {
+    fn find_image_names(&self, content: &str) -> Vec<String> {
         util::find_and_extract(r#">([0-9]+)/<"#, content)
     }
 
-    fn get_image_dir_url(&self, name: &str, arch: Arch) -> String {
-        let base_url = self.get_image_list_url();
+    fn get_image_dir_path(&self, name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
-        format!("{base_url}{name}/images/{arch_name}/",)
+        format!("{name}/images/{arch_name}/",)
     }
 
-    fn get_image_info(&self, _content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
-        let base_url = self.get_image_dir_url(name, arch);
+    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
+        vec![name.to_string()]
+    }
+
+    fn get_image_file_pattern(&self, name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
-        let image_url =
-            format!("{base_url}Rocky-{name}-GenericCloud-Base.latest.{arch_name}.qcow2");
-        let checksum_url = format!("{image_url}.CHECKSUM");
-        Some(ImageInfo {
-            names: vec![name.to_string()],
-            image_url,
-            checksum_url,
-            hash_alg: HashAlg::Sha256,
-        })
+        format!("Rocky-{name}-GenericCloud-Base.latest.{arch_name}.qcow2")
+    }
+
+    fn get_checksum_file(&self, image_file: &str, _name: &str, _arch: Arch) -> String {
+        format!("{image_file}.CHECKSUM")
+    }
+
+    fn get_checksum_alg(&self) -> HashAlg {
+        HashAlg::Sha256
     }
 }

--- a/src/image/ubuntu_image_provider.rs
+++ b/src/image/ubuntu_image_provider.rs
@@ -1,5 +1,5 @@
 use crate::arch::Arch;
-use crate::image::{HashAlg, ImageInfo, ImageProvider};
+use crate::image::{HashAlg, ImageProvider};
 use crate::util;
 
 pub struct UbuntuImageProvider {}
@@ -16,34 +16,41 @@ impl UbuntuImageProvider {
 }
 
 impl ImageProvider for UbuntuImageProvider {
-    fn get_vendor(&self) -> String {
-        "ubuntu".to_string()
+    fn get_vendor(&self) -> &str {
+        "ubuntu"
     }
 
-    fn get_image_list_url(&self) -> String {
-        "https://cloud-images.ubuntu.com/minimal/releases/".to_string()
+    fn get_base_url(&self) -> &str {
+        "https://cloud-images.ubuntu.com/minimal/releases/"
     }
 
-    fn get_image_names(&self, content: &str) -> Vec<String> {
+    fn find_image_names(&self, content: &str) -> Vec<String> {
         util::find_and_extract(r#"href=\"([a-z]+)/\""#, content)
     }
 
-    fn get_image_dir_url(&self, name: &str, _arch: Arch) -> String {
-        format!("{}{name}/release/", self.get_image_list_url(),)
+    fn get_image_dir_path(&self, name: &str, _arch: Arch) -> String {
+        format!("{name}/release/")
     }
 
-    fn get_image_info(&self, content: &str, name: &str, arch: Arch) -> Option<ImageInfo> {
-        self.get_version_from_content(content).map(|version| {
-            let base_url = self.get_image_dir_url(name, arch);
-            let arch_name = arch.to_string();
-            let image_url = format!("{base_url}ubuntu-{version}-minimal-cloudimg-{arch_name}.img");
-            let checksum_url = format!("{base_url}SHA256SUMS");
-            ImageInfo {
-                names: vec![version.to_string(), name.to_string()],
-                image_url,
-                checksum_url,
-                hash_alg: HashAlg::Sha256,
-            }
-        })
+    fn get_image_names(&self, image_file: &str, name: &str) -> Vec<String> {
+        let mut names = Vec::new();
+        if let Some(version) = self.get_version_from_content(image_file) {
+            names.push(version);
+        }
+        names.push(name.to_string());
+        names
+    }
+
+    fn get_image_file_pattern(&self, _name: &str, arch: Arch) -> String {
+        let arch_name = arch.as_vendor_str();
+        format!("ubuntu-[0-9]+\\.[0-9]+-minimal-cloudimg-{arch_name}.img")
+    }
+
+    fn get_checksum_file(&self, _image_file: &str, _name: &str, _arch: Arch) -> String {
+        "SHA256SUMS".to_string()
+    }
+
+    fn get_checksum_alg(&self) -> HashAlg {
+        HashAlg::Sha256
     }
 }


### PR DESCRIPTION
Cleaned up the `ImageProvider` trait to remove unnecessary complexity. This makes it much simpler to add new VM guest images and keeps the existing ones easier to maintain.