### PR TITLE
Fix Windows Compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
           - name: cubic-windows-amd64
             target: x86_64-pc-windows-gnu
-            packages: gcc-mingw-w64-x86-64 nasm
+            packages: gcc-mingw-w64-x86-64
             suffix: .exe
 
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,29 +171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "untrusted 0.7.1",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,8 +325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -461,15 +436,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cmov"
@@ -866,12 +832,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,12 +1029,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1629,16 +1583,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -2494,7 +2438,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -2545,7 +2489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67013f080c226e5a34db1c71f2567f44d95a6300005bb6cd4e2c8fe3c326d1b"
 dependencies = [
  "aes",
- "aws-lc-rs",
  "bitflags",
  "block-padding 0.4.2",
  "byteorder",
@@ -2563,7 +2506,6 @@ dependencies = [
  "ed25519-dalek 3.0.0-pre.7",
  "elliptic-curve 0.14.0-rc.32",
  "enum_dispatch",
- "flate2",
  "futures",
  "generic-array 1.4.3",
  "getrandom 0.2.17",
@@ -2590,6 +2532,7 @@ dependencies = [
  "polyval",
  "rand 0.10.1",
  "rand_core 0.10.1",
+ "ring",
  "rsa 0.10.0-rc.18",
  "russh-cryptovec",
  "russh-util",
@@ -2736,7 +2679,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -3464,12 +3407,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ clap_complete = "4"
 crossterm = "0"
 regex = "1"
 reqwest = { version = "0", default-features = false, features = ["rustls-tls", "blocking", "gzip", "brotli"] }
-russh = "0"
+russh = { version = "0", default-features = false, features = ["ring", "rsa"] }
 russh-sftp = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -4,7 +4,7 @@ use crate::error::Result;
 use crate::image::ImageDao;
 use crate::instance::InstanceDao;
 use crate::view::Console;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 
 #[derive(Subcommand)]
 pub enum Commands {
@@ -79,13 +79,12 @@ The source code is located at: https://github.com/cubic-vm/cubic";
     author,
     version,
     about = ABOUT,
-    arg_required_else_help = true,
     infer_subcommands = true,
     disable_help_subcommand = true
 )]
 pub struct CommandDispatcher {
     #[command(subcommand)]
-    pub command: commands::Commands,
+    pub command: Option<commands::Commands>,
 
     #[clap(flatten)]
     global: GlobalOptions,
@@ -93,6 +92,11 @@ pub struct CommandDispatcher {
 
 impl CommandDispatcher {
     pub fn dispatch(self, console: &mut dyn Console) -> Result<()> {
+        let Some(command) = self.command else {
+            println!("{}", CommandDispatcher::command().render_long_help());
+            return Ok(());
+        };
+
         console.set_verbosity(commands::Verbosity::new(
             self.global.verbose,
             self.global.quiet,
@@ -104,7 +108,7 @@ impl CommandDispatcher {
             Box::new(InstanceDao::new(&env)?),
         );
 
-        match &self.command {
+        match &command {
             Commands::Run(cmd) => cmd as &dyn Command,
             Commands::Instances(cmd) => cmd,
             Commands::Images(cmd) => cmd,

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -1,13 +1,13 @@
 use crate::actions::StartInstanceAction;
 use crate::commands::{self, Command};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::ssh_cmd::{PortChecker, Russh};
 use crate::util;
 use crate::view::Console;
 use crate::view::SpinnerView;
 use clap::Parser;
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Start VM instances
 ///
@@ -67,7 +67,12 @@ impl Command for StartCommand {
         // Wait for virtual machine instances to be started
         if self.wait && !verbosity.is_quiet() {
             let mut spinner = SpinnerView::new("Starting instance(s)".to_string());
+            let deadline = Instant::now() + Duration::from_secs(300);
             while actions.iter().any(|a| !a.is_done()) {
+                if Instant::now() >= deadline {
+                    spinner.stop();
+                    return Err(Error::StartTimeout);
+                }
                 sleep(Duration::from_secs(1));
             }
             spinner.stop()

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -150,12 +150,10 @@ impl Emulator {
     }
 
     pub fn run(&mut self) -> Result<()> {
-        self.command.arg("-daemonize");
-
         if self.verbose {
             println!("{}", self.command.get_command());
         }
 
-        self.command.run()
+        self.command.run_daemonized()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,11 @@ pub enum Error {
     InstanceNotRunning(String),
 
     #[error(
+        "Timed out waiting for instance(s) to start.\n\nTroubleshoot:\n  - Run with --verbose to see the QEMU command\n  - Check that QEMU can open /dev/kvm and firmware files\n  - Try again; the system may be under load\n"
+    )]
+    StartTimeout,
+
+    #[error(
         "Instance name '{0}' is already taken.\n\nOptions:\n  - Choose a different name\n  - Connect to existing instance: `cubic ssh {0}`"
     )]
     InstanceAlreadyExists(String),

--- a/src/util/system_command.rs
+++ b/src/util/system_command.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use std::ffi::OsStr;
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Read};
 use std::process::{Command, Output, Stdio};
 use std::str::from_utf8;
 
@@ -93,6 +93,54 @@ impl SystemCommand {
             })
     }
 
+    pub fn run_daemonized(&mut self) -> Result<()> {
+        #[cfg(unix)]
+        unsafe {
+            use std::os::unix::process::CommandExt;
+            self.cmd.pre_exec(detach_from_session);
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            const DETACHED_PROCESS: u32 = 0x0000_0008;
+            self.cmd.creation_flags(DETACHED_PROCESS);
+        }
+
+        let mut child = self
+            .cmd
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| self.map_spawn_error(e))?;
+
+        // Check immediately for instant failures, then again after a brief window
+        // to catch startup errors (KVM permission denied, bad firmware, port conflicts).
+        for ms in [0, 100] {
+            std::thread::sleep(std::time::Duration::from_millis(ms));
+            if let Ok(Some(_)) = child.try_wait() {
+                let stderr = child
+                    .stderr
+                    .take()
+                    .map(|mut s| {
+                        let mut buf = Vec::new();
+                        s.read_to_end(&mut buf).unwrap_or(0);
+                        from_utf8(&buf).unwrap_or_default().to_owned()
+                    })
+                    .unwrap_or_default();
+                return Err(Error::SystemCommandFailed(self.get_command(), stderr));
+            }
+        }
+
+        // Reap the child when it eventually exits to avoid a zombie process.
+        std::thread::spawn(move || {
+            let _ = child.wait();
+        });
+
+        Ok(())
+    }
+
     pub fn output(&mut self) -> Result<Output> {
         self.cmd
             .stdout(Stdio::piped())
@@ -100,6 +148,17 @@ impl SystemCommand {
             .output()
             .map_err(|e| self.map_spawn_error(e))
     }
+}
+
+#[cfg(unix)]
+fn detach_from_session() -> std::io::Result<()> {
+    unsafe extern "C" {
+        fn setsid() -> i32;
+    }
+    if unsafe { setsid() } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Changes

**Fix QEMU daemonization on Windows**
Replace QEMU's `-daemonize` flag (unsupported on Windows) with a cross-platform `run_daemonized()` helper. On Unix it calls `setsid()` via `pre_exec`. On Windows it sets the `DETACHED_PROCESS` creation flag. Includes a 300-second startup timeout with a actionable error message, and a brief post-spawn stderr check to catch immediate failures (KVM permission denied, bad firmware paths, etc.).

**Remove NASM dependency from Windows cross-compilation**
Switch `russh` from the `aws-lc-rs` backend to `ring` (already a transitive dependency via `reqwest`/`rustls`). This eliminates the NASM assembler requirement when cross-compiling for `x86_64-pc-windows-gnu` and removes six packages from the dependency tree (`aws-lc-rs`, `aws-lc-sys`, `cmake`, `dunce`, `fs_extra`, `jobserver`).

**Exit code 0 for `cubic`, `cubic --help`, `cubic -h`**
`arg_required_else_help = true` caused clap to treat a missing subcommand as a usage error (exit code 2), which also prints an error in Windows cmd. Replaced with an optional subcommand and a manual `None` branch that prints full help and returns `Ok(())`.