### PR TITLE
fix: raise the web request timeout to 30 seconds

### DIFF
--- a/src/web/web_client.rs
+++ b/src/web/web_client.rs
@@ -10,7 +10,7 @@ use std::io;
 use std::path::Path;
 use std::time::Duration;
 
-const REQUEST_TIMEOUT_SEC: u64 = 10;
+const REQUEST_TIMEOUT_SEC: u64 = 30;
 
 struct ProgressWriter {
     file: File,


### PR DESCRIPTION
Some images were intermittently missing from cubic images because the per image size request timed out against slow mirrors and dropped the image. Raising the request timeout from 10 to 30 seconds gives slow mirrors enough time to respond.