### PR TITLE
feat: look up edk2/OVMF firmware instead of hardcoding paths

### DIFF
--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -2,6 +2,7 @@ use crate::cloudinit::UserDataImageFactory;
 use crate::commands::Context;
 use crate::emulator::Emulator;
 use crate::error::Result;
+use crate::firmware::FirmwareFinder;
 use crate::fs::FS;
 use crate::models::Instance;
 use crate::ssh_cmd::PortChecker;
@@ -31,10 +32,12 @@ impl StartInstanceAction {
         FS::new().setup_directory_access(&env.get_instance_runtime_dir(&self.instance.name))?;
         UserDataImageFactory.create_rust(env, &self.instance)?;
 
-        let mut emulator = Emulator::from(
-            self.instance.arch,
-            std::env::var("SNAP").as_deref().unwrap_or_default(),
-        )?;
+        let snap = std::env::var("SNAP").ok();
+        let snap_str = snap.as_deref();
+
+        let mut emulator = Emulator::from(self.instance.arch)?;
+        let firmware = FirmwareFinder::new(self.instance.arch, snap_str).find()?;
+        emulator.set_firmware(&firmware);
         emulator.set_cpus(self.instance.cpus);
         emulator.set_memory(self.instance.mem.get_bytes() as u64);
         emulator.set_console(&env.get_console_file(&self.instance.name));
@@ -51,7 +54,7 @@ impl StartInstanceAction {
         emulator.set_verbose(verbose);
         emulator.set_pid_file(&env.get_qemu_pid_file(&self.instance.name));
 
-        if let Ok(qemu_root) = std::env::var("SNAP") {
+        if let Some(qemu_root) = snap_str {
             emulator.add_env(
                 "QEMU_MODULE_DIR",
                 "/snap/cubic/current/usr/lib/x86_64-linux-gnu/qemu",

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::error::Result;
 use crate::models::{Arch, PortForward};
 use crate::util::SystemCommand;
@@ -27,26 +29,17 @@ impl Emulator {
         }
     }
 
-    pub fn from(arch: Arch, rootdir: &str) -> Result<Emulator> {
+    pub fn from(arch: Arch) -> Result<Emulator> {
         let mut command = match arch {
             Arch::AMD64 => {
                 let mut command = SystemCommand::new("qemu-system-x86_64");
-                // Set machine type
                 command.arg("-machine").arg("q35");
-                command.arg("-drive").arg(format!(
-                    "if=pflash,readonly=on,file={rootdir}/usr/share/OVMF/OVMF_CODE_4M.fd"
-                ));
-                command.arg("-drive").arg(format!(
-                    "if=pflash,readonly=on,file={rootdir}/usr/share/OVMF/OVMF_VARS_4M.fd"
-                ));
                 command.arg("-smbios").arg("type=0,uefi=on");
                 command
             }
             Arch::ARM64 => {
                 let mut command = SystemCommand::new("qemu-system-aarch64");
-                // Set machine type
                 command.arg("-machine").arg("virt");
-                command.arg("-bios").arg("QEMU_EFI.fd");
                 command
             }
         };
@@ -135,6 +128,12 @@ impl Emulator {
         for arg in args.split(' ') {
             self.command.arg(arg);
         }
+    }
+
+    pub fn set_firmware(&mut self, path: &Path) {
+        self.command
+            .arg("-drive")
+            .arg(format!("if=pflash,readonly=on,file={}", path.display()));
     }
 
     pub fn add_search_path(&mut self, path: &str) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,6 +112,37 @@ Troubleshoot:
     #[error("SSH Error: {0}")]
     Ssh(#[from] ssh_key::Error),
 
+    #[error(
+        "OVMF firmware not found. Cubic requires UEFI firmware to run AMD64 virtual machines.
+
+Install it with:
+  - Debian/Ubuntu:  sudo apt install ovmf
+  - Fedora/RHEL:    sudo dnf install edk2-ovmf
+  - Arch Linux:     sudo pacman -S edk2-ovmf
+  - openSUSE:       sudo zypper install qemu-ovmf-x86_64
+  - macOS:          brew install qemu
+  - Windows:        install QEMU from https://www.qemu.org/download/#windows
+
+After installing, rerun your Cubic command.
+"
+    )]
+    OvmfNotFound,
+
+    #[error(
+        "ARM64 EFI firmware not found. Cubic requires UEFI firmware to run ARM64 virtual machines.
+
+Install it with:
+  - Debian/Ubuntu:  sudo apt install qemu-efi-aarch64
+  - Fedora/RHEL:    sudo dnf install edk2-aarch64
+  - Arch Linux:     sudo pacman -S edk2-armvirt
+  - macOS:          brew install qemu
+  - Windows:        install QEMU from https://www.qemu.org/download/#windows
+
+After installing, rerun your Cubic command.
+"
+    )]
+    ArmFirmwareNotFound,
+
     #[error("Invalid path: {0}")]
     InvalidPath(String),
 

--- a/src/firmware.rs
+++ b/src/firmware.rs
@@ -1,0 +1,252 @@
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+use crate::models::Arch;
+
+pub struct FirmwareFinder {
+    arch: Arch,
+    snap: Option<String>,
+}
+
+impl FirmwareFinder {
+    pub fn new(arch: Arch, snap: Option<&str>) -> Self {
+        Self {
+            arch,
+            snap: snap.map(str::to_owned),
+        }
+    }
+
+    pub fn find(&self) -> Result<PathBuf> {
+        let share = self.qemu_share_dir();
+        let err = match self.arch {
+            Arch::AMD64 => Error::OvmfNotFound,
+            Arch::ARM64 => Error::ArmFirmwareNotFound,
+        };
+        self.candidates(share.as_deref())
+            .into_iter()
+            .find(|p| p.exists())
+            .ok_or(err)
+    }
+
+    fn qemu_share_dir(&self) -> Option<PathBuf> {
+        let binary = match self.arch {
+            Arch::AMD64 => "qemu-system-x86_64",
+            Arch::ARM64 => "qemu-system-aarch64",
+        };
+        find_on_path(binary)
+            .as_deref()
+            .and_then(Path::parent) // bin/
+            .and_then(Path::parent) // install root
+            .map(|root| root.join("share").join("qemu"))
+    }
+
+    fn candidates(&self, qemu_share: Option<&Path>) -> Vec<PathBuf> {
+        match self.arch {
+            Arch::AMD64 => self.ovmf_candidates(qemu_share),
+            Arch::ARM64 => self.arm_candidates(qemu_share),
+        }
+    }
+
+    fn ovmf_candidates(&self, qemu_share: Option<&Path>) -> Vec<PathBuf> {
+        let mut candidates = Vec::new();
+
+        if let Some(snap_dir) = &self.snap {
+            candidates.push(PathBuf::from(format!(
+                "{snap_dir}/usr/share/OVMF/OVMF_CODE_4M.fd"
+            )));
+        }
+
+        if let Some(share) = qemu_share {
+            candidates.push(share.join("edk2-x86_64-code.fd"));
+            candidates.push(share.join("OVMF_CODE_4M.fd"));
+        }
+
+        candidates.extend([
+            // Debian/Ubuntu (ovmf)
+            PathBuf::from("/usr/share/OVMF/OVMF_CODE_4M.fd"),
+            // Fedora/RHEL (edk2-ovmf)
+            PathBuf::from("/usr/share/edk2/ovmf/OVMF_CODE.4m.fd"),
+            // Fedora older
+            PathBuf::from("/usr/share/edk2-ovmf/OVMF_CODE.fd"),
+            // Arch Linux (edk2-ovmf)
+            PathBuf::from("/usr/share/edk2/x64/OVMF_CODE.4m.fd"),
+            // openSUSE (qemu-ovmf-x86_64)
+            PathBuf::from("/usr/share/qemu/ovmf-x86_64-code.bin"),
+            // Homebrew Apple Silicon
+            PathBuf::from("/opt/homebrew/share/qemu/edk2-x86_64-code.fd"),
+            // Homebrew Intel / Linux Homebrew root
+            PathBuf::from("/usr/local/share/qemu/edk2-x86_64-code.fd"),
+            // Linux Homebrew non-root
+            PathBuf::from("/home/linuxbrew/.linuxbrew/share/qemu/edk2-x86_64-code.fd"),
+            // Windows QEMU installer
+            PathBuf::from("C:/Program Files/QEMU/share/edk2-x86_64-code.fd"),
+        ]);
+
+        candidates
+    }
+
+    fn arm_candidates(&self, qemu_share: Option<&Path>) -> Vec<PathBuf> {
+        let mut candidates = Vec::new();
+
+        if let Some(snap_dir) = &self.snap {
+            candidates.push(PathBuf::from(format!(
+                "{snap_dir}/usr/share/AAVMF/AAVMF_CODE.fd"
+            )));
+        }
+
+        if let Some(share) = qemu_share {
+            candidates.push(share.join("edk2-aarch64-code.fd"));
+        }
+
+        candidates.extend([
+            // Debian/Ubuntu (qemu-efi-aarch64 or ovmf) - 64 MB, pflash-safe
+            PathBuf::from("/usr/share/AAVMF/AAVMF_CODE.fd"),
+            // Fedora/RHEL (edk2-aarch64) - pflash-safe variant
+            PathBuf::from("/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw"),
+            // Arch Linux (edk2-armvirt) - 64 MB on Arch
+            PathBuf::from("/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd"),
+            // openSUSE (qemu-uefi-aarch64)
+            PathBuf::from("/usr/share/qemu/aavmf-aarch64-code.bin"),
+            // Homebrew Apple Silicon
+            PathBuf::from("/opt/homebrew/share/qemu/edk2-aarch64-code.fd"),
+            // Homebrew Intel / Linux Homebrew root
+            PathBuf::from("/usr/local/share/qemu/edk2-aarch64-code.fd"),
+            // Linux Homebrew non-root
+            PathBuf::from("/home/linuxbrew/.linuxbrew/share/qemu/edk2-aarch64-code.fd"),
+            // Windows QEMU installer
+            PathBuf::from("C:/Program Files/QEMU/share/edk2-aarch64-code.fd"),
+        ]);
+
+        candidates
+    }
+}
+
+fn find_on_path(binary: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(binary);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            let candidate = dir.join(format!("{binary}.exe"));
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ovmf_candidates_snap_is_first() {
+        let candidates =
+            FirmwareFinder::new(Arch::AMD64, Some("/snap/cubic/current")).candidates(None);
+        assert_eq!(
+            candidates[0],
+            PathBuf::from("/snap/cubic/current/usr/share/OVMF/OVMF_CODE_4M.fd")
+        );
+    }
+
+    #[test]
+    fn test_ovmf_candidates_qemu_share_before_system() {
+        let share = PathBuf::from("/opt/homebrew/share/qemu");
+        let candidates = FirmwareFinder::new(Arch::AMD64, None).candidates(Some(&share));
+        let qemu_pos = candidates
+            .iter()
+            .position(|p| p.starts_with("/opt/homebrew/share/qemu"))
+            .unwrap();
+        let debian_pos = candidates
+            .iter()
+            .position(|p| *p == PathBuf::from("/usr/share/OVMF/OVMF_CODE_4M.fd"))
+            .unwrap();
+        assert!(qemu_pos < debian_pos);
+    }
+
+    #[test]
+    fn test_ovmf_candidates_all_platforms_present() {
+        let candidates = FirmwareFinder::new(Arch::AMD64, None).candidates(None);
+        let paths: Vec<&str> = candidates.iter().filter_map(|p| p.to_str()).collect();
+        assert!(
+            paths.iter().any(|p| p.contains("/usr/share/OVMF/")),
+            "Debian/Ubuntu missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("/usr/share/edk2/")),
+            "Fedora missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("/usr/share/edk2/x64/")),
+            "Arch missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("/usr/share/qemu/ovmf")),
+            "openSUSE missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("/opt/homebrew/")),
+            "Homebrew Apple Silicon missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("/usr/local/")),
+            "Homebrew Intel missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("linuxbrew")),
+            "Linux Homebrew non-root missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("Program Files/QEMU")),
+            "Windows missing"
+        );
+    }
+
+    #[test]
+    fn test_arm_candidates_snap_is_first() {
+        let candidates =
+            FirmwareFinder::new(Arch::ARM64, Some("/snap/cubic/current")).candidates(None);
+        assert_eq!(
+            candidates[0],
+            PathBuf::from("/snap/cubic/current/usr/share/AAVMF/AAVMF_CODE.fd")
+        );
+    }
+
+    #[test]
+    fn test_arm_candidates_all_platforms_present() {
+        let candidates = FirmwareFinder::new(Arch::ARM64, None).candidates(None);
+        let paths: Vec<&str> = candidates.iter().filter_map(|p| p.to_str()).collect();
+        assert!(
+            paths.iter().any(|p| p.contains("AAVMF")),
+            "Debian/Ubuntu missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("/usr/share/edk2/aarch64")),
+            "Fedora missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("edk2-armvirt")),
+            "Arch missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("/opt/homebrew/")),
+            "Homebrew Apple Silicon missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("/usr/local/")),
+            "Homebrew Intel missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("linuxbrew")),
+            "Linux Homebrew non-root missing"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("Program Files/QEMU")),
+            "Windows missing"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod commands;
 mod emulator;
 mod env;
 mod error;
+mod firmware;
 mod fs;
 mod image;
 mod instance;


### PR DESCRIPTION
Previously the OVMF firmware paths were hardcoded to the Debian/Ubuntu convention (/usr/share/OVMF/...), causing every VM launch to fail when Cubic was installed via Homebrew, on Windows, or on any non-Debian Linux distribution where the firmware lives elsewhere.

Introduce FirmwareFinder, a struct that searches an ordered list of candidate paths at startup:

1. Snap prefix (when running from a snap package)
2. QEMU-relative: resolve the qemu-system binary on PATH and look in the sibling share/qemu/ directory — covers Homebrew and the Windows QEMU installer without any hardcoded prefix
3. Known system-package paths for Debian/Ubuntu, Fedora/RHEL, Arch Linux, openSUSE, Homebrew (macOS Apple Silicon, macOS Intel, Linux non-root), and Windows

Both AMD64 (OVMF) and ARM64 (AAVMF) firmware are looked up. ARM64 uses AAVMF_CODE.fd rather than QEMU_EFI.fd because the latter is only 3 MB and incompatible with -drive if=pflash, which requires a 64 MB image.

When no firmware is found, a structured error is returned with per-platform install instructions instead of letting QEMU fail with a cryptic missing-file error.

Closes #373