### PR TITLE
refactor: code quality improvements across error handling and parsing

### DIFF
--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -50,7 +50,7 @@ impl Command for CloneCommand {
         // Setup target instance info
         let mut target = source.clone();
         target.name = self.new_name.to_string();
-        target.ssh_port = PortChecker::new().get_new_port();
+        target.ssh_port = PortChecker::new().get_new_port()?;
 
         // Create VM instance
         CreateInstanceAction::new().run(context, &FS::new(), image_path, target)?;

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -77,7 +77,7 @@ impl Command for CreateCommand {
         let instance_store = context.get_instance_store();
 
         if instance_store.exists(self.instance_name.as_str()) {
-            return Result::Err(Error::InstanceAlreadyExists(self.instance_name.to_string()));
+            return Err(Error::InstanceAlreadyExists(self.instance_name.to_string()));
         }
 
         // Fetch image
@@ -108,6 +108,6 @@ impl Command for CreateCommand {
         CreateInstanceAction::new().run(context, &FS::new(), image_path, instance)?;
 
         create_spinner.stop();
-        Result::Ok(())
+        Ok(())
     }
 }

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -85,6 +85,7 @@ impl Command for CreateCommand {
         fetch_image(env, context.get_image_store(), image)?;
 
         let mut create_spinner = SpinnerView::new("Creating virtual machine instance".to_string());
+        let ssh_port = PortChecker::new().get_new_port()?;
 
         let instance = Instance {
             name: self.instance_name.to_string(),
@@ -97,7 +98,7 @@ impl Command for CreateCommand {
             cpus: self.cpus,
             mem: self.memory.clone(),
             disk_capacity: self.disk.clone(),
-            ssh_port: PortChecker::new().get_new_port(),
+            ssh_port,
             hostfwd: self.port.clone(),
             execute: self.execute.clone(),
             isolate: self.isolate,

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -36,7 +36,7 @@ impl Command for DeleteCommand {
         // Check if the instance names are valid
         for instance in &self.instances {
             if !instance_store.exists(instance) {
-                return Result::Err(Error::UnknownInstance(instance.clone()));
+                return Err(Error::UnknownInstance(instance.clone()));
             }
         }
 

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -62,7 +62,7 @@ impl Command for ListInstanceCommand {
                 );
         }
         view.print(console);
-        Result::Ok(())
+        Ok(())
     }
 }
 

--- a/src/commands/modify_command.rs
+++ b/src/commands/modify_command.rs
@@ -95,6 +95,6 @@ impl Command for ModifyCommand {
         instance.hostfwd.retain(|p| !self.rm_port.contains(p));
 
         instance_store.store(&instance)?;
-        Result::Ok(())
+        Ok(())
     }
 }

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -16,7 +16,7 @@ impl Command for ShowInstanceCommand {
         let instance_store = context.get_instance_store();
 
         if !instance_store.exists(self.instance.as_str()) {
-            return Result::Err(Error::UnknownInstance(self.instance.to_string()));
+            return Err(Error::UnknownInstance(self.instance.to_string()));
         }
 
         let instance = instance_store.load(self.instance.as_str())?;
@@ -170,7 +170,7 @@ SSH:        ssh -p 8000 john@localhost
                 instance: InstanceName::from_str("test").unwrap()
             }
             .run(console, &context),
-            Result::Err(Error::UnknownInstance(_))
+            Err(Error::UnknownInstance(_))
         ));
     }
 }

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -53,7 +53,7 @@ impl Command for StartCommand {
             if !async_caller.call(russh.is_running(instance.ssh_port)) {
                 // Make SSH port is available
                 if PortChecker::new().is_open(instance.ssh_port) {
-                    instance.ssh_port = PortChecker::new().get_new_port();
+                    instance.ssh_port = PortChecker::new().get_new_port()?;
                     instance_store.store(instance)?;
                 }
 

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -73,6 +73,6 @@ impl Command for StartCommand {
             spinner.stop()
         }
 
-        Result::Ok(())
+        Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -114,4 +114,12 @@ Troubleshoot:
 
     #[error("Invalid path: {0}")]
     InvalidPath(String),
+
+    #[error(
+        "No available port found.\n\nAll ports are currently in use. Stop unused processes and try again."
+    )]
+    NoPortAvailable,
+
+    #[error("SFTP Error: {0}")]
+    Sftp(String),
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -15,7 +15,7 @@ impl FS {
                 .map_err(|e| Error::FS(format!("Cannot create directory '{path}' ({e})")));
         }
 
-        Result::Ok(())
+        Ok(())
     }
 
     pub fn read_dir(&self, path: &str) -> Result<fs::ReadDir> {
@@ -43,7 +43,7 @@ impl FS {
             return Err(Error::FS(format!("Cannot write directory '{path}'")));
         }
 
-        Result::Ok(())
+        Ok(())
     }
 
     pub fn create_file(&self, path: &str) -> Result<fs::File> {

--- a/src/image/image_dao.rs
+++ b/src/image/image_dao.rs
@@ -11,7 +11,7 @@ pub struct ImageDao {
 impl ImageDao {
     pub fn new(env: &Environment) -> Result<Self> {
         FS::new().setup_directory_access(&env.get_image_dir())?;
-        Result::Ok(ImageDao { env: env.clone() })
+        Ok(ImageDao { env: env.clone() })
     }
 }
 

--- a/src/image/image_fetcher.rs
+++ b/src/image/image_fetcher.rs
@@ -3,6 +3,9 @@ use crate::models::{HashAlg, Image};
 use crate::view::{SpinnerView, TransferView};
 use crate::web::WebClient;
 use regex::Regex;
+use std::sync::LazyLock;
+
+static HEX_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new("^[0-9A-Fa-f]+$").unwrap());
 
 pub struct ImageFetcher {}
 
@@ -17,7 +20,6 @@ impl ImageFetcher {
         image: &Image,
     ) -> Result<Option<(HashAlg, String)>> {
         if let Some(pos) = image.image_url.rfind("/") {
-            let regex = Regex::new("^[0-9A-Fa-f]+$").unwrap();
             let file_name = &image.image_url[pos + 1..image.image_url.len()];
             let content = client.download_content(&image.checksum_url)?;
             for line in content.lines() {
@@ -35,7 +37,7 @@ impl ImageFetcher {
                     .collect::<Vec<_>>();
                 let hashsums = tokens
                     .iter()
-                    .filter(|i| regex.is_match(i))
+                    .filter(|i| HEX_REGEX.is_match(i))
                     .collect::<Vec<_>>();
 
                 if let (&[_], &[hashsum]) = (file_names.as_slice(), hashsums.as_slice()) {

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -76,7 +76,7 @@ impl InstanceStore for InstanceDao {
                 (yaml_path, Box::new(YamlInstanceDeserializer::new()))
             };
 
-        Ok(self
+        let instance = self
             .fs
             .open_file(path)
             .ok()
@@ -87,16 +87,20 @@ impl InstanceStore for InstanceDao {
                     .map(|info| DataSize::new(info.actual_size as usize));
                 instance.disk_used = size;
                 instance
-            })
-            .unwrap_or(Instance {
+            });
+
+        Ok(match instance {
+            Some(i) => i,
+            None => Instance {
                 name: name.to_string(),
                 user: self.env.get_username().to_string(),
                 cpus: 1,
                 mem: DataSize::from_str("1G").unwrap(),
                 disk_capacity: DataSize::from_str("1G").unwrap(),
-                ssh_port: PortChecker::new().get_new_port(),
+                ssh_port: PortChecker::new().get_new_port()?,
                 ..Instance::default()
-            }))
+            },
+        })
     }
 
     fn store(&self, instance: &Instance) -> Result<()> {

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -27,7 +27,7 @@ impl InstanceDao {
         fs.setup_directory_access(env.get_cache_dir())?;
         fs.setup_directory_access(env.get_runtime_dir())?;
 
-        Result::Ok(InstanceDao {
+        Ok(InstanceDao {
             fs,
             env: env.clone(),
         })
@@ -63,7 +63,7 @@ impl InstanceStore for InstanceDao {
 
     fn load(&self, name: &str) -> Result<Instance> {
         if !self.exists(name) {
-            return Result::Err(Error::UnknownInstance(name.to_string()));
+            return Err(Error::UnknownInstance(name.to_string()));
         }
 
         let yaml_path = &self.env.get_instance_yaml_config_file(name);
@@ -117,24 +117,24 @@ impl InstanceStore for InstanceDao {
 
     fn rename(&self, instance: &mut Instance, new_name: &str) -> Result<()> {
         if self.exists(new_name) {
-            Result::Err(Error::InstanceAlreadyExists(new_name.to_string()))
+            Err(Error::InstanceAlreadyExists(new_name.to_string()))
         } else if self.is_running(instance) {
-            Result::Err(Error::InstanceNotStopped(instance.name.to_string()))
+            Err(Error::InstanceNotStopped(instance.name.to_string()))
         } else {
             self.fs.rename_file(
                 &self.env.get_instance_dir2(&instance.name),
                 &self.env.get_instance_dir2(new_name),
             )?;
             instance.name = new_name.to_string();
-            Result::Ok(())
+            Ok(())
         }
     }
 
     fn resize(&self, instance: &mut Instance, size: u64) -> Result<()> {
         if self.is_running(instance) {
-            Result::Err(Error::InstanceNotStopped(instance.name.to_string()))
+            Err(Error::InstanceNotStopped(instance.name.to_string()))
         } else if instance.disk_capacity.get_bytes() >= size as usize {
-            Result::Err(Error::CannotShrinkDisk(instance.name.to_string()))
+            Err(Error::CannotShrinkDisk(instance.name.to_string()))
         } else {
             SystemCommand::new("qemu-img")
                 .arg("resize")
@@ -142,13 +142,13 @@ impl InstanceStore for InstanceDao {
                 .arg(size.to_string())
                 .run()?;
             instance.disk_capacity = DataSize::new(size as usize);
-            Result::Ok(())
+            Ok(())
         }
     }
 
     fn delete(&self, instance: &Instance) -> Result<()> {
         if self.is_running(instance) {
-            Result::Err(Error::InstanceNotStopped(instance.name.to_string()))
+            Err(Error::InstanceNotStopped(instance.name.to_string()))
         } else {
             self.fs
                 .remove_dir(&self.env.get_instance_runtime_dir(&instance.name))

--- a/src/instance/instance_store_mock.rs
+++ b/src/instance/instance_store_mock.rs
@@ -33,19 +33,19 @@ pub mod tests {
         }
 
         fn store(&self, _instance: &Instance) -> Result<()> {
-            Result::Ok(())
+            Ok(())
         }
 
         fn rename(&self, _instance: &mut Instance, _new_name: &str) -> Result<()> {
-            Result::Ok(())
+            Ok(())
         }
 
         fn resize(&self, _instance: &mut Instance, _size: u64) -> Result<()> {
-            Result::Ok(())
+            Ok(())
         }
 
         fn delete(&self, _instance: &Instance) -> Result<()> {
-            Result::Ok(())
+            Ok(())
         }
 
         fn is_running(&self, _instance: &Instance) -> bool {

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -56,7 +56,7 @@ ssh_port = 14357
 
         let instance = TomlInstanceDeserializer::new()
             .deserialize("test", reader)
-            .expect("Cannot parser config");
+            .expect("Cannot parse config");
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "cubic");
         assert_eq!(instance.cpus, 1);
@@ -86,7 +86,7 @@ isolate = true
 
         let instance = TomlInstanceDeserializer::new()
             .deserialize("test", reader)
-            .expect("Cannot parser config");
+            .expect("Cannot parse config");
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "tux");
         assert_eq!(instance.cpus, 1);
@@ -120,7 +120,7 @@ ssh_port = 14357
 
         let instance = TomlInstanceDeserializer::new()
             .deserialize("test", reader)
-            .expect("Cannot parser config");
+            .expect("Cannot parse config");
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "tux");
         assert_eq!(instance.cpus, 1);

--- a/src/instance/yaml_instance_deserializer.rs
+++ b/src/instance/yaml_instance_deserializer.rs
@@ -51,7 +51,7 @@ machine:
 
         let instance = YamlInstanceDeserializer::new()
             .deserialize("test", reader)
-            .expect("Cannot parser config");
+            .expect("Cannot parse config");
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "cubic");
         assert_eq!(instance.cpus, 1);
@@ -78,7 +78,7 @@ machine:
 
         let instance = YamlInstanceDeserializer::new()
             .deserialize("test", reader)
-            .expect("Cannot parser config");
+            .expect("Cannot parse config");
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "tux");
         assert_eq!(instance.cpus, 1);
@@ -112,7 +112,7 @@ machine:
 
         let instance = YamlInstanceDeserializer::new()
             .deserialize("test", reader)
-            .expect("Cannot parser config");
+            .expect("Cannot parse config");
         assert_eq!(instance.name, "test");
         assert_eq!(instance.user, "tux");
         assert_eq!(instance.cpus, 1);

--- a/src/models/arch.rs
+++ b/src/models/arch.rs
@@ -14,7 +14,7 @@ impl Arch {
         match arch {
             "amd64" => Ok(Arch::AMD64),
             "arm64" => Ok(Arch::ARM64),
-            _ => Result::Err(Error::UnknownArch(arch.to_string())),
+            _ => Err(Error::UnknownArch(arch.to_string())),
         }
     }
 

--- a/src/models/image_name.rs
+++ b/src/models/image_name.rs
@@ -2,6 +2,10 @@ use crate::models::Arch;
 use regex::Regex;
 use std::fmt;
 use std::str::FromStr;
+use std::sync::LazyLock;
+
+static IMAGE_NAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new("^(\\w+):([\\w\\.]+)(:(amd64|arm64))?$").unwrap());
 
 #[cfg(target_arch = "aarch64")]
 pub fn get_default_arch() -> Arch {
@@ -38,10 +42,7 @@ impl FromStr for ImageName {
     type Err = String;
 
     fn from_str(name: &str) -> Result<Self, Self::Err> {
-        if Regex::new("^(\\w+):([\\w\\.]+)(:(amd64|arm64))?$")
-            .unwrap()
-            .is_match(name)
-        {
+        if IMAGE_NAME_REGEX.is_match(name) {
             let mut tokens = name.split(':');
             let vendor = tokens.next().unwrap().to_string();
             let name = tokens.next().unwrap().to_string();

--- a/src/models/instance_name.rs
+++ b/src/models/instance_name.rs
@@ -1,6 +1,9 @@
 use regex::Regex;
 use std::fmt;
 use std::str::FromStr;
+use std::sync::LazyLock;
+
+static INSTANCE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new("^[\\w_-]+$").unwrap());
 
 #[derive(Clone)]
 pub struct InstanceName {
@@ -17,7 +20,7 @@ impl FromStr for InstanceName {
     type Err = String;
 
     fn from_str(name: &str) -> Result<Self, Self::Err> {
-        if Regex::new("^[\\w_-]+$").unwrap().is_match(name) {
+        if INSTANCE_NAME_REGEX.is_match(name) {
             Ok(Self {
                 name: name.to_string(),
             })

--- a/src/models/port_forward.rs
+++ b/src/models/port_forward.rs
@@ -4,6 +4,12 @@ use std::fmt::{Display, Error, Formatter};
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
+use std::sync::LazyLock;
+
+static QEMU_PORT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(\w+)?:([\d.:]+)?:(\d+)-:(\d+)$").unwrap());
+static PORT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(([\d.:]+):)?(\d+):(\d+)(/(\w+))?$").unwrap());
 
 const FORMAT_ERROR: &str = "Must comply with format: [host_ip:]host_port:guest_port[/(udp|tcp)] (e.g. -p 8000:80 or -p 127.0.0.1:9000:90/tcp)";
 const QEMU_FORMAT_ERROR: &str = "Must comply with format: [tcp|udp]:[hostaddr]:hostport-[guestaddr]:guestport (e.g. ::8000-:80 or -p tcp:127.0.0.1:9000-:90)";
@@ -96,8 +102,7 @@ impl PortForward {
     }
 
     pub fn from_qemu(value: &str) -> Result<Self, String> {
-        let re = Regex::new(r"^(\w+)?:([\d.:]+)?:(\d+)-:(\d+)$").unwrap();
-        let caps: Vec<_> = re
+        let caps: Vec<_> = QEMU_PORT_REGEX
             .captures(value)
             .ok_or(QEMU_FORMAT_ERROR.to_string())?
             .iter()
@@ -138,8 +143,7 @@ impl FromStr for PortForward {
     type Err = String;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let re = Regex::new(r"^(([\d.:]+):)?(\d+):(\d+)(/(\w+))?$").unwrap();
-        let caps: Vec<_> = re
+        let caps: Vec<_> = PORT_REGEX
             .captures(value)
             .ok_or(FORMAT_ERROR.to_string())?
             .iter()

--- a/src/models/target_instance_path.rs
+++ b/src/models/target_instance_path.rs
@@ -1,6 +1,9 @@
 use crate::models::Instance;
 use regex::Regex;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+static HOME_DIR_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new("^~").unwrap());
 
 #[derive(Clone)]
 pub struct TargetInstancePath {
@@ -11,13 +14,13 @@ pub struct TargetInstancePath {
 
 impl TargetInstancePath {
     pub fn to_pathbuf(&self) -> PathBuf {
-        let re = Regex::new("^~").unwrap();
         let path = if let Some(user) = self
             .user
             .clone()
             .or(self.instance.as_ref().map(|i| i.user.clone()))
         {
-            re.replace_all(&self.path, &format!("/home/{user}"))
+            HOME_DIR_REGEX
+                .replace_all(&self.path, &format!("/home/{user}"))
                 .to_string()
         } else {
             self.path.to_string()

--- a/src/ssh_cmd/port_checker.rs
+++ b/src/ssh_cmd/port_checker.rs
@@ -1,3 +1,4 @@
+use crate::error::{Error, Result};
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
 
@@ -18,11 +19,11 @@ impl PortChecker {
             .is_ok()
     }
 
-    pub fn get_new_port(&self) -> u16 {
+    pub fn get_new_port(&self) -> Result<u16> {
         TcpListener::bind("127.0.0.1:0")
-            .unwrap()
+            .map_err(|_| Error::NoPortAvailable)?
             .local_addr()
-            .unwrap()
-            .port()
+            .map(|addr| addr.port())
+            .map_err(|_| Error::NoPortAvailable)
     }
 }

--- a/src/ssh_cmd/sftp_path.rs
+++ b/src/ssh_cmd/sftp_path.rs
@@ -14,18 +14,25 @@ pub struct SftpPath {
 }
 
 impl SftpPath {
-    pub fn name(&self) -> String {
-        self.path.file_name().unwrap().to_str().unwrap().to_string()
+    pub fn name(&self) -> Result<String> {
+        self.path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| Error::InvalidPath(self.path.display().to_string()))
     }
 
     pub fn to_str(&self) -> &str {
         self.path.to_str().unwrap()
     }
 
-    pub async fn exists(&self) -> bool {
+    pub async fn exists(&self) -> Result<bool> {
         match &self.sftp {
-            None => self.path.exists(),
-            Some(sftp) => sftp.try_exists(self.to_str()).await.unwrap(),
+            None => Ok(self.path.exists()),
+            Some(sftp) => sftp
+                .try_exists(self.to_str())
+                .await
+                .map_err(|e| Error::FS(e.to_string())),
         }
     }
 
@@ -80,29 +87,49 @@ impl SftpPath {
         }
     }
 
-    pub async fn open_file(&self) -> Box<dyn AsyncRead + Unpin> {
+    pub async fn open_file(&self) -> Result<Box<dyn AsyncRead + Unpin>> {
         match &self.sftp {
-            None => Box::new(tokio::fs::File::open(self.path.clone()).await.unwrap()),
-            Some(sftp) => Box::new(sftp.open(self.to_str()).await.unwrap()),
+            None => tokio::fs::File::open(self.path.clone())
+                .await
+                .map(|f| Box::new(f) as Box<dyn AsyncRead + Unpin>)
+                .map_err(Error::Io),
+            Some(sftp) => sftp
+                .open(self.to_str())
+                .await
+                .map(|f| Box::new(f) as Box<dyn AsyncRead + Unpin>)
+                .map_err(|e| Error::FS(e.to_string())),
         }
     }
 
-    pub async fn create_file(&self) -> Box<dyn AsyncWrite + Unpin> {
+    pub async fn create_file(&self) -> Result<Box<dyn AsyncWrite + Unpin>> {
         match &self.sftp {
-            None => Box::new(tokio::fs::File::create(self.path.clone()).await.unwrap()),
-            Some(sftp) => Box::new(sftp.create(self.to_str()).await.unwrap()),
+            None => tokio::fs::File::create(self.path.clone())
+                .await
+                .map(|f| Box::new(f) as Box<dyn AsyncWrite + Unpin>)
+                .map_err(Error::Io),
+            Some(sftp) => sftp
+                .create(self.to_str())
+                .await
+                .map(|f| Box::new(f) as Box<dyn AsyncWrite + Unpin>)
+                .map_err(|e| Error::FS(e.to_string())),
         }
     }
 
-    pub async fn write_file(&self, name: &str, size: usize, content: Box<dyn AsyncRead + Unpin>) {
+    pub async fn write_file(
+        &self,
+        name: &str,
+        size: usize,
+        content: Box<dyn AsyncRead + Unpin>,
+    ) -> Result<()> {
         let name = &format!("{:30}", &name[max(30, name.len()) - 30..name.len()]);
         let read = &mut AsyncTransferView::new(name, std::pin::Pin::new(content), size);
-        tokio::io::copy(read, &mut self.create_file().await)
+        tokio::io::copy(read, &mut self.create_file().await?)
             .await
-            .unwrap();
+            .map(|_| ())
+            .map_err(Error::Io)
     }
 
-    pub async fn read_dir(&self) -> Vec<SftpPath> {
+    pub async fn read_dir(&self) -> Result<Vec<SftpPath>> {
         let mut children = Vec::new();
         match &self.sftp {
             None => {
@@ -116,7 +143,11 @@ impl SftpPath {
                 }
             }
             Some(sftp) => {
-                for entry in sftp.read_dir(self.to_str()).await.unwrap() {
+                for entry in sftp
+                    .read_dir(self.to_str())
+                    .await
+                    .map_err(|e| Error::FS(e.to_string()))?
+                {
                     children.push(Self {
                         sftp: Some(sftp.clone()),
                         path: Path::new(&format!("{}/{}", self.to_str(), entry.file_name()))
@@ -125,13 +156,16 @@ impl SftpPath {
                 }
             }
         }
-        children
+        Ok(children)
     }
 
-    pub async fn create_path(&self) {
+    pub async fn create_path(&self) -> Result<()> {
         match &self.sftp {
-            None => fs::create_dir(self.path.clone()).unwrap(),
-            Some(sftp) => sftp.create_dir(self.to_str()).await.unwrap(),
+            None => fs::create_dir(self.path.clone()).map_err(Error::Io),
+            Some(sftp) => sftp
+                .create_dir(self.to_str())
+                .await
+                .map_err(|e| Error::FS(e.to_string())),
         }
     }
 
@@ -139,19 +173,19 @@ impl SftpPath {
         if self.is_file().await? {
             let name = &self.path.display().to_string();
             let size = self.get_file_size().await?;
-            let reader = self.open_file().await;
-            if target.exists().await && target.is_dir().await? {
+            let reader = self.open_file().await?;
+            if target.exists().await? && target.is_dir().await? {
                 target
-                    .append(&self.name())
+                    .append(&self.name()?)
                     .write_file(name, size, reader)
-                    .await;
+                    .await?;
             } else {
-                target.write_file(name, size, reader).await;
+                target.write_file(name, size, reader).await?;
             }
         } else if self.is_dir().await? {
-            let target_dir = target.append(&self.name());
-            target_dir.create_path().await;
-            for entry in self.read_dir().await {
+            let target_dir = target.append(&self.name()?);
+            target_dir.create_path().await?;
+            for entry in self.read_dir().await? {
                 Box::pin(entry.recursive_copy(target_dir.clone())).await?;
             }
         }
@@ -160,11 +194,15 @@ impl SftpPath {
     }
 
     pub async fn copy(&self, target: SftpPath) -> Result<()> {
-        if target.exists().await || self.is_file().await? {
+        if !self.exists().await? {
+            return Err(Error::InvalidPath(self.path.display().to_string()));
+        }
+
+        if target.exists().await? || self.is_file().await? {
             self.recursive_copy(target).await?;
         } else if self.is_dir().await? {
-            target.create_path().await;
-            for entry in self.read_dir().await {
+            target.create_path().await?;
+            for entry in self.read_dir().await? {
                 entry.recursive_copy(target.clone()).await?;
             }
         }

--- a/src/ssh_cmd/sftp_path.rs
+++ b/src/ssh_cmd/sftp_path.rs
@@ -32,7 +32,7 @@ impl SftpPath {
             Some(sftp) => sftp
                 .try_exists(self.to_str())
                 .await
-                .map_err(|e| Error::FS(e.to_string())),
+                .map_err(|e| Error::Sftp(e.to_string())),
         }
     }
 
@@ -97,7 +97,7 @@ impl SftpPath {
                 .open(self.to_str())
                 .await
                 .map(|f| Box::new(f) as Box<dyn AsyncRead + Unpin>)
-                .map_err(|e| Error::FS(e.to_string())),
+                .map_err(|e| Error::Sftp(e.to_string())),
         }
     }
 
@@ -111,7 +111,7 @@ impl SftpPath {
                 .create(self.to_str())
                 .await
                 .map(|f| Box::new(f) as Box<dyn AsyncWrite + Unpin>)
-                .map_err(|e| Error::FS(e.to_string())),
+                .map_err(|e| Error::Sftp(e.to_string())),
         }
     }
 
@@ -146,7 +146,7 @@ impl SftpPath {
                 for entry in sftp
                     .read_dir(self.to_str())
                     .await
-                    .map_err(|e| Error::FS(e.to_string()))?
+                    .map_err(|e| Error::Sftp(e.to_string()))?
                 {
                     children.push(Self {
                         sftp: Some(sftp.clone()),
@@ -165,7 +165,7 @@ impl SftpPath {
             Some(sftp) => sftp
                 .create_dir(self.to_str())
                 .await
-                .map_err(|e| Error::FS(e.to_string())),
+                .map_err(|e| Error::Sftp(e.to_string())),
         }
     }
 

--- a/src/web/web_client.rs
+++ b/src/web/web_client.rs
@@ -91,7 +91,7 @@ impl WebClient {
         }
 
         if Path::new(&file_path).exists() {
-            return Result::Ok(Checksum::default());
+            return Ok(Checksum::default());
         }
 
         let mut resp = self.client.get(url).send().map_err(Error::from)?;


### PR DESCRIPTION
## Changes

### Propagate errors in SftpPath instead of panicking
`open_file`, `create_file`, `write_file`, `read_dir,` `create_path`, `exists`, and name now return Result so I/O failures surface as errors rather than crashing the process. A missing source path in `cubic scp` now produces a clear error message instead of silently succeeding.

### Add NoPortAvailable and Sftp error variants
Port allocation failures and SFTP transfer errors now have dedicated error variants with actionable messages. `PortChecker::get_new_port` returns `Result<u16> ` and all call sites propagate the error.

### Cache regex compilation with LazyLock
Constant regex patterns in `image_name`, `instance_name`, `port_forward`, `target_instance_path`, and `image_fetcher` are now compiled once at first use rather than on every call.

### Use idiomatic `Ok`/`Err` instead of `Result::Ok`/`Result::Err`
27 occurrences replaced across 12 files. No behaviour change.

### Fix typo in deserializer test messages
"Cannot parser config" → "Cannot parse config"