### PR TITLE
Add env vars to override QEMU, qemu-img and firmware paths

### DIFF
--- a/docs/howto/qemu_detection.rst
+++ b/docs/howto/qemu_detection.rst
@@ -1,0 +1,237 @@
+.. _qemu detection:
+
+QEMU and Firmware Detection
+============================
+
+Cubic relies on QEMU and UEFI firmware to create and run virtual machines.
+When you start a VM, Cubic automatically searches for these tools in standard
+locations. This page explains where Cubic looks and how to override the
+detected paths when needed.
+
+QEMU Binary
+-----------
+
+Cubic searches for the QEMU system emulator on your ``PATH``. The binary name
+depends on the architecture of the virtual machine:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40
+
+   * - Architecture
+     - Binary
+   * - amd64
+     - ``qemu-system-x86_64``
+   * - arm64
+     - ``qemu-system-aarch64``
+
+Install QEMU if it is not already present:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 50
+
+   * - Platform
+     - Command
+   * - Debian / Ubuntu
+     - ``sudo apt install qemu-system``
+   * - Fedora / RHEL
+     - ``sudo dnf install qemu-system-x86``
+   * - Arch Linux
+     - ``sudo pacman -S qemu-full``
+   * - openSUSE
+     - ``sudo zypper install qemu``
+   * - macOS (Homebrew)
+     - ``brew install qemu``
+   * - Windows
+     - Install from https://www.qemu.org/download/#windows
+
+Override
+~~~~~~~~
+
+Set ``CUBIC_QEMU`` to use a QEMU binary that is not on ``PATH``:
+
+.. code-block::
+
+    $ CUBIC_QEMU=/opt/qemu/bin/qemu-system-x86_64 cubic start my-vm
+
+qemu-img
+--------
+
+Cubic searches for ``qemu-img`` on your ``PATH``. This tool is used to create
+and resize virtual machine disk images. It is included with QEMU on all
+platforms.
+
+Install ``qemu-img`` if it is not already present:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 50
+
+   * - Platform
+     - Command
+   * - Debian / Ubuntu
+     - ``sudo apt install qemu-utils``
+   * - Fedora / RHEL
+     - ``sudo dnf install qemu-img``
+   * - Arch Linux
+     - ``sudo pacman -S qemu-img``
+   * - openSUSE
+     - ``sudo zypper install qemu-tools``
+   * - macOS (Homebrew)
+     - ``brew install qemu``
+   * - Windows
+     - Install from https://www.qemu.org/download/#windows
+
+Override
+~~~~~~~~
+
+Set ``CUBIC_QEMU_IMG`` to use a ``qemu-img`` binary that is not on ``PATH``:
+
+.. code-block::
+
+    $ CUBIC_QEMU_IMG=/opt/qemu/bin/qemu-img cubic create my-vm --image ubuntu:noble
+
+UEFI Firmware
+-------------
+
+Cubic requires a UEFI firmware image (OVMF for amd64, AAVMF for arm64) to
+boot virtual machines. Cubic searches a list of well-known paths in order and
+uses the first file that exists.
+
+AMD64 (OVMF)
+~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40
+
+   * - Path
+     - Platform
+   * - ``$SNAP/usr/share/OVMF/OVMF_CODE_4M.fd``
+     - Snap package
+   * - ``<qemu-root>/share/qemu/edk2-x86_64-code.fd``
+     - QEMU install directory
+   * - ``/usr/share/OVMF/OVMF_CODE_4M.fd``
+     - Debian / Ubuntu
+   * - ``/usr/share/edk2/ovmf/OVMF_CODE.4m.fd``
+     - Fedora / RHEL
+   * - ``/usr/share/edk2-ovmf/OVMF_CODE.fd``
+     - Fedora (older)
+   * - ``/usr/share/edk2/x64/OVMF_CODE.4m.fd``
+     - Arch Linux
+   * - ``/usr/share/qemu/ovmf-x86_64-code.bin``
+     - openSUSE
+   * - ``/opt/homebrew/share/qemu/edk2-x86_64-code.fd``
+     - Homebrew (Apple Silicon)
+   * - ``/usr/local/share/qemu/edk2-x86_64-code.fd``
+     - Homebrew (Intel)
+   * - ``/home/linuxbrew/.linuxbrew/share/qemu/edk2-x86_64-code.fd``
+     - Linux Homebrew (non-root)
+   * - ``C:/Program Files/QEMU/share/edk2-x86_64-code.fd``
+     - Windows
+
+Install OVMF if it is not already present:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 50
+
+   * - Platform
+     - Command
+   * - Debian / Ubuntu
+     - ``sudo apt install ovmf``
+   * - Fedora / RHEL
+     - ``sudo dnf install edk2-ovmf``
+   * - Arch Linux
+     - ``sudo pacman -S edk2-ovmf``
+   * - openSUSE
+     - ``sudo zypper install qemu-ovmf-x86_64``
+   * - macOS (Homebrew)
+     - ``brew install qemu``
+   * - Windows
+     - Install from https://www.qemu.org/download/#windows
+
+ARM64 (AAVMF)
+~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40
+
+   * - Path
+     - Platform
+   * - ``$SNAP/usr/share/AAVMF/AAVMF_CODE.fd``
+     - Snap package
+   * - ``<qemu-root>/share/qemu/edk2-aarch64-code.fd``
+     - QEMU install directory
+   * - ``/usr/share/AAVMF/AAVMF_CODE.fd``
+     - Debian / Ubuntu
+   * - ``/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw``
+     - Fedora / RHEL
+   * - ``/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd``
+     - Arch Linux
+   * - ``/usr/share/qemu/aavmf-aarch64-code.bin``
+     - openSUSE
+   * - ``/opt/homebrew/share/qemu/edk2-aarch64-code.fd``
+     - Homebrew (Apple Silicon)
+   * - ``/usr/local/share/qemu/edk2-aarch64-code.fd``
+     - Homebrew (Intel)
+   * - ``/home/linuxbrew/.linuxbrew/share/qemu/edk2-aarch64-code.fd``
+     - Linux Homebrew (non-root)
+   * - ``C:/Program Files/QEMU/share/edk2-aarch64-code.fd``
+     - Windows
+
+Install AAVMF if it is not already present:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 50
+
+   * - Platform
+     - Command
+   * - Debian / Ubuntu
+     - ``sudo apt install qemu-efi-aarch64``
+   * - Fedora / RHEL
+     - ``sudo dnf install edk2-aarch64``
+   * - Arch Linux
+     - ``sudo pacman -S edk2-armvirt``
+   * - openSUSE
+     - ``sudo zypper install qemu-uefi-aarch64``
+   * - macOS (Homebrew)
+     - ``brew install qemu``
+   * - Windows
+     - Install from https://www.qemu.org/download/#windows
+
+Override
+~~~~~~~~
+
+Set ``CUBIC_FW`` to use a firmware file that was not found by autodetection.
+This bypasses the entire candidate search:
+
+.. code-block::
+
+    $ CUBIC_FW=/usr/share/OVMF/OVMF_CODE.fd cubic start my-vm
+
+Environment Variable Reference
+-------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - Variable
+     - Tool
+     - Description
+   * - ``CUBIC_QEMU``
+     - QEMU emulator
+     - Path to the ``qemu-system-*`` binary to use instead of the one found on
+       ``PATH``
+   * - ``CUBIC_QEMU_IMG``
+     - qemu-img
+     - Path to the ``qemu-img`` binary to use instead of the one found on
+       ``PATH``
+   * - ``CUBIC_FW``
+     - UEFI firmware
+     - Path to the OVMF or AAVMF firmware file to use instead of the
+       autodetected path

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -59,6 +59,7 @@ Cubic
    howto/http_server
    howto/ssh_connect
    howto/environment_variables
+   howto/qemu_detection
    howto/recover_disk
 
 .. toctree::

--- a/src/actions/create_instance_action.rs
+++ b/src/actions/create_instance_action.rs
@@ -32,8 +32,10 @@ impl CreateInstanceAction {
         // Create SSH key
         SshKeyGenerator::new().generate_key(&Path::new(tmp_dir).join("ssh_client_key"))?;
 
+        let qemu_img = std::env::var("CUBIC_QEMU_IMG").unwrap_or_else(|_| "qemu-img".to_owned());
+
         // Create virtual machine instance image file
-        SystemCommand::new("qemu-img")
+        SystemCommand::new(&qemu_img)
             .arg("convert")
             .arg("-f")
             .arg("qcow2")
@@ -44,7 +46,7 @@ impl CreateInstanceAction {
             .run()?;
 
         // Set disk capacity
-        SystemCommand::new("qemu-img")
+        SystemCommand::new(&qemu_img)
             .arg("resize")
             .arg(tmp_image)
             .arg(instance.disk_capacity.get_bytes().to_string())

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -30,15 +30,20 @@ impl Emulator {
     }
 
     pub fn from(arch: Arch) -> Result<Emulator> {
+        let default_binary = match arch {
+            Arch::AMD64 => "qemu-system-x86_64",
+            Arch::ARM64 => "qemu-system-aarch64",
+        };
+        let binary = std::env::var("CUBIC_QEMU").unwrap_or_else(|_| default_binary.to_owned());
         let mut command = match arch {
             Arch::AMD64 => {
-                let mut command = SystemCommand::new("qemu-system-x86_64");
+                let mut command = SystemCommand::new(&binary);
                 command.arg("-machine").arg("q35");
                 command.arg("-smbios").arg("type=0,uefi=on");
                 command
             }
             Arch::ARM64 => {
-                let mut command = SystemCommand::new("qemu-system-aarch64");
+                let mut command = SystemCommand::new(&binary);
                 command.arg("-machine").arg("virt");
                 command
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,11 +48,27 @@ Troubleshoot:
   - Make sure '{0}' is available on your PATH
   - Linux/WSL2: install the qemu-system and qemu-utils packages for your distribution
   - macOS: install QEMU with Homebrew: `brew install qemu`
+  - Or set CUBIC_QEMU=/path/to/binary to override the QEMU binary location
 
 After installing QEMU, rerun your Cubic command.
 "
     )]
     QemuNotFound(String),
+
+    #[error(
+        "qemu-img not found. Cubic requires qemu-img to manage virtual machine disk images.
+
+Troubleshoot:
+  - Install QEMU for your platform (qemu-img is included with QEMU)
+  - Make sure 'qemu-img' is available on your PATH
+  - Linux/WSL2: install the qemu-utils package for your distribution
+  - macOS: install QEMU with Homebrew: `brew install qemu`
+  - Or set CUBIC_QEMU_IMG=/path/to/qemu-img to override the qemu-img binary location
+
+After installing qemu-img, rerun your Cubic command.
+"
+    )]
+    QemuImgNotFound,
 
     #[error("System command '{0}' was not found on PATH")]
     SystemCommandNotFound(String),
@@ -122,6 +138,7 @@ Install it with:
   - openSUSE:       sudo zypper install qemu-ovmf-x86_64
   - macOS:          brew install qemu
   - Windows:        install QEMU from https://www.qemu.org/download/#windows
+  - Or set CUBIC_FW=/path/to/firmware.fd to override the firmware path
 
 After installing, rerun your Cubic command.
 "
@@ -137,6 +154,7 @@ Install it with:
   - Arch Linux:     sudo pacman -S edk2-armvirt
   - macOS:          brew install qemu
   - Windows:        install QEMU from https://www.qemu.org/download/#windows
+  - Or set CUBIC_FW=/path/to/firmware.fd to override the firmware path
 
 After installing, rerun your Cubic command.
 "

--- a/src/firmware.rs
+++ b/src/firmware.rs
@@ -17,6 +17,9 @@ impl FirmwareFinder {
     }
 
     pub fn find(&self) -> Result<PathBuf> {
+        if let Ok(fw) = std::env::var("CUBIC_FW") {
+            return Ok(PathBuf::from(fw));
+        }
         let share = self.qemu_share_dir();
         let err = match self.arch {
             Arch::AMD64 => Error::OvmfNotFound,

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -140,7 +140,9 @@ impl InstanceStore for InstanceDao {
         } else if instance.disk_capacity.get_bytes() >= size as usize {
             Err(Error::CannotShrinkDisk(instance.name.to_string()))
         } else {
-            SystemCommand::new("qemu-img")
+            let qemu_img =
+                std::env::var("CUBIC_QEMU_IMG").unwrap_or_else(|_| "qemu-img".to_owned());
+            SystemCommand::new(&qemu_img)
                 .arg("resize")
                 .arg(self.env.get_instance_image_file(&instance.name))
                 .arg(size.to_string())

--- a/src/qemu/qemu_img.rs
+++ b/src/qemu/qemu_img.rs
@@ -18,7 +18,8 @@ impl QemuImg {
     }
 
     pub fn get_image_info(&self, env: &Environment, instance: &Instance) -> Option<ImageInfo> {
-        SystemCommand::new("qemu-img")
+        let qemu_img = std::env::var("CUBIC_QEMU_IMG").unwrap_or_else(|_| "qemu-img".to_owned());
+        SystemCommand::new(&qemu_img)
             .arg("info")
             .arg("--output")
             .arg("json")

--- a/src/util/system_command.rs
+++ b/src/util/system_command.rs
@@ -38,7 +38,10 @@ impl SystemCommand {
     fn map_spawn_error(&self, error: std::io::Error) -> Error {
         if error.kind() == ErrorKind::NotFound {
             let program = self.get_program();
-            if program.starts_with("qemu-") {
+            if program == "qemu-img" || program.ends_with("/qemu-img") {
+                return Error::QemuImgNotFound;
+            }
+            if program.starts_with("qemu-") || program.contains("/qemu-") {
                 return Error::QemuNotFound(program);
             }
 
@@ -146,6 +149,18 @@ mod tests {
         let err = SystemCommand::new(program).output().unwrap_err();
 
         assert!(matches!(err, Error::QemuNotFound(ref missing) if missing == program));
+    }
+
+    #[test]
+    fn test_output_reports_missing_qemu_img_binary() {
+        let err = SystemCommand::new("/nonexistent/path/qemu-img")
+            .output()
+            .unwrap_err();
+
+        assert!(matches!(err, Error::QemuImgNotFound));
+        let message = err.to_string();
+        assert!(message.contains("qemu-img not found"));
+        assert!(message.contains("CUBIC_QEMU_IMG"));
     }
 
     #[test]


### PR DESCRIPTION
## Add `CUBIC_QEMU`, `CUBIC_QEMU_IMG` and `CUBIC_FW` environment variables

  Sometimes QEMU or the firmware is installed in a non-standard location
  and Cubic can't find it automatically. These three environment variables
  let you point Cubic at the right paths directly:

  - `CUBIC_QEMU`: path to the qemu-system binary
  - `CUBIC_QEMU_IMG`: path to qemu-img
  - `CUBIC_FW`: path to the OVMF/AAVMF firmware file

  Error messages now mention the relevant variable when a tool isn't
  found. A new how-to page documents where Cubic looks by default and how
  to use the overrides.