### PR TITLE
refactor: add Context struct to simplify dependency injection

### DIFF
--- a/src/actions/create_instance_action.rs
+++ b/src/actions/create_instance_action.rs
@@ -1,7 +1,7 @@
-use crate::env::Environment;
+use crate::commands::Context;
 use crate::error::Result;
 use crate::fs::FS;
-use crate::instance::{Instance, InstanceStore};
+use crate::instance::Instance;
 use crate::ssh_cmd::SshKeyGenerator;
 use crate::util::SystemCommand;
 use std::path::Path;
@@ -16,14 +16,13 @@ impl CreateInstanceAction {
 
     pub fn run(
         &mut self,
-        env: &Environment,
+        context: &Context,
         fs: &FS,
-        instance_store: &dyn InstanceStore,
         image_path: &str,
         mut instance: Instance,
     ) -> Result<()> {
         let instance_name = instance.name.clone();
-        let target_dir = &env.get_instance_dir2(&instance.name);
+        let target_dir = &context.get_env().get_instance_dir2(&instance.name);
         let tmp_dir = &format!("{target_dir}.tmp");
         let tmp_image = &format!("{tmp_dir}/machine.img");
 
@@ -53,7 +52,7 @@ impl CreateInstanceAction {
 
         // Write configuration file
         instance.name = format!("{instance_name}.tmp");
-        instance_store.store(&instance)?;
+        context.get_instance_store().store(&instance)?;
         instance.name = instance_name;
 
         fs.rename_file(tmp_dir, target_dir)

--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -1,10 +1,9 @@
 use crate::cloudinit::UserDataImageFactory;
-use crate::commands::Iso9660;
+use crate::commands::{Context, Iso9660};
 use crate::emulator::Emulator;
-use crate::env::Environment;
 use crate::error::Result;
 use crate::fs::FS;
-use crate::instance::{Instance, InstanceStore};
+use crate::instance::Instance;
 use crate::ssh_cmd::PortChecker;
 
 pub struct StartInstanceAction {
@@ -20,16 +19,16 @@ impl StartInstanceAction {
 
     pub fn run(
         &mut self,
-        instance_dao: &dyn InstanceStore,
-        env: &Environment,
+        context: &Context,
         qemu_args: &Option<String>,
         verbose: bool,
         iso9660: Iso9660,
     ) -> Result<()> {
-        if instance_dao.is_running(&self.instance) {
+        if context.get_instance_store().is_running(&self.instance) {
             return Ok(());
         }
 
+        let env = context.get_env();
         FS::new().setup_directory_access(&env.get_instance_runtime_dir(&self.instance.name))?;
         match iso9660 {
             Iso9660::Rust => UserDataImageFactory.create_rust(env, &self.instance)?,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,6 +2,7 @@ mod clone_command;
 mod command_dispatcher;
 mod completions_command;
 mod console_command;
+mod context;
 mod create_command;
 mod delete_command;
 mod exec_command;
@@ -28,6 +29,7 @@ pub use clone_command::*;
 pub use command_dispatcher::*;
 pub use completions_command::*;
 pub use console_command::*;
+pub use context::*;
 pub use create_command::*;
 pub use delete_command::*;
 pub use exec_command::*;
@@ -50,18 +52,9 @@ pub use start_command::*;
 pub use stop_command::*;
 pub use verbosity::*;
 
-use crate::env::Environment;
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 use crate::view::Console;
 
 trait Command {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()>;
+    fn run(&self, console: &mut dyn Console, context: &Context) -> Result<()>;
 }

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -1,10 +1,8 @@
 use crate::actions::CreateInstanceAction;
-use crate::commands::Command;
-use crate::env::Environment;
+use crate::commands::{Command, Context};
 use crate::error::{Error, Result};
 use crate::fs::FS;
-use crate::image::ImageStore;
-use crate::instance::{InstanceName, InstanceStore};
+use crate::instance::InstanceName;
 use crate::ssh_cmd::PortChecker;
 use crate::view::{Console, SpinnerView};
 use clap::Parser;
@@ -26,13 +24,9 @@ pub struct CloneCommand {
 }
 
 impl Command for CloneCommand {
-    fn run(
-        &self,
-        _console: &mut dyn Console,
-        env: &Environment,
-        _image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, _console: &mut dyn Console, context: &Context) -> Result<()> {
+        let instance_store = context.get_instance_store();
+
         // Verify that the target name is available
         if instance_store.exists(self.new_name.as_str()) {
             return Err(Error::InstanceAlreadyExists(self.new_name.to_string()));
@@ -49,7 +43,9 @@ impl Command for CloneCommand {
         let mut spinner = SpinnerView::new("Cloning VM instance".to_string());
 
         // Load source instance info
-        let image_path = &env.get_instance_image_file(self.name.as_str());
+        let image_path = &context
+            .get_env()
+            .get_instance_image_file(self.name.as_str());
 
         // Setup target instance info
         let mut target = source.clone();
@@ -57,7 +53,7 @@ impl Command for CloneCommand {
         target.ssh_port = PortChecker::new().get_new_port();
 
         // Create VM instance
-        CreateInstanceAction::new().run(env, &FS::new(), instance_store, image_path, target)?;
+        CreateInstanceAction::new().run(context, &FS::new(), image_path, target)?;
 
         spinner.stop();
         Ok(())

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -63,8 +63,11 @@ impl CommandDispatcher {
             self.global.quiet,
         ));
         let env = EnvironmentFactory::create_env()?;
-        let image_dao = ImageDao::new(&env)?;
-        let instance_dao = InstanceDao::new(&env)?;
+        let context = &commands::Context::new(
+            env.clone(),
+            Box::new(ImageDao::new(&env)?),
+            Box::new(InstanceDao::new(&env)?),
+        );
 
         match &self.command {
             Commands::Run(cmd) => cmd as &dyn Command,
@@ -87,6 +90,6 @@ impl CommandDispatcher {
             Commands::Prune(cmd) => cmd,
             Commands::Completions(cmd) => cmd,
         }
-        .run(console, &env, &image_dao, &instance_dao)
+        .run(console, context)
     }
 }

--- a/src/commands/completions_command.rs
+++ b/src/commands/completions_command.rs
@@ -1,8 +1,5 @@
-use crate::commands::{Command, CommandDispatcher};
-use crate::env::Environment;
+use crate::commands::{Command, CommandDispatcher, Context};
 use crate::error::{Error, Result};
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 use crate::view::Console;
 use clap::{CommandFactory, Parser};
 use clap_complete::Shell;
@@ -25,13 +22,7 @@ pub struct CompletionsCommand {
 }
 
 impl Command for CompletionsCommand {
-    fn run(
-        &self,
-        _console: &mut dyn Console,
-        _env: &Environment,
-        _image_store: &dyn ImageStore,
-        _instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, _console: &mut dyn Console, _context: &Context) -> Result<()> {
         let Some(shell) = self.shell.or_else(Shell::from_env) else {
             return Err(Error::CouldNotDetectShell);
         };

--- a/src/commands/console_command.rs
+++ b/src/commands/console_command.rs
@@ -1,8 +1,5 @@
 use crate::commands::{self, Command, Iso9660Arg};
-use crate::env::Environment;
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 #[cfg(not(windows))]
 use crate::util::Terminal;
 use crate::view::Console;
@@ -32,24 +29,18 @@ pub struct ConsoleCommand {
 }
 
 impl Command for ConsoleCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
         commands::StartCommand {
             qemu_args: None,
             wait: false,
             instances: vec![self.instance.to_string()],
             iso9660: self.iso9660.clone(),
         }
-        .run(console, env, image_store, instance_store)?;
+        .run(console, context)?;
 
         console.info("Default credentials: cubic / cubic");
         console.info("Press CTRL+W to exit the console.");
-        let console_path = env.get_console_file(&self.instance);
+        let console_path = context.get_env().get_console_file(&self.instance);
         while !Path::new(&console_path).exists() {
             thread::sleep(Duration::new(1, 0));
         }

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -1,0 +1,35 @@
+use crate::env::Environment;
+use crate::image::ImageStore;
+use crate::instance::InstanceStore;
+
+pub struct Context {
+    env: Environment,
+    image_store: Box<dyn ImageStore>,
+    instance_store: Box<dyn InstanceStore>,
+}
+
+impl Context {
+    pub fn new(
+        env: Environment,
+        image_store: Box<dyn ImageStore>,
+        instance_store: Box<dyn InstanceStore>,
+    ) -> Self {
+        Self {
+            env,
+            image_store,
+            instance_store,
+        }
+    }
+
+    pub fn get_env(&self) -> &Environment {
+        &self.env
+    }
+
+    pub fn get_image_store(&self) -> &dyn ImageStore {
+        self.image_store.as_ref()
+    }
+
+    pub fn get_instance_store(&self) -> &dyn InstanceStore {
+        self.instance_store.as_ref()
+    }
+}

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -1,13 +1,12 @@
 use crate::actions::CreateInstanceAction;
 use crate::commands::{
-    Command,
+    Command, Context,
     image::{fetch_image, fetch_image_info},
 };
-use crate::env::Environment;
 use crate::error::{Error, Result};
 use crate::fs::FS;
-use crate::image::{ImageName, ImageStore};
-use crate::instance::{Instance, InstanceName, InstanceStore, PortForward};
+use crate::image::ImageName;
+use crate::instance::{Instance, InstanceName, PortForward};
 use crate::model::DataSize;
 use crate::ssh_cmd::PortChecker;
 use crate::view::Console;
@@ -75,20 +74,17 @@ pub struct CreateCommand {
 }
 
 impl Command for CreateCommand {
-    fn run(
-        &self,
-        _console: &mut dyn Console,
-        env: &Environment,
-        image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, _console: &mut dyn Console, context: &Context) -> Result<()> {
+        let env = context.get_env();
+        let instance_store = context.get_instance_store();
+
         if instance_store.exists(self.instance_name.as_str()) {
             return Result::Err(Error::InstanceAlreadyExists(self.instance_name.to_string()));
         }
 
         // Fetch image
         let image = &fetch_image_info(env, &self.image)?;
-        fetch_image(env, image_store, image)?;
+        fetch_image(env, context.get_image_store(), image)?;
 
         let mut create_spinner = SpinnerView::new("Creating virtual machine instance".to_string());
 
@@ -107,7 +103,7 @@ impl Command for CreateCommand {
         };
 
         let image_path = &env.get_image_file(&image.to_file_name());
-        CreateInstanceAction::new().run(env, &FS::new(), instance_store, image_path, instance)?;
+        CreateInstanceAction::new().run(context, &FS::new(), image_path, instance)?;
 
         create_spinner.stop();
         Result::Ok(())

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -1,8 +1,5 @@
 use crate::commands::{self, Command};
-use crate::env::Environment;
 use crate::error::{Error, Result};
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 use crate::util;
 use crate::view::Console;
 use clap::Parser;
@@ -34,13 +31,9 @@ pub struct DeleteCommand {
 }
 
 impl Command for DeleteCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let instance_store = context.get_instance_store();
+
         // Check if the instance names are valid
         for instance in &self.instances {
             if !instance_store.exists(instance) {
@@ -62,7 +55,7 @@ impl Command for DeleteCommand {
                 wait: true,
                 instances: self.instances.clone(),
             }
-            .run(console, env, image_store, instance_store)?;
+            .run(console, context)?;
 
             // Delete the VM instances
             for instance in &self.instances {

--- a/src/commands/exec_command.rs
+++ b/src/commands/exec_command.rs
@@ -1,9 +1,7 @@
 use crate::commands::{self, Command, Iso9660Arg};
-use crate::env::Environment;
 use crate::error::Result;
 use crate::fs::FS;
-use crate::image::ImageStore;
-use crate::instance::{InstanceStore, Target};
+use crate::instance::Target;
 use crate::ssh_cmd::Russh;
 use crate::view::Console;
 use clap::Parser;
@@ -27,13 +25,8 @@ pub struct ExecCommand {
 }
 
 impl Command for ExecCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let env = context.get_env();
         let name = self.target.get_instance();
 
         commands::StartCommand {
@@ -42,9 +35,9 @@ impl Command for ExecCommand {
             instances: vec![name.to_string()],
             iso9660: self.iso9660.clone(),
         }
-        .run(console, env, image_store, instance_store)?;
+        .run(console, context)?;
 
-        let instance = instance_store.load(name.as_str())?;
+        let instance = context.get_instance_store().load(name.as_str())?;
         let user = self
             .target
             .get_user()

--- a/src/commands/list_image_command.rs
+++ b/src/commands/list_image_command.rs
@@ -1,8 +1,6 @@
-use crate::commands::{Command, fetch_image_list};
-use crate::env::Environment;
+use crate::commands::{Command, Context, fetch_image_list};
 use crate::error::Result;
-use crate::image::{ImageStore, get_default_arch};
-use crate::instance::InstanceStore;
+use crate::image::get_default_arch;
 use crate::model::DataSize;
 use crate::view::{Alignment, Console, TableView};
 use clap::Parser;
@@ -42,14 +40,8 @@ pub struct ListImageCommand {
 }
 
 impl Command for ListImageCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        image_store: &dyn ImageStore,
-        _instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
-        let images = fetch_image_list(env);
+    fn run(&self, console: &mut dyn Console, context: &Context) -> Result<()> {
+        let images = fetch_image_list(context.get_env());
 
         let mut view = TableView::new();
         view.add_row()
@@ -73,7 +65,7 @@ impl Command for ListImageCommand {
                 .add(&image.arch.to_string(), Alignment::Left)
                 .add(&size, Alignment::Right)
                 .add(
-                    if image_store.exists(&image) {
+                    if context.get_image_store().exists(&image) {
                         "yes"
                     } else {
                         "no"

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -1,8 +1,5 @@
-use crate::commands::Command;
-use crate::env::Environment;
+use crate::commands::{self, Command};
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 use crate::view::{Alignment, Console, TableView};
 use clap::Parser;
 
@@ -22,13 +19,8 @@ use clap::Parser;
 pub struct ListInstanceCommand;
 
 impl Command for ListInstanceCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        _env: &Environment,
-        _image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let instance_store = context.get_instance_store();
         let instance_names = instance_store.get_instances();
 
         let mut view = TableView::new();
@@ -82,6 +74,7 @@ impl Command for ListInstanceCommand {
 mod tests {
     use super::*;
     use crate::arch::Arch;
+    use crate::env::Environment;
     use crate::image::ImageStoreMock;
     use crate::instance::Instance;
     use crate::instance::InstanceStoreMock;
@@ -91,9 +84,9 @@ mod tests {
     #[test]
     fn test_list_instance_command() {
         let console = &mut ConsoleMock::new();
-        let image_store = &ImageStoreMock::default();
-        let env = &Environment::new(String::new(), String::new(), String::new());
-        let instance_store = &InstanceStoreMock::new(vec![
+        let image_store = ImageStoreMock::default();
+        let env = Environment::new(String::new(), String::new(), String::new());
+        let instance_store = InstanceStoreMock::new(vec![
             Instance {
                 name: "test".to_string(),
                 arch: Arch::AMD64,
@@ -117,10 +110,9 @@ mod tests {
                 ..Instance::default()
             },
         ]);
+        let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
 
-        ListInstanceCommand {}
-            .run(console, env, image_store, instance_store)
-            .unwrap();
+        ListInstanceCommand {}.run(console, &context).unwrap();
 
         assert_eq!(
             console.get_output(),
@@ -135,13 +127,12 @@ PID   Name    Arch    CPUs    Memory   Disk Used   Disk Total   State
     #[test]
     fn test_list_instance_command_empty() {
         let console = &mut ConsoleMock::new();
-        let instance_store = &InstanceStoreMock::new(Vec::new());
-        let image_store = &ImageStoreMock::default();
-        let env = &Environment::new(String::new(), String::new(), String::new());
+        let instance_store = InstanceStoreMock::new(Vec::new());
+        let image_store = ImageStoreMock::default();
+        let env = Environment::new(String::new(), String::new(), String::new());
+        let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
 
-        ListInstanceCommand {}
-            .run(console, env, image_store, instance_store)
-            .unwrap();
+        ListInstanceCommand {}.run(console, &context).unwrap();
 
         assert_eq!(
             console.get_output(),

--- a/src/commands/list_port_command.rs
+++ b/src/commands/list_port_command.rs
@@ -1,8 +1,5 @@
-use crate::commands::Command;
-use crate::env::Environment;
+use crate::commands::{self, Command};
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 use crate::view::{Alignment, Console, TableView};
 use clap::Parser;
 
@@ -26,13 +23,8 @@ use clap::Parser;
 pub struct ListPortCommand;
 
 impl Command for ListPortCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        _env: &Environment,
-        _image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let instance_store = context.get_instance_store();
         let instance_names = instance_store.get_instances();
 
         let mut view = TableView::new();

--- a/src/commands/modify_command.rs
+++ b/src/commands/modify_command.rs
@@ -1,8 +1,6 @@
-use crate::commands::Command;
-use crate::env::Environment;
+use crate::commands::{self, Command};
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::{InstanceStore, PortForward};
+use crate::instance::PortForward;
 use crate::model::DataSize;
 use crate::view::Console;
 use clap::{ArgAction, Parser};
@@ -68,13 +66,8 @@ pub struct ModifyCommand {
 }
 
 impl Command for ModifyCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        _env: &Environment,
-        _image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let instance_store = context.get_instance_store();
         let mut instance = instance_store.load(&self.instance)?;
 
         if instance_store.is_running(&instance) {

--- a/src/commands/prune_command.rs
+++ b/src/commands/prune_command.rs
@@ -1,9 +1,6 @@
-use crate::commands::Command;
-use crate::env::Environment;
+use crate::commands::{self, Command};
 use crate::error::Result;
 use crate::fs::FS;
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 use crate::model::DataSize;
 use crate::util;
 use crate::view::Console;
@@ -18,13 +15,9 @@ use clap::Parser;
 pub struct PruneCommand;
 
 impl Command for PruneCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        _image_store: &dyn ImageStore,
-        _instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let env = context.get_env();
+
         // Calculate size
         let fs = FS::new();
         let paths = [env.get_image_cache_file(), env.get_image_dir()];

--- a/src/commands/rename_command.rs
+++ b/src/commands/rename_command.rs
@@ -1,8 +1,6 @@
-use crate::commands::Command;
-use crate::env::Environment;
+use crate::commands::{self, Command};
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::{InstanceName, InstanceStore};
+use crate::instance::InstanceName;
 use crate::view::Console;
 use clap::Parser;
 
@@ -23,13 +21,9 @@ pub struct RenameCommand {
 }
 
 impl Command for RenameCommand {
-    fn run(
-        &self,
-        _console: &mut dyn Console,
-        _env: &Environment,
-        _image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, _console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let instance_store = context.get_instance_store();
+
         instance_store.rename(
             &mut instance_store.load(self.old_name.as_str())?,
             self.new_name.as_str(),

--- a/src/commands/restart_command.rs
+++ b/src/commands/restart_command.rs
@@ -1,8 +1,5 @@
 use crate::commands::{self, Command, Iso9660Arg};
-use crate::env::Environment;
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 use crate::view::Console;
 use clap::Parser;
 
@@ -26,25 +23,19 @@ pub struct RestartCommand {
 }
 
 impl Command for RestartCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
         commands::StopCommand {
             all: false,
             wait: true,
             instances: self.instances.to_vec(),
         }
-        .run(console, env, image_store, instance_store)?;
+        .run(console, context)?;
         commands::StartCommand {
             qemu_args: None,
             wait: true,
             instances: self.instances.to_vec(),
             iso9660: self.iso9660.clone(),
         }
-        .run(console, env, image_store, instance_store)
+        .run(console, context)
     }
 }

--- a/src/commands/run_command.rs
+++ b/src/commands/run_command.rs
@@ -1,8 +1,6 @@
 use crate::commands::{self, Command};
-use crate::env::Environment;
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::{InstanceStore, Target};
+use crate::instance::Target;
 use crate::view::Console;
 use clap::{self, Parser};
 
@@ -40,20 +38,13 @@ pub struct RunCommand {
 }
 
 impl Command for RunCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
-        self.create_cmd
-            .run(console, env, image_store, instance_store)?;
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        self.create_cmd.run(console, context)?;
         commands::SshCommand {
             target: Target::from_instance_name(self.create_cmd.instance_name.clone()),
             cmd: None,
             iso9660: self.iso9660.clone(),
         }
-        .run(console, env, image_store, instance_store)
+        .run(console, context)
     }
 }

--- a/src/commands/scp_command.rs
+++ b/src/commands/scp_command.rs
@@ -1,8 +1,6 @@
-use crate::commands::Command;
-use crate::env::Environment;
+use crate::commands::{self, Command};
 use crate::error::{Error, Result};
 use crate::fs::FS;
-use crate::image::ImageStore;
 use crate::instance::{InstanceStore, TargetPath};
 use crate::ssh_cmd::Russh;
 use crate::view::Console;
@@ -48,20 +46,15 @@ pub struct ScpCommand {
 }
 
 impl Command for ScpCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        _image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let instance_store = context.get_instance_store();
         check_target_is_running(instance_store, &self.from)?;
         check_target_is_running(instance_store, &self.to)?;
 
         let root_dir = env::var("SNAP").unwrap_or_default();
         let mut ssh = Russh::new();
 
-        let pubkeys = env.get_ssh_private_key_paths(
+        let pubkeys = context.get_env().get_ssh_private_key_paths(
             &FS::new(),
             [&self.from, &self.to]
                 .iter()

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -1,8 +1,5 @@
 use crate::commands::{self, Command};
-use crate::env::Environment;
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 use crate::model::InstanceImageName;
 use crate::view::Console;
 use clap::Parser;
@@ -41,20 +38,15 @@ pub struct ShowCommand {
 }
 
 impl Command for ShowCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
         match &self.name {
-            InstanceImageName::Image(name) => commands::ShowImageCommand { name: name.clone() }
-                .run(console, env, image_store, instance_store),
+            InstanceImageName::Image(name) => {
+                commands::ShowImageCommand { name: name.clone() }.run(console, context)
+            }
             InstanceImageName::Instance(instance) => commands::ShowInstanceCommand {
                 instance: instance.clone(),
             }
-            .run(console, env, image_store, instance_store),
+            .run(console, context),
         }
     }
 }

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -1,8 +1,6 @@
-use crate::commands::{Command, image::fetch_image_info};
-use crate::env::Environment;
+use crate::commands::{self, Command, image::fetch_image_info};
 use crate::error::Result;
-use crate::image::{ImageName, ImageStore};
-use crate::instance::InstanceStore;
+use crate::image::ImageName;
 use crate::view::{Console, MapView};
 use clap::Parser;
 
@@ -14,14 +12,8 @@ pub struct ShowImageCommand {
 }
 
 impl Command for ShowImageCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        _image_store: &dyn ImageStore,
-        _instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
-        let image = fetch_image_info(env, &self.name)?;
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let image = fetch_image_info(context.get_env(), &self.name)?;
         let mut view = MapView::new();
         view.add("Name", &image.get_image_names());
         view.add("Image URL", &image.image_url);

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -1,8 +1,6 @@
-use crate::commands::Command;
-use crate::env::Environment;
+use crate::commands::{self, Command};
 use crate::error::{Error, Result};
-use crate::image::ImageStore;
-use crate::instance::{InstanceName, InstanceStore};
+use crate::instance::InstanceName;
 use crate::view::{Console, MapView};
 use clap::Parser;
 
@@ -14,13 +12,9 @@ pub struct ShowInstanceCommand {
 }
 
 impl Command for ShowInstanceCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        _env: &Environment,
-        _image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let instance_store = context.get_instance_store();
+
         if !instance_store.exists(self.instance.as_str()) {
             return Result::Err(Error::UnknownInstance(self.instance.to_string()));
         }
@@ -62,6 +56,7 @@ impl Command for ShowInstanceCommand {
 mod tests {
     use super::*;
     use crate::arch::Arch;
+    use crate::env::Environment;
     use crate::image::ImageStoreMock;
     use crate::instance::Instance;
     use crate::instance::InstanceStoreMock;
@@ -72,9 +67,9 @@ mod tests {
     #[test]
     fn test_show_command1() {
         let console = &mut ConsoleMock::new();
-        let env = &Environment::new(String::new(), String::new(), String::new());
-        let image_store = &ImageStoreMock::default();
-        let instance_store = &InstanceStoreMock::new(vec![Instance {
+        let env = Environment::new(String::new(), String::new(), String::new());
+        let image_store = ImageStoreMock::default();
+        let instance_store = InstanceStoreMock::new(vec![Instance {
             name: "test".to_string(),
             arch: Arch::AMD64,
             user: "cubic".to_string(),
@@ -85,11 +80,12 @@ mod tests {
             hostfwd: Vec::new(),
             ..Instance::default()
         }]);
+        let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
 
         ShowInstanceCommand {
             instance: InstanceName::from_str("test").unwrap(),
         }
-        .run(console, env, image_store, instance_store)
+        .run(console, &context)
         .unwrap();
 
         assert_eq!(
@@ -111,9 +107,9 @@ SSH:        ssh -p 9000 cubic@localhost
     #[test]
     fn test_show_command2() {
         let console = &mut ConsoleMock::new();
-        let env = &Environment::new(String::new(), String::new(), String::new());
-        let image_store = &ImageStoreMock::default();
-        let instance_store = &InstanceStoreMock::new(vec![Instance {
+        let env = Environment::new(String::new(), String::new(), String::new());
+        let image_store = ImageStoreMock::default();
+        let instance_store = InstanceStoreMock::new(vec![Instance {
             name: "test".to_string(),
             arch: Arch::ARM64,
             user: "john".to_string(),
@@ -125,11 +121,12 @@ SSH:        ssh -p 9000 cubic@localhost
             isolate: true,
             ..Instance::default()
         }]);
+        let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
 
         ShowInstanceCommand {
             instance: InstanceName::from_str("test").unwrap(),
         }
-        .run(console, env, image_store, instance_store)
+        .run(console, &context)
         .unwrap();
 
         assert_eq!(
@@ -151,15 +148,16 @@ SSH:        ssh -p 8000 john@localhost
     #[test]
     fn test_show_command_failed() {
         let console = &mut ConsoleMock::new();
-        let env = &Environment::new(String::new(), String::new(), String::new());
-        let instance_store = &InstanceStoreMock::new(Vec::new());
-        let image_store = &ImageStoreMock::default();
+        let env = Environment::new(String::new(), String::new(), String::new());
+        let instance_store = InstanceStoreMock::new(Vec::new());
+        let image_store = ImageStoreMock::default();
+        let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
 
         assert!(matches!(
             ShowInstanceCommand {
                 instance: InstanceName::from_str("test").unwrap()
             }
-            .run(console, env, image_store, instance_store),
+            .run(console, &context),
             Result::Err(Error::UnknownInstance(_))
         ));
     }

--- a/src/commands/ssh_command.rs
+++ b/src/commands/ssh_command.rs
@@ -1,9 +1,7 @@
 use crate::commands::{self, Command};
-use crate::env::Environment;
 use crate::error::Result;
 use crate::fs::FS;
-use crate::image::ImageStore;
-use crate::instance::{InstanceStore, Target};
+use crate::instance::Target;
 use crate::ssh_cmd::Russh;
 use crate::view::Console;
 use clap::Parser;
@@ -29,13 +27,10 @@ pub struct SshCommand {
 }
 
 impl Command for SshCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let env = context.get_env();
+        let instance_store = context.get_instance_store();
+
         if self.cmd.is_some() {
             console.info(
                 "Note: cubic ssh with cmd is deprecated - use 'cubic exec <instance> <cmd>' instead",
@@ -50,7 +45,7 @@ impl Command for SshCommand {
             instances: vec![name.to_string()],
             iso9660: self.iso9660.clone(),
         }
-        .run(console, env, image_store, instance_store)?;
+        .run(console, context)?;
 
         let instance = instance_store.load(name.as_str())?;
         let user = self

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -1,9 +1,6 @@
 use crate::actions::StartInstanceAction;
 use crate::commands::{self, Command};
-use crate::env::Environment;
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 use crate::ssh_cmd::{PortChecker, Russh};
 use crate::util;
 use crate::view::Console;
@@ -44,13 +41,9 @@ pub struct StartCommand {
 }
 
 impl Command for StartCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        env: &Environment,
-        _image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let instance_store = context.get_instance_store();
+
         let verbosity = console.get_verbosity();
         let async_caller = util::AsyncCaller::new();
         let russh = Russh::new();
@@ -68,8 +61,7 @@ impl Command for StartCommand {
 
                 let mut action = StartInstanceAction::new(instance);
                 action.run(
-                    instance_store,
-                    env,
+                    context,
                     &self.qemu_args,
                     verbosity.is_verbose(),
                     self.iso9660.value.clone(),

--- a/src/commands/stop_command.rs
+++ b/src/commands/stop_command.rs
@@ -1,9 +1,6 @@
 use crate::actions::StopInstanceAction;
-use crate::commands::Command;
-use crate::env::Environment;
+use crate::commands::{self, Command};
 use crate::error::Result;
-use crate::image::ImageStore;
-use crate::instance::InstanceStore;
 use crate::view::Console;
 use crate::view::SpinnerView;
 use clap::Parser;
@@ -37,13 +34,9 @@ pub struct StopCommand {
 }
 
 impl Command for StopCommand {
-    fn run(
-        &self,
-        console: &mut dyn Console,
-        _env: &Environment,
-        _image_store: &dyn ImageStore,
-        instance_store: &dyn InstanceStore,
-    ) -> Result<()> {
+    fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let instance_store = context.get_instance_store();
+
         let stop_instances = if self.all {
             instance_store.get_instances()
         } else {


### PR DESCRIPTION
Replace passing `Environment`, `ImageStore`, and `InstanceStore` individually with a single `Context` struct containing all three fields.