### PR TITLE
feat: introduce Vulnlog for structured vulnerability tracking

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,4 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2023-0071", # No fix available so far
+    "RUSTSEC-2023-0071",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,12 @@ RUN apt update && \
         python3-sphinx-rtd-theme \
         git \
         vim \
-        yamllint &&\
+        yamllint \
+        unzip \
+        curl &&\
+    curl -fsSL https://github.com/vulnlog/vulnlog/releases/download/v0.14.0/install-vulnlog.sh | sh &&\
     git config --global --add safe.directory /usr/local/app
 RUN rustup component add clippy rustfmt && \
     cargo install --locked cargo-audit &&\
-    echo 'alias cubic="cargo run"' >> ~/.bashrc
+    echo 'alias cubic="cargo run"' >> ~/.bashrc &&\
+    echo 'alias vulnlog="/root/bin/vulnlog"' >> ~/.bashrc

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ doc: build-image
 	@${DOCKER_CMD} -it ${IMAGE} sphinx-build docs target/doc
 	@${DOCKER_CMD} -it ${IMAGE} python3 -m http.server -d target/doc 4000
 
+suppress: build-image
+	@${DOCKER_CMD} -it ${IMAGE} /root/bin/vulnlog suppress vulnlog.yml -o .cargo/audit.toml
+
 release: build-image
 	sed "s/^\(version =\).*$$/\1 \"${version}\"/g" -i Cargo.toml
 	make build

--- a/vulnlog.yml
+++ b/vulnlog.yml
@@ -1,0 +1,24 @@
+---
+schemaVersion: "1"
+
+project:
+  organization: "cubic-vm"
+  name: "cubic"
+  author: "Cubic VM team"
+
+releases: []
+
+vulnerabilities:
+  - id: RUSTSEC-2023-0071
+    releases: []
+    packages: ["pkg:cargo/rsa@0.9.10"]
+    reports:
+      - reporter: cargo-audit
+    verdict: not affected
+    justification: vulnerable code not in execute path
+    description: >
+      This is a timing attack that could allow an attacker to recover RSA keys from the server.
+    analysis: >
+      The RSA crate is only used for client authentication.
+    comment: >
+      See https://github.com/Eugeny/russh/issues/637


### PR DESCRIPTION
Replace inline comments in .cargo/audit.toml with vulnlog.yml, a structured file for documenting vulnerability verdicts and analysis.

A new `make suppress` target generates .cargo/audit.toml from vulnlog.yml via `vulnlog suppress`. The Dockerfile installs the vulnlog binary so the target can run inside the build container.