### PR TITLE
feat: force-kill stalled VMs and detect crashed QEMU processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.11.0",
  "ssh-key 0.6.7",
+ "sysinfo",
  "thiserror",
  "tokio",
  "toml",
@@ -1853,6 +1854,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,6 +1931,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3301,6 +3321,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 serde_yaml = "0"
 sha2 = "0"
 ssh-key = { version = "0", features = ["ed25519", "rand_core", "getrandom"]}
+sysinfo = { version = "0", default-features = false, features = ["system"] }
 thiserror = "2"
 tokio = { version = "1", default-features = false, features = ["fs", "io-std"] }
 toml = "1"

--- a/src/actions/stop_instance_action.rs
+++ b/src/actions/stop_instance_action.rs
@@ -13,13 +13,17 @@ impl StopInstanceAction {
         }
     }
 
-    pub fn run(&mut self, instance_dao: &dyn InstanceStore) -> Result<()> {
+    pub fn run(&mut self, instance_dao: &dyn InstanceStore, kill: bool) -> Result<()> {
         if !instance_dao.exists(&self.instance.name) {
             return Err(Error::UnknownInstance(self.instance.name.clone()));
         }
 
         if instance_dao.is_running(&self.instance) {
-            instance_dao.get_monitor(&self.instance)?.shutdown()?;
+            if kill {
+                instance_dao.kill(&self.instance)?;
+            } else {
+                instance_dao.get_monitor(&self.instance)?.shutdown()?;
+            }
         }
 
         Ok(())

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -52,6 +52,7 @@ impl Command for DeleteCommand {
             commands::StopCommand {
                 all: false,
                 wait: true,
+                kill: false,
                 instances: self.instances.clone(),
             }
             .run(console, context)?;

--- a/src/commands/restart_command.rs
+++ b/src/commands/restart_command.rs
@@ -25,6 +25,7 @@ impl Command for RestartCommand {
         commands::StopCommand {
             all: false,
             wait: true,
+            kill: false,
             instances: self.instances.to_vec(),
         }
         .run(console, context)?;

--- a/src/commands/stop_command.rs
+++ b/src/commands/stop_command.rs
@@ -20,6 +20,9 @@ use std::time::Duration;
 ///   Stop all VM instances:
 ///   $ cubic stop --all --wait
 ///
+///   Force-kill the VM instance 'my-instance':
+///   $ cubic stop --kill my-instance
+///
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
 pub struct StopCommand {
@@ -29,6 +32,9 @@ pub struct StopCommand {
     /// Wait for the virtual machine instance to be stopped
     #[clap(short, long, default_value_t = false)]
     pub wait: bool,
+    /// Kill the virtual machine instance
+    #[clap(short, long, default_value_t = false)]
+    pub kill: bool,
     /// Name of the virtual machine instances to stop
     pub instances: Vec<String>,
 }
@@ -46,7 +52,7 @@ impl Command for StopCommand {
         let mut actions = Vec::new();
         for instance in &stop_instances {
             let mut action = StopInstanceAction::new(&instance_store.load(instance)?);
-            action.run(instance_store)?;
+            action.run(instance_store, self.kill)?;
             actions.push(action);
         }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -59,10 +59,6 @@ impl FS {
         fs::File::open(path).map_err(|e| Error::FS(format!("Cannot open file '{path}' ({e})")))
     }
 
-    pub fn path_exists(&self, path: &str) -> bool {
-        Path::new(path).exists()
-    }
-
     pub fn read_file_to_string(&self, path: &str) -> Result<String> {
         fs::read_to_string(path).map_err(|e| Error::FS(format!("Cannot read file '{path}' ({e})")))
     }

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -176,6 +176,24 @@ impl InstanceStore for InstanceDao {
         pid.trim().parse::<u64>().map_err(|_| ())
     }
 
+    fn kill(&self, instance: &Instance) -> Result<()> {
+        let pid = self
+            .get_pid(instance)
+            .map_err(|_| Error::InstanceNotRunning(instance.name.clone()))?;
+
+        let sys_pid = sysinfo::Pid::from_u32(pid as u32);
+        let mut system = sysinfo::System::new();
+        system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[sys_pid]), true);
+        if let Some(process) = system.process(sys_pid) {
+            process.kill();
+        }
+
+        self.fs
+            .remove_file(&self.env.get_qemu_pid_file(&instance.name))
+            .ok();
+        Ok(())
+    }
+
     fn get_monitor(&self, instance: &Instance) -> Result<Monitor> {
         Monitor::new(&self.env, instance)
     }

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -30,6 +30,32 @@ impl InstanceDao {
             env: env.clone(),
         })
     }
+
+    fn is_process_alive(&self, pid: u64) -> bool {
+        let sys_pid = sysinfo::Pid::from_u32(pid as u32);
+        let mut system = sysinfo::System::new();
+        system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[sys_pid]), true);
+        system.process(sys_pid).is_some()
+    }
+
+    fn read_running_pid(&self, instance: &Instance) -> Option<u64> {
+        let pid = self
+            .fs
+            .read_file_to_string(&self.env.get_qemu_pid_file(&instance.name))
+            .ok()?
+            .trim()
+            .parse::<u64>()
+            .ok()?;
+
+        if self.is_process_alive(pid) {
+            Some(pid)
+        } else {
+            self.fs
+                .remove_file(&self.env.get_qemu_pid_file(&instance.name))
+                .ok();
+            None
+        }
+    }
 }
 
 impl InstanceStore for InstanceDao {
@@ -163,17 +189,11 @@ impl InstanceStore for InstanceDao {
     }
 
     fn is_running(&self, instance: &Instance) -> bool {
-        self.fs
-            .path_exists(&self.env.get_qemu_pid_file(&instance.name))
+        self.read_running_pid(instance).is_some()
     }
 
     fn get_pid(&self, instance: &Instance) -> std::result::Result<u64, ()> {
-        let pid = self
-            .fs
-            .read_file_to_string(&self.env.get_qemu_pid_file(&instance.name))
-            .map_err(|_| ())?;
-
-        pid.trim().parse::<u64>().map_err(|_| ())
+        self.read_running_pid(instance).ok_or(())
     }
 
     fn kill(&self, instance: &Instance) -> Result<()> {

--- a/src/instance/instance_store.rs
+++ b/src/instance/instance_store.rs
@@ -15,6 +15,7 @@ pub trait InstanceStore {
 
     fn is_running(&self, instance: &Instance) -> bool;
     fn get_pid(&self, instance: &Instance) -> std::result::Result<u64, ()>;
+    fn kill(&self, instance: &Instance) -> Result<()>;
 
     fn get_monitor(&self, instance: &Instance) -> Result<Monitor>;
 }

--- a/src/instance/instance_store_mock.rs
+++ b/src/instance/instance_store_mock.rs
@@ -57,6 +57,10 @@ pub mod tests {
             std::result::Result::Err(())
         }
 
+        fn kill(&self, _instance: &Instance) -> Result<()> {
+            Ok(())
+        }
+
         fn get_monitor(&self, instance: &Instance) -> Result<Monitor> {
             Err(Error::InstanceNotRunning(instance.name.clone()))
         }


### PR DESCRIPTION
## Summary

Improve QEMU process lifecycle handling in the `stop` command and instance status checks.

### `stop --kill`: force-terminate a VM
Adds a `--kill` flag to `cubic stop`. The normal path performs a graceful QMP
`system_powerdown`, which is useless for a guest that is hung or ignoring the
shutdown request. `--kill` bypasses the graceful path and force-kills the QEMU
process by the PID in `qemu.pid`, then removes the pid file. Killing goes
through the `sysinfo` crate, so it works on Linux, macOS, and Windows.

### Report crashed VMs as stopped
Previously `is_running`/`get_pid` only checked that the `qemu.pid` file existed.
QEMU deletes that file on a clean exit, but when the process dies unexpectedly
(e.g. an OOM kill) the file is left behind, so cubic wrongly reported the VM as
running and showed a stale PID, blocking `delete`, `rename`, `resize`, and
`start`. Both calls now verify a live process actually holds the PID (via
`sysinfo`, through a shared helper) and clean up the stale pid file otherwise.

### Notes
- Adds `sysinfo` as a dependency (cross-platform process inspection/termination).