### PR TITLE
ci: support release/v* branches in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - 'release/v*'
     tags:
       - 'v*'
 
@@ -168,7 +169,10 @@ jobs:
         run: cubic --help
 
   publish-snap:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: >
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/release/') ||
+      startsWith(github.ref, 'refs/tags/')
     needs: validate-packages
     strategy:
       matrix:
@@ -194,7 +198,10 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
           snap: ${{ env.SNAP_FILE }}
-          release: ${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}
+          release: >-
+            ${{ (startsWith(github.ref, 'refs/tags/') ||
+            startsWith(github.ref, 'refs/heads/release/')) &&
+            'candidate' || 'edge' }}
 
   publish-crate:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/v*'
 
 jobs:
   check:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,14 @@
 
 ## Supported Versions
 
-Security fixes are applied to the latest release only.
-Older versions do not receive backported security patches.
+Security fixes are applied to the `main` branch and the latest release.
+Older releases do not receive backported security patches.
 
-| Version | Supported |
-| ------- | --------- |
-| latest  | ✅        |
-| older   | ❌        |
+| Version        | Supported |
+| -------------- | --------- |
+| main           | ✅        |
+| latest release | ✅        |
+| older releases | ❌        |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Add `release/v*` to the push trigger in `build.yml `so the full build and packaging pipeline runs on every push to a release branch. Extend the `pull-request.yml` branch filter to run CI checks on PRs targeting release branches.

Snaps pushed from a release branch are published to the candidate channel (same as tags) instead of edge.

Update `SECURITY.md` to reflect that both main and the latest release are supported.