### PR TITLE
fix: show opensuse leap images in cubic images

### DIFF
--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -51,7 +51,7 @@ impl ImageFactory {
 
         let image_file = util::find_and_extract(
             &format!(
-                "href=\"({})\"",
+                "href=\"\\.?/?({})\"",
                 image_provider.get_image_file_pattern(name, arch)
             ),
             &image_content,


### PR DESCRIPTION
The OBS (Open Build Service) download server, which hosts OpenSUSE images, generates directory listings where file hrefs use a relative path prefix:

```
  href="./openSUSE-Leap-15.6.x86_64-NoCloud.qcow2"
```

The image factory was parsing image filenames with a regex that expected href="filename" (no prefix), so no match was ever found for OpenSUSE and the provider returned zero images.

Widen the regex to accept an optional leading dot and slash so both href="filename" (standard Apache) and href="./filename" (OBS) are handled correctly.