### PR TITLE
fix: show disk size for running instances

### DIFF
--- a/src/qemu/qemu_img.rs
+++ b/src/qemu/qemu_img.rs
@@ -33,6 +33,7 @@ impl QemuImg {
     pub fn get_image_info(&self, env: &Environment, instance: &Instance) -> Option<ImageInfo> {
         Self::command()
             .arg("info")
+            .arg("--force-share")
             .arg("--output")
             .arg("json")
             .arg(env.get_instance_image_file(&instance.name))


### PR DESCRIPTION
The Disk Used column in 'cubic instances' showed n/a for any running machine. The size comes from 'qemu-img info', which fails because a running QEMU holds an exclusive lock on the image file.

Pass --force-share so qemu-img opens the image in shared read-only mode and reports its size regardless of the lock. The flag is safe for a read-only info query and harmless for stopped instances.