### PR TITLE
fix: list fedora images from the stable download host

### DIFF
--- a/src/image/fedora_image_provider.rs
+++ b/src/image/fedora_image_provider.rs
@@ -10,7 +10,7 @@ impl ImageProvider for FedoraImageProvider {
     }
 
     fn get_base_url(&self) -> &str {
-        "https://download.fedoraproject.org/pub/fedora/linux/releases/"
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/"
     }
 
     fn find_image_names(&self, content: &str) -> Vec<String> {


### PR DESCRIPTION
The fedora image provider scraped its release listing from download.fedoraproject.org, a mirror redirector that round-robins each request to an arbitrary mirror. Many mirrors do not serve the release directory listing, so version discovery often matched nothing and fedora silently disappeared from cubic images. Point the provider at the canonical dl.fedoraproject.org host, which serves a stable listing.

Closes  #405