### PR TITLE
feat: locate QEMU modules and trim firmware blobs

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -65,7 +65,6 @@ parts:
       - qemu-system-x86:$CRAFT_ARCH_BUILD_FOR
       - qemu-system-arm:$CRAFT_ARCH_BUILD_FOR
       - qemu-efi-aarch64:$CRAFT_ARCH_BUILD_FOR
-      - seabios:$CRAFT_ARCH_BUILD_FOR
       - ovmf:$CRAFT_ARCH_BUILD_FOR
     override-build: |
       rm -rf $SNAPCRAFT_PART_INSTALL/usr/lib/*/libicudata*
@@ -81,6 +80,8 @@ parts:
       rm -rf $SNAPCRAFT_PART_INSTALL/usr/share/qemu/openbios-ppc
       rm -rf $SNAPCRAFT_PART_INSTALL/usr/share/qemu/openbios-sparc32
       rm -rf $SNAPCRAFT_PART_INSTALL/usr/share/qemu/openbios-sparc64
+      rm -rf $SNAPCRAFT_PART_INSTALL/usr/lib/ipxe
+      rm -rf $SNAPCRAFT_PART_INSTALL/usr/share/seabios
   cleanup:
     after:
       - cubic

--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -4,7 +4,7 @@ use crate::error::{Error, Result};
 use crate::fs::FS;
 use crate::instance::InstanceCertGenerator;
 use crate::models::{Instance, InstanceCertPaths};
-use crate::qemu::{QemuFirmware, QemuPathBuilder, QemuSystem};
+use crate::qemu::{QemuFirmware, QemuInstall, QemuPathBuilder, QemuSystem};
 use crate::ssh_cmd::PortChecker;
 use std::path::PathBuf;
 
@@ -45,9 +45,23 @@ impl StartInstanceAction {
         context.get_instance_store().store(&self.instance)?;
 
         let mut qemu_system = QemuSystem::from(self.instance.arch)?;
-        let firmware = QemuFirmware::locate(QemuPathBuilder::new().get_dirs(), self.instance.arch)
+
+        let path_builder = QemuPathBuilder::new();
+        let install = QemuInstall::find(path_builder.get_dirs());
+
+        let firmware = QemuFirmware::locate(path_builder.get_dirs(), self.instance.arch)
             .ok_or(Error::QemuNotFound)?;
         qemu_system.set_firmware(&firmware);
+
+        if let Some(install) = &install {
+            if let Some(module_dir) = install.find_module_dir() {
+                qemu_system.set_module_dir(&module_dir);
+            }
+            if let Some(datadir) = install.find_datadir() {
+                qemu_system.add_datadir(&datadir);
+            }
+        }
+
         qemu_system.set_cpus(self.instance.cpus);
         qemu_system.set_memory(self.instance.mem.get_bytes() as u64);
         qemu_system.set_console(self.instance.console_port.unwrap(), &instance_dir);

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -9,7 +9,7 @@ mod qmp_message;
 mod tls_client;
 
 pub use monitor::*;
-pub use qemu_firmware::QemuFirmware;
+pub use qemu_firmware::{QemuFirmware, QemuInstall};
 pub use qemu_img::*;
 pub use qemu_path_builder::QemuPathBuilder;
 pub use qemu_system::*;

--- a/src/qemu/qemu_firmware.rs
+++ b/src/qemu/qemu_firmware.rs
@@ -17,12 +17,12 @@ impl QemuFirmware {
     }
 }
 
-struct QemuInstall {
+pub struct QemuInstall {
     prefix: PathBuf,
 }
 
 impl QemuInstall {
-    fn find(dirs: &[PathBuf]) -> Option<Self> {
+    pub fn find(dirs: &[PathBuf]) -> Option<Self> {
         let names = ["qemu-system-x86_64", "qemu-system-aarch64"];
         let dir = dirs
             .iter()
@@ -33,6 +33,45 @@ impl QemuInstall {
             dir.parent().unwrap_or(dir).to_path_buf()
         };
         Some(Self { prefix })
+    }
+
+    pub fn find_module_dir(&self) -> Option<PathBuf> {
+        self.build_module_dir_candidates()
+            .into_iter()
+            .find(|dir| Self::contains_shared_object(dir))
+    }
+
+    pub fn find_datadir(&self) -> Option<PathBuf> {
+        let dir = self.prefix.join("share/qemu");
+        dir.is_dir().then_some(dir)
+    }
+
+    fn build_module_dir_candidates(&self) -> Vec<PathBuf> {
+        let mut candidates = Vec::new();
+        if let Some(triplet) = self.find_lib_triplet() {
+            candidates.push(self.prefix.join("lib").join(triplet).join("qemu"));
+        }
+        candidates.push(self.prefix.join("lib/qemu"));
+        candidates.push(self.prefix.join("lib64/qemu"));
+        candidates
+    }
+
+    fn find_lib_triplet(&self) -> Option<PathBuf> {
+        let entries = std::fs::read_dir(self.prefix.join("lib")).ok()?;
+        entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.join("qemu").is_dir())
+            .find_map(|path| path.file_name().map(PathBuf::from))
+    }
+
+    fn contains_shared_object(dir: &Path) -> bool {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return false;
+        };
+        entries
+            .flatten()
+            .any(|entry| entry.path().extension().is_some_and(|ext| ext == "so"))
     }
 
     fn find_firmware(&self, arch: Arch) -> Option<PathBuf> {
@@ -81,5 +120,25 @@ impl QemuInstall {
             .map(|entry| entry.path())
             .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_dir_candidates_cover_lib_layouts() {
+        let candidates = QemuInstall {
+            prefix: PathBuf::from("/snap/cubic/current/usr"),
+        }
+        .build_module_dir_candidates();
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/snap/cubic/current/usr/lib/qemu"),
+                PathBuf::from("/snap/cubic/current/usr/lib64/qemu"),
+            ]
+        );
     }
 }

--- a/src/qemu/qemu_system.rs
+++ b/src/qemu/qemu_system.rs
@@ -62,6 +62,8 @@ impl QemuSystem {
         command.arg("-boot").arg("c");
         // Disable display
         command.arg("-display").arg("none");
+        // Disable VGA
+        command.arg("-vga").arg("none");
 
         // Sandbox
         #[cfg(feature = "qemu-sandbox")]
@@ -126,7 +128,7 @@ impl QemuSystem {
         let restrict = if isolate { "on" } else { "off" };
         self.command
             .arg("-device")
-            .arg("virtio-net-pci,netdev=net0")
+            .arg("virtio-net-pci,netdev=net0,romfile=")
             .arg("-netdev")
             .arg(format!(
                 "user,id=net0,restrict={restrict},hostfwd=tcp:127.0.0.1:{ssh_port}-:22{hostfwd_options}"
@@ -149,6 +151,14 @@ impl QemuSystem {
         self.command
             .arg("-drive")
             .arg(format!("if=pflash,readonly=on,file={}", path.display()));
+    }
+
+    pub fn set_module_dir(&mut self, dir: &Path) {
+        self.command.set_env("QEMU_MODULE_DIR", dir);
+    }
+
+    pub fn add_datadir(&mut self, dir: &Path) {
+        self.command.arg("-L").arg(dir);
     }
 
     pub fn set_pid_file(&mut self, path: &str) {
@@ -183,6 +193,17 @@ mod tests {
             )),
             Error::QemuNotFound
         ));
+    }
+
+    #[test]
+    fn test_add_datadir_appends_dash_l() {
+        let mut qemu = QemuSystem::from(Arch::AMD64).unwrap();
+        qemu.add_datadir(Path::new("/snap/cubic/current/usr/share/qemu"));
+        assert!(
+            qemu.command
+                .get_command()
+                .contains("-L /snap/cubic/current/usr/share/qemu")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Snap and other relocatable QEMU installs place loadable modules and data files under a prefix that QEMU cannot find on its own. Discover the install prefix and point QEMU at the right module directory via QEMU_MODULE_DIR and at the data directory via -L so device modules and firmware resolve correctly at runtime.

Disable VGA and clear the virtio-net option ROM so the guest no longer depends on the seabios and iPXE blobs, then drop those blobs from the snap to keep the package small.