### PR TITLE
fix: pin Rust toolchain to 1.92.0 in PR checks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,17 +15,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - check: cargo fmt --check
-            cargo: ""
-
-          - check: cargo clippy -- -D warnings
-            cargo: ""
-
+          - check: rustup component add rustfmt && cargo fmt --check
+          - check: rustup component add clippy && cargo clippy --version && cargo clippy -- -D warnings
           - check: cargo test
-            cargo: ""
-
-          - check: cargo audit
-            cargo: "cargo-audit"
+          - check: cargo install cargo-audit && cargo audit
 
     runs-on: ubuntu-latest
     steps:
@@ -33,10 +26,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        run: rustup toolchain install 1.92.0
-
-      - name: Install Tools
-        run: sh -c "[ -n \"${{ matrix.cargo }}\" ]  && cargo install ${{ matrix.cargo }} || true"
+        run: |
+            rustup toolchain install 1.92.0
+            rustup override set 1.92.0
 
       - name: Run Check
         run: ${{ matrix.check }}


### PR DESCRIPTION
Set an explicit Rust version for all check jobs in the pull request workflow. Without a pinned toolchain, the clippy and rustfmt versions used in CI were determined by whatever the image installed by default, making lint results non-reproducible across runs.