### PR TITLE
feat: default to host username for new instances (#276)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "whoami",
 ]
 
 [[package]]
@@ -1816,6 +1817,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +1989,24 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3748,6 +3776,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ ssh-key = { version = "0", features = ["ed25519", "rand_core"]}
 thiserror = "2"
 tokio = { version = "1", default-features = false, features = ["fs", "io-std"] }
 toml = "1"
+whoami = { version = "2", default-features = false, features = ["std"] }
 
 [profile.release]
 opt-level = 'z'

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -51,8 +51,8 @@ pub struct CreateCommand {
     #[clap(short, long)]
     image: ImageName,
     /// Username (default: 'cubic')
-    #[clap(short, long, default_value = "cubic")]
-    user: String,
+    #[clap(short, long)]
+    user: Option<String>,
     /// Number of vCPUs for the VM instance
     #[clap(short, long, default_value_t = DEFAULT_CPU_COUNT)]
     cpus: u16,
@@ -91,7 +91,11 @@ impl Command for CreateCommand {
         let instance = Instance {
             name: self.instance_name.to_string(),
             arch: image.arch,
-            user: self.user.to_string(),
+            user: self
+                .user
+                .as_deref()
+                .unwrap_or(context.get_env().get_username())
+                .to_string(),
             cpus: self.cpus,
             mem: self.memory.clone(),
             disk_capacity: self.disk.clone(),

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -85,7 +85,12 @@ mod tests {
     fn test_list_instance_command() {
         let console = &mut ConsoleMock::new();
         let image_store = ImageStoreMock::default();
-        let env = Environment::new(String::new(), String::new(), String::new());
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
         let instance_store = InstanceStoreMock::new(vec![
             Instance {
                 name: "test".to_string(),
@@ -129,7 +134,12 @@ PID   Name    Arch    CPUs    Memory   Disk Used   Disk Total   State
         let console = &mut ConsoleMock::new();
         let instance_store = InstanceStoreMock::new(Vec::new());
         let image_store = ImageStoreMock::default();
-        let env = Environment::new(String::new(), String::new(), String::new());
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
         let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
 
         ListInstanceCommand {}.run(console, &context).unwrap();

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -67,12 +67,17 @@ mod tests {
     #[test]
     fn test_show_command1() {
         let console = &mut ConsoleMock::new();
-        let env = Environment::new(String::new(), String::new(), String::new());
+        let env = Environment::new(
+            "myuser".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
         let image_store = ImageStoreMock::default();
         let instance_store = InstanceStoreMock::new(vec![Instance {
             name: "test".to_string(),
             arch: Arch::AMD64,
-            user: "cubic".to_string(),
+            user: "myuser".to_string(),
             cpus: 1,
             mem: DataSize::new(1024),
             disk_capacity: DataSize::new(1048576),
@@ -96,10 +101,10 @@ CPUs:       1
 Memory:     1.0 KiB
 Disk Used:  n/a
 Disk Total: 1.0 MiB
-User:       cubic
+User:       myuser
 Isolated:   no
 SSH Port:   9000
-SSH:        ssh -p 9000 cubic@localhost
+SSH:        ssh -p 9000 myuser@localhost
 "
         );
     }
@@ -107,7 +112,12 @@ SSH:        ssh -p 9000 cubic@localhost
     #[test]
     fn test_show_command2() {
         let console = &mut ConsoleMock::new();
-        let env = Environment::new(String::new(), String::new(), String::new());
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
         let image_store = ImageStoreMock::default();
         let instance_store = InstanceStoreMock::new(vec![Instance {
             name: "test".to_string(),
@@ -148,7 +158,12 @@ SSH:        ssh -p 8000 john@localhost
     #[test]
     fn test_show_command_failed() {
         let console = &mut ConsoleMock::new();
-        let env = Environment::new(String::new(), String::new(), String::new());
+        let env = Environment::new(
+            "testuser".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
         let instance_store = InstanceStoreMock::new(Vec::new());
         let image_store = ImageStoreMock::default();
         let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));

--- a/src/env.rs
+++ b/src/env.rs
@@ -2,4 +2,4 @@ mod environment;
 mod environment_factory;
 
 pub use environment::Environment;
-pub use environment_factory::EnvironmentFactory;
+pub use environment_factory::{DEFAULT_USERNAME, EnvironmentFactory};

--- a/src/env/environment.rs
+++ b/src/env/environment.rs
@@ -3,18 +3,24 @@ use std::env;
 
 #[derive(Default, Clone)]
 pub struct Environment {
+    username: String,
     data_dir: String,
     cache_dir: String,
     runtime_dir: String,
 }
 
 impl Environment {
-    pub fn new(data_dir: String, cache_dir: String, runtime_dir: String) -> Self {
+    pub fn new(username: String, data_dir: String, cache_dir: String, runtime_dir: String) -> Self {
         Self {
+            username,
             data_dir,
             cache_dir,
             runtime_dir,
         }
+    }
+
+    pub fn get_username(&self) -> &str {
+        &self.username
     }
 
     pub fn get_cache_dir(&self) -> &str {
@@ -121,11 +127,14 @@ mod tests {
     #[test]
     fn test_paths() {
         let env = Environment::new(
+            "testuser".to_string(),
             "/data/cubic".to_string(),
             "/cache/cubic".to_string(),
             "/runtime/cubic".to_string(),
         );
 
+        assert_eq!(env.get_username(), "testuser");
+        assert_eq!(env.get_cache_dir(), "/cache/cubic");
         assert_eq!(env.get_cache_dir(), "/cache/cubic");
         assert_eq!(env.get_runtime_dir(), "/runtime/cubic");
         assert_eq!(env.get_instance_dir(), "/data/cubic/machines");

--- a/src/env/environment_factory.rs
+++ b/src/env/environment_factory.rs
@@ -2,11 +2,23 @@ use crate::env::Environment;
 use crate::error::{Error, Result};
 use std::env;
 
+const ROOT_USERNAME: &str = "root";
+pub const DEFAULT_USERNAME: &str = "cubic";
+
 pub struct EnvironmentFactory;
 
 impl EnvironmentFactory {
     fn read_env(var: &str) -> Result<String> {
         env::var(var).map_err(|_| Error::UnsetEnvVar(var.to_string()))
+    }
+
+    pub fn get_username() -> String {
+        let username = whoami::username().unwrap_or(DEFAULT_USERNAME.to_string());
+        if username == ROOT_USERNAME {
+            DEFAULT_USERNAME.to_string()
+        } else {
+            username
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -20,6 +32,7 @@ impl EnvironmentFactory {
             .or_else(|_| Self::read_env("UID").map(|uid| format!("/run/user/{uid}")))?;
 
         Ok(Environment::new(
+            Self::get_username(),
             format!("{data_dir}/cubic"),
             format!("{cache_dir}/cubic"),
             format!("{runtime_dir}/cubic"),
@@ -31,6 +44,7 @@ impl EnvironmentFactory {
         let home_dir = Self::read_env("HOME")?;
 
         Ok(Environment::new(
+            Self::get_username(),
             format!("{home_dir}/Library/cubic"),
             format!("{home_dir}/Library/Caches/cubic"),
             format!("{home_dir}/Library/Caches/cubic"),
@@ -43,6 +57,7 @@ impl EnvironmentFactory {
         let temp_dir = Self::read_env("TEMP")?;
 
         Ok(Environment::new(
+            Self::get_username(),
             format!("{local_app_data_dir}/cubic"),
             format!("{temp_dir}/cubic"),
             format!("{temp_dir}/cubic"),

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -27,10 +27,11 @@ pub use target_path::*;
 pub use toml_instance_deserializer::*;
 pub use yaml_instance_deserializer::*;
 
+use crate::env::DEFAULT_USERNAME;
 use crate::model::DataSize;
 
 fn default_user() -> String {
-    USER.to_string()
+    DEFAULT_USERNAME.to_string()
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -17,8 +17,6 @@ use std::path::Path;
 use std::str;
 use std::str::FromStr;
 
-pub const USER: &str = "cubic";
-
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub machine: Instance,
@@ -99,7 +97,7 @@ impl InstanceStore for InstanceDao {
             })
             .unwrap_or(Instance {
                 name: name.to_string(),
-                user: USER.to_string(),
+                user: self.env.get_username().to_string(),
                 cpus: 1,
                 mem: DataSize::from_str("1G").unwrap(),
                 disk_capacity: DataSize::from_str("1G").unwrap(),


### PR DESCRIPTION
Auto-detect the host OS user as the default VM username, replacing the hardcoded "cubic" placeholder. Falls back to "cubic" if detection fails and preserves explicit flag overrides.