### PR TITLE
[Backport] fix: keep SSH port in sync with instance.toml

### DIFF
--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -1,8 +1,7 @@
 use crate::actions::StartInstanceAction;
 use crate::commands::{self, Command};
 use crate::error::Result;
-use crate::ssh_cmd::{PortChecker, Russh};
-use crate::util;
+use crate::ssh_cmd::PortChecker;
 use crate::view::Console;
 use crate::view::SpinnerView;
 use clap::Parser;
@@ -43,17 +42,15 @@ impl Command for StartCommand {
         let instance_store = context.get_instance_store();
 
         let verbosity = console.get_verbosity();
-        let async_caller = util::AsyncCaller::new();
-        let russh = Russh::new();
+        let port_checker = PortChecker::new();
 
         // Launch virtual machine instances
         let mut actions = Vec::new();
         for name in &self.instances {
             let instance = &mut instance_store.load(name)?;
-            if !async_caller.call(russh.is_running(instance.ssh_port)) {
-                // Make SSH port is available
-                if PortChecker::new().is_open(instance.ssh_port) {
-                    instance.ssh_port = PortChecker::new().get_new_port()?;
+            if !instance_store.is_running(instance) {
+                if port_checker.is_open(instance.ssh_port) {
+                    instance.ssh_port = port_checker.get_new_port()?;
                     instance_store.store(instance)?;
                 }
 

--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -130,16 +130,6 @@ impl Russh {
         Self::default()
     }
 
-    pub async fn is_running(&self, port: u16) -> bool {
-        client::connect(
-            Arc::new(client::Config::default()),
-            ("127.0.0.1", port),
-            Client {},
-        )
-        .await
-        .is_ok()
-    }
-
     async fn authenticate_with_default_password(
         &self,
         session: &mut russh::client::Handle<Client>,


### PR DESCRIPTION
Starting an instance whose QEMU was already running (but whose guest SSH was not yet answering) could reallocate the SSH port and persist it to instance.toml without relaunching QEMU, leaving the stored port out of sync with the live instance.

Gate the start logic on the QEMU pid file instead of an SSH handshake, so the port is only reassigned when the instance is actually stopped.