### PR TITLE
docs: improve contributor documentation and add security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,137 @@ Thank you for taking the time to contribute to Cubic!
 
 ## How to contribute?
 
-You can contribute by creating a pull request (PR) on the official Github repository:
-https://github.com/cubic-vm/cubic/pulls
+There are many ways to contribute, no matter your background:
 
-## What license does Cubic use?
+- **Report bugs** — open an [issue on GitHub](https://github.com/cubic-vm/cubic/issues) if something does not work as expected.
+- **Request features** — open an [issue on GitHub](https://github.com/cubic-vm/cubic/issues) to suggest improvements.
+- **Improve documentation** — fix typos, clarify explanations, or add missing guides in the `docs/` directory.
+- **Submit code changes** — open a [pull request](https://github.com/cubic-vm/cubic/pulls) with your fix or feature.
+- **Join the discussion** — share feedback and ideas on existing issues and pull requests.
 
-Cubic is dual-licensed under the MIT and Apache 2.0 licenses.
-By submitting a pull request, you agree that your contribution is licensed under these licenses.
+## How to set up a development environment?
+
+Before building Cubic, ensure you have the necessary tools installed:
+
+- **Git**
+- **GCC**
+- **Rustup**
+
+For **Debian**, **Ubuntu**, and derivatives:
+```bash
+sudo apt update && sudo apt install -y git gcc rustup
+```
+
+For **Fedora** and derivatives:
+```bash
+sudo dnf install -y git gcc rustup && sudo rustup-init -y
+```
+
+For **OpenSUSE** and derivatives:
+```bash
+sudo zypper install -y git gcc rustup
+```
+
+Then clone the repository:
+```bash
+git clone https://github.com/cubic-vm/cubic.git
+cd cubic/
+rustup toolchain add 1.92.0
+```
+
+## How to build?
+
+Debug build (fast compile, no optimisations):
+```bash
+cargo build
+```
+
+Release build (optimised, matches the distributed binary):
+```bash
+cargo build --locked --release
+```
+
+The release binary is written to `target/release/cubic`.
+
+> **Note:** `--locked` ensures the build uses the exact dependency versions
+> intended by the developers.
+
+## How to run the binary?
+
+```bash
+cargo run -- [COMMAND] [OPTIONS]
+```
+
+For example:
+```bash
+cargo run -- images
+cargo run -- --help
+```
+
+### Runtime dependencies
+
+To actually run virtual machines, Cubic requires QEMU to be installed on the host:
+
+- `qemu-system-x86_64`
+- `qemu-system-aarch64`
+- `qemu-img`
+
+## How to test?
+
+```bash
+cargo test
+```
+
+To run a single test by name:
+```bash
+cargo test <test_name>
+```
+
+## How to generate the documentation?
+
+The documentation is built with [Sphinx](https://www.sphinx-doc.org/).
+The source files live in the `docs/` directory and are written in
+[reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html).
+
+First, generate the CLI reference pages from the binary's help output:
+```bash
+./scripts/generate-docs.sh dev
+```
+
+Then build the HTML site:
+```bash
+sphinx-build docs target/doc
+```
+
+The output is written to `target/doc/`.
+
+## How to fix code formatting?
+
+```bash
+cargo fmt
+```
+
+To only check without modifying files:
+```bash
+cargo fmt --check
+```
+
+## How to lint?
+
+```bash
+cargo clippy -- -D warnings
+```
+
+To automatically apply safe fixes:
+```bash
+cargo clippy --fix --allow-dirty
+```
+
+## How to run a security audit?
+
+```bash
+cargo audit
+```
 
 ## How to create a good pull request?
 
@@ -19,9 +143,10 @@ High quality pull requests are easier to review and thus take less of your and o
 
 General guideline:
 - Each pull request must have exactly one intent (fix a bug, update doc, etc.).
-- Each pull request should have one Git commit (not mandatory, but recommend).
+- Each pull request should have one Git commit (not mandatory, but recommended).
 - Each Git commit must have a descriptive message that explains the changes.
-- Each Git commit must have a sign off (git commit --signoff).
+- Each Git commit must have a sign-off (`git commit --signoff`), which
+  indicates that you agree with the [Developer Certificate of Origin](https://developercertificate.org/).
 - Each Git commit message must start with either:
   - `feat: ...` for features
   - `fix: ...` for bug and security fixes
@@ -30,4 +155,12 @@ General guideline:
   - `chore: ...` for changes not related to source code
   - `revert: ...` for reverting a previous commit
 
-Mandatory check before creating a pull request: `task check`
+Before opening a pull request, please verify that your changes pass all checks:
+```bash
+cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo audit
+```
+
+## What license does Cubic use?
+
+Cubic is dual-licensed under the MIT and Apache 2.0 licenses.
+By submitting a pull request, you agree that your contribution is licensed under these licenses.

--- a/README.md
+++ b/README.md
@@ -160,50 +160,8 @@ Options:
 
 # :hammer: How to Build Cubic from Source?
 
-## Install Toolchain
-
-Before running the build commands, ensure you have the necessary tools installed:
-
-- **Git**
-- **GCC**
-- **Rustup**
-
-For **Debian**, **Ubuntu**, and derivatives:
-```bash
-sudo apt update && sudo apt install -y git gcc rustup
-```
-
-For **Fedora** and derivatives:
-```bash
-sudo dnf install -y git gcc rustup && sudo rustup-init -y
-```
-
-For **OpenSUSE** and derivatives:
-```bash
-sudo zypper install -y git gcc rustup
-```
-
-## Build Cubic
-
-Download the source code, navigate to the Cubic source directory and run the build command.
-
-```bash
-git clone https://github.com/cubic-vm/cubic.git
-cd cubic/
-rustup toolchain add 1.92.0
-cargo build --locked --release
-```
-The target executable is located at `target/release/cubic`.
-
-**Note**:
-- The `--release` flag is used to create an optimized version of the application.
-- The `--locked` flag is used to ensure the build uses the exact dependency versions intended by the developers.
-
-## Runtime Dependencies
-
-Once built, Cubic needs these tools to actually run the virtual machines:
-
-- **QEMU** (qemu-system-x86_64, qemu-system-arm64, qemu-img)
+See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on setting up a development
+environment and building the project.
 
 # :speech_balloon: How to contribute to Cubic?
 
@@ -213,6 +171,7 @@ We are actively looking for help to improve Cubic. You can help in various ways:
 - :star: Star us on [Github](https://github.com/cubic-vm/cubic) to promote the project!
 - :beetle: If you found a bug or you are interested in a feature, please create an [issue on Github](https://github.com/cubic-vm/cubic/issues)!
 - :construction_worker: If you are a developer and you want to submit a change, please have a look at the [contribution page](CONTRIBUTING.md)!
+- :pencil: If you are a technical writer and you want to improve the documentation, please have a look at the [contribution page](CONTRIBUTING.md)!
 
 # :page_with_curl: License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest release only.
+Older versions do not receive backported security patches.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |
+| older   | ❌        |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+If you discover a security vulnerability, please report it privately so that
+it can be assessed and fixed before public disclosure. You can report a
+vulnerability through GitHub's private vulnerability reporting:
+
+https://github.com/cubic-vm/cubic/security/advisories/new
+
+Please include as much of the following information as possible to help us
+understand and reproduce the issue:
+
+- A description of the vulnerability and its potential impact
+- The affected version(s)
+- Step-by-step instructions to reproduce the issue
+- Any relevant logs, screenshots, or proof-of-concept code
+
+## Response Process
+
+1. We will acknowledge receipt of your report.
+2. We will investigate and keep you informed of our progress.
+3. Once a fix is ready, we will coordinate a release and public disclosure
+   with you.
+
+We appreciate your effort in responsibly disclosing security issues and
+helping to keep Cubic safe for everyone.


### PR DESCRIPTION
# Summary

  - Overhauled `CONTRIBUTING.md` into a complete onboarding guide covering environment setup, build, run, test, documentation generation, formatting, linting, and security
  audit commands. Moved the build-from-source section from `README.md` (which now links to `CONTRIBUTING.md`) and added guidance for technical writers.
  - Introduced `SECURITY.md` with a vulnerability reporting policy, directing reporters to GitHub's private advisory system and describing the response process.

 # Changes

  - `CONTRIBUTING.md` — expanded from PR-convention-only to a full contributor guide; grammar fixes ("recommended", "sign-off" with DCO link); license section moved to end
  - `README.md` — build-from-source section replaced with a link to `CONTRIBUTING.md`. Technical-writer bullet added to the contribution section
  - `SECURITY.md` — new file; covers supported versions, private reporting via GitHub advisories, and response process

# Test plan

  - Read through `CONTRIBUTING.md` end-to-end and verify all commands are correct
  - Verify the GitHub advisory link in `SECURITY.md` resolves correctly
  - Confirm `README.md` links to `CONTRIBUTING.md` and renders correctly on GitHub