### PR TITLE
fix: correct workflow toolchain pinning and packaging flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ${{ matrix.packages }}
 
       - name: Setup Rust
-        run: rustup target add ${{ matrix.target }}
+        run: |
+          rustup toolchain install 1.92.0
+          rustup override set 1.92.0
+          rustup target add ${{ matrix.target }}
 
       - name: Build Executable
         run: cargo build --locked --release --target ${{ matrix.target }}
@@ -88,7 +91,7 @@ jobs:
         run: cargo install cargo-deb
 
       - name: Build Debian Package
-        run: cargo deb
+        run: cargo deb -- --locked
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,11 +22,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Install Sphinx
-        run: sudo apt install -y python3-sphinx python3-sphinx-rtd-theme
-
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install Sphinx
+        run: sudo apt install -y python3-sphinx python3-sphinx-rtd-theme
 
       - name: Generate Docs
         run: ./scripts/generate-docs.sh ${{ github.ref_name }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -72,7 +72,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        run: rustup toolchain install 1.92.0
+        run: |
+          rustup toolchain install 1.92.0
+          rustup override set 1.92.0
 
       - name: Build Source Code
         run: cargo build

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 version="$1"
 


### PR DESCRIPTION
Pin Rust 1.92.0 in the build job of build.yml (was using the runner default, unlike every other job in the repository). Activate the pinned toolchain in the pull-request build job, which installed 1.92.0 but never set the override, so cargo was still using the runner default. Add --locked to cargo deb so the Debian package build is reproducible.

Move the checkout step before the Sphinx install in doc.yml so the job follows the standard order. Add set -euo pipefail to generate-docs.sh so failures in cargo run or sed are not silently swallowed.