### PR TITLE
feat: add --yes flag to prune command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -23,6 +23,7 @@ mod ssh_command;
 mod start_command;
 mod stop_command;
 mod verbosity;
+mod yes_arg;
 
 pub use clone_command::*;
 pub use command_dispatcher::*;
@@ -49,6 +50,7 @@ pub use ssh_command::*;
 pub use start_command::*;
 pub use stop_command::*;
 pub use verbosity::*;
+pub use yes_arg::*;
 
 use crate::error::Result;
 use crate::view::Console;

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -23,9 +23,8 @@ pub struct DeleteCommand {
     /// Delete the VM instances even when running (Deprecated)
     #[clap(hide = true, short, long, default_value_t = false)]
     force: bool,
-    /// Delete the VM instances without confirmation
-    #[clap(short, long, default_value_t = false)]
-    yes: bool,
+    #[clap(flatten)]
+    yes: commands::YesArg,
     /// Name of the VM instances to delete
     instances: Vec<String>,
 }
@@ -48,7 +47,7 @@ impl Command for DeleteCommand {
         }
 
         // Ask for confirmation
-        if self.yes || util::confirm("\nDo you want to proceed? [y/n]: ") {
+        if self.yes.value || util::confirm("\nDo you want to proceed? [y/n]: ") {
             // Stop the VM instances
             commands::StopCommand {
                 all: false,

--- a/src/commands/prune_command.rs
+++ b/src/commands/prune_command.rs
@@ -12,7 +12,10 @@ use clap::Parser;
 ///
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
-pub struct PruneCommand;
+pub struct PruneCommand {
+    #[clap(flatten)]
+    yes: commands::YesArg,
+}
 
 impl Command for PruneCommand {
     fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
@@ -35,7 +38,7 @@ impl Command for PruneCommand {
         // Print size of files to be deleted
         console.info(&format!("\nTotal size: {total}\n"));
 
-        if util::confirm("Are you sure you want to continue? [y/N]") {
+        if self.yes.value || util::confirm("Are you sure you want to continue? [y/N]") {
             // Delete files
             fs.remove_file(&env.get_image_cache_file()).ok();
             fs.remove_dir(&env.get_image_dir()).ok();

--- a/src/commands/yes_arg.rs
+++ b/src/commands/yes_arg.rs
@@ -1,0 +1,9 @@
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(verbatim_doc_comment)]
+pub struct YesArg {
+    /// Answer all questions with yes
+    #[clap(short = 'y', long = "yes", default_value_t = false)]
+    pub value: bool,
+}


### PR DESCRIPTION
Skips the confirmation prompt when deleting the image cache. This makes the command non-interactive, which is handy for scripts.