### PR TITLE
fix: restore aliases in the image list (#359)

### DIFF
--- a/src/image/debian_image_provider.rs
+++ b/src/image/debian_image_provider.rs
@@ -6,7 +6,7 @@ pub struct DebianImageProvider {}
 
 impl DebianImageProvider {
     fn get_version_from_content(&self, content: &str) -> Option<String> {
-        util::find_and_extract(r#"href=\"debian-([0-9]+)-generic-.*.qcow2\""#, content)
+        util::find_and_extract(r"debian-([^-]+)-generic-[^.]+.qcow2", content)
             .into_iter()
             .next()
     }

--- a/src/image/ubuntu_image_provider.rs
+++ b/src/image/ubuntu_image_provider.rs
@@ -6,12 +6,9 @@ pub struct UbuntuImageProvider {}
 
 impl UbuntuImageProvider {
     fn get_version_from_content(&self, content: &str) -> Option<String> {
-        util::find_and_extract(
-            r#"href=\"ubuntu-([0-9]+\.[0-9]+)-minimal-cloudimg-.*.img\""#,
-            content,
-        )
-        .into_iter()
-        .next()
+        util::find_and_extract(r"ubuntu-([^-]+)-minimal-cloudimg-[^.]+.img", content)
+            .into_iter()
+            .next()
     }
 }
 


### PR DESCRIPTION
Restore the previous behavior of showing the image aliases like ubuntu:24.04.