### PR TITLE
feat: publish crate to crates.io on v* tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,3 +192,24 @@ jobs:
         with:
           snap: ${{ env.SNAP_FILE }}
           release: ${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}
+
+  publish-crate:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: validate-packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        run: rustup toolchain install 1.92.0
+
+      - name: Set Version from Tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "0,/^version = /s/^version = .*/version = \"$VERSION\"/" Cargo.toml
+
+      - name: Publish to crates.io
+        run: cargo publish --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubic"
-version = "0.21.0"
+version = "0.0.0-dev"
 authors = ["Roger Knecht <rknecht@pm.me>"]
 license = "MIT OR Apache-2.0"
 description = """\


### PR DESCRIPTION
Add a publish-crate CI job that runs after validate-packages succeeds. The job triggers only on tags starting with 'v', patches Cargo.toml with the version derived from the tag (stripping the leading 'v'), and runs cargo publish. Between releases, Cargo.toml carries 0.0.0-dev so source builds are clearly identified as development builds.

Requires a CARGO_REGISTRY_TOKEN repository secret containing a crates.io API token with publish rights for the cubic crate.