### PR TITLE
chore: release v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "cubic"
-version = "0.0.0-dev"
+version = "0.23.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubic"
-version = "0.0.0-dev"
+version = "0.23.0"
 authors = ["Roger Knecht <rknecht@pm.me>"]
 license = "MIT OR Apache-2.0"
 description = "Daemonless, rootless CLI virtual machine manager built on QEMU, KVM and cloud-init"


### PR DESCRIPTION
Bump version in Cargo.toml and Cargo.lock.