### PR TITLE
chore: validate PR commit messages

### DIFF
--- a/.github/scripts/check-pr-commits.sh
+++ b/.github/scripts/check-pr-commits.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the pull request range from CI arguments or local environment.
+base_sha="${1:-${BASE_SHA:-}}"
+head_sha="${2:-${HEAD_SHA:-HEAD}}"
+
+if [[ -z "$base_sha" ]]; then
+    echo "::error::Base commit SHA is required."
+    exit 2
+fi
+
+# Make sure both endpoints are present before walking the PR commits.
+for revision in "$base_sha" "$head_sha"; do
+    if ! git cat-file -e "${revision}^{commit}" 2>/dev/null; then
+        echo "::error::Commit '${revision}' is not available in the checkout."
+        exit 2
+    fi
+done
+
+# Match the commit type prefixes documented in CONTRIBUTING.md.
+commit_subject='^(feat|fix|refactor|docs|chore|revert): .+'
+
+has_error=0
+
+while read -r commit_hash; do
+    short_sha="$(git rev-parse --short "$commit_hash")"
+    message="$(git show -s --format=%B "$commit_hash" | tr -d '\r')"
+    subject="$(printf '%s\n' "$message" | sed -n '1p')"
+    last_line="$(printf '%s\n' "$message" | sed '/^[[:space:]]*$/d' | tail -n 1)"
+    line_count="$(wc -l <<< "$message")"
+
+    if ! printf '%s\n' "$subject" | grep -Eq "$commit_subject" ||
+        [[ "$line_count" -lt 4 ]] ||
+        [[ "$last_line" != Signed-off-by:* ]]; then
+        echo "::error::${short_sha} is not formatted according to the CONTRIBUTING.md."
+        has_error=1
+    fi
+done < <(git log "${base_sha}..${head_sha}" --pretty=tformat:"%H")
+
+exit "$has_error"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -46,6 +46,21 @@ jobs:
       - name: Lint YAML
         run: yamllint --strict .
 
+  commits:
+    name: Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Commit Messages
+        run: >
+          bash .github/scripts/check-pr-commits.sh
+          "${{ github.event.pull_request.base.sha }}"
+          "${{ github.event.pull_request.head.sha }}"
+
   build:
     name: Build
     strategy:


### PR DESCRIPTION
Fixes #385.

## What changed
- Added a dependency-free Bash check for pull request commits.
- The check requires each commit in the PR range to have a subject plus at least one non-empty descriptive body line, excluding `Signed-off-by` trailers.
- The check also requires a `Signed-off-by: Name <email>` trailer.
- Added a `Commit Messages` pull request workflow job that checks out full history and passes the PR base/head SHAs to the script.

## Validation
- Temp git repo smoke test: valid commit passed; missing descriptive body failed; missing `Signed-off-by` failed.
- `bash -n .github/scripts/check-pr-commits.sh`
- `PYTHONPATH=/private/tmp/cubic-yamllint python3 -m yamllint --strict .github/workflows/pull-request.yml .yamllint`
- `git diff --check`
- `git diff --cached --check`
- `git diff origin/main..HEAD --check`
- `git diff origin/main..HEAD | gitleaks stdin --no-banner --redact --exit-code 1`
- `cargo fmt --check`
- `rustup run 1.92.0 cargo test` (`132 passed`)
- `rustup run 1.92.0 cargo clippy -- -D warnings`
- `rustup run 1.92.0 cargo audit`

## Limitations
- The new GitHub Actions job has not run upstream yet; local validation covered the script behavior and workflow YAML.
