### PR TITLE
feat: show more details in the show command

### DIFF
--- a/docs/howto/http_server.rst
+++ b/docs/howto/http_server.rst
@@ -54,22 +54,29 @@ You can also open ``http://localhost:8080`` in a browser.
 Show VM Settings
 ----------------
 
-Use ``cubic show`` to inspect the VM configuration including all active port
-forwarding rules:
+Use ``cubic show --all`` to inspect the full VM configuration including all
+active port forwarding rules:
 
 .. code-block::
 
-    $ cubic show webserver
-    Arch:        amd64
-    CPUs:        4
-    Memory:      4.0 GiB
-    Disk Used:   1.2 GiB
-    Disk Total:  100.0 GiB
-    User:        alice
-    Isolated:    no
-    SSH Port:    10022
-    SSH:         ssh -p 10022 alice@localhost
-    Forward:     127.0.0.1:8080:80/tcp
+    $ cubic show --all webserver
+    Status:       stopped
+    PID:          n/a
+    Arch:         amd64
+    CPUs:         4
+    Memory:       4.0 GiB
+    Disk Used:    1.2 GiB
+    Disk Total:   100.0 GiB
+    User:         alice
+    Isolated:     no
+    SSH Port:     10022
+    Monitor Port: 10023
+    Console Port: 10024
+    Disk Image:   ~/.local/share/cubic/machines/webserver/machine.img
+    Config:       ~/.local/share/cubic/machines/webserver/instance.toml
+    SSH Key:      ~/.local/share/cubic/machines/webserver/ssh_client_key
+    SSH:          ssh -i .../webserver/ssh_client_key -p 10022 alice@localhost
+    Forward:      127.0.0.1:8080:80/tcp
 
 Modify VM Settings
 ------------------

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -12,22 +12,42 @@ use clap::Parser;
 ///
 ///   Show information of a VM instance
 ///   $ cubic show trixie
-///   Arch:       amd64
-///   CPUs:       6
-///   Memory:     16.0 GiB
-///   Disk Used:  5.2 GiB
-///   Disk Total: 100.0 GiB
-///   User:       cubic
-///   Isolated:   no
-///   SSH Port:   54315
-///   SSH:        ssh -p 54315 cubic@localhost
-///   Forward:    127.0.0.1:4000:4000/tcp
+///   Status:       running
+///   PID:          12345
+///   Arch:         amd64
+///   CPUs:         6
+///   Memory:       16.0 GiB
+///   Disk Used:    5.2 GiB
+///   Disk Total:   100.0 GiB
+///   User:         cubic
+///   Isolated:     no
+///   SSH Port:     54315
+///   Monitor Port: 54316
+///   Console Port: 54317
+///
+///   Show all information, adding file locations, the SSH command and forwards
+///   $ cubic show --all trixie
+///   ... (fields above, then)
+///   Disk Image:   ~/.local/share/cubic/machines/trixie/machine.img
+///   Config:       ~/.local/share/cubic/machines/trixie/instance.toml
+///   SSH Key:      ~/.local/share/cubic/machines/trixie/ssh_client_key
+///   SSH:          ssh -i .../trixie/ssh_client_key -p 54315 cubic@localhost
+///   Forward:      127.0.0.1:4000:4000/tcp
 ///
 ///   Show information of a VM image
 ///   $ cubic show ubuntu:noble
 ///   Name:         ubuntu:{24.04, noble}
-///   Image URL:    https://cloud-images.ubuntu.com/minimal/releases/noble/release/...
-///   Checksum URL: https://cloud-images.ubuntu.com/minimal/releases/noble/release/...
+///   Architecture: amd64
+///   Size:         512.0 MiB
+///   Cached:       yes
+///
+///   Show all image information, adding checksum, file path and URLs
+///   $ cubic show --all ubuntu:noble
+///   ... (fields above, then)
+///   Checksum:     sha256
+///   Image File:   ~/.cache/cubic/images/ubuntu_noble_amd64
+///   Image URL:    https://cloud-images.ubuntu.com/minimal/releases/noble/...
+///   Checksum URL: https://cloud-images.ubuntu.com/minimal/releases/noble/...
 ///
 ///
 #[derive(Parser)]
@@ -35,16 +55,23 @@ use clap::Parser;
 pub struct ShowCommand {
     /// Name of the virtual machine image or instance
     name: InstanceImageName,
+
+    /// Show all available information
+    #[arg(short = 'a', long = "all")]
+    all: bool,
 }
 
 impl Command for ShowCommand {
     fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
         match &self.name {
-            InstanceImageName::Image(name) => {
-                commands::ShowImageCommand { name: name.clone() }.run(console, context)
+            InstanceImageName::Image(name) => commands::ShowImageCommand {
+                name: name.clone(),
+                all: self.all,
             }
+            .run(console, context),
             InstanceImageName::Instance(instance) => commands::ShowInstanceCommand {
                 instance: instance.clone(),
+                all: self.all,
             }
             .run(console, context),
         }

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -1,6 +1,7 @@
 use crate::commands::{self, Command, image::fetch_image_info};
 use crate::error::Result;
-use crate::models::ImageName;
+use crate::models::{DataSize, ImageName};
+use crate::util;
 use crate::view::{Console, MapView};
 use clap::Parser;
 
@@ -9,15 +10,41 @@ use clap::Parser;
 pub struct ShowImageCommand {
     /// Name of the virtual machine image
     pub name: ImageName,
+
+    /// Show all available information
+    #[arg(short = 'a', long = "all")]
+    pub all: bool,
 }
 
 impl Command for ShowImageCommand {
     fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
-        let image = fetch_image_info(context.get_env(), &self.name)?;
+        let env = context.get_env();
+        let image = fetch_image_info(env, &self.name)?;
+
+        let size = image
+            .size
+            .map(|size| DataSize::new(size as usize).to_size())
+            .unwrap_or("n/a".to_string());
+
         let mut view = MapView::new();
         view.add("Name", &image.get_image_names());
-        view.add("Image URL", &image.image_url);
-        view.add("Checksum URL", &image.checksum_url);
+        view.add("Architecture", &image.arch.to_string());
+        view.add("Size", &size);
+        view.add(
+            "Cached",
+            util::to_yes_no(context.get_image_store().exists(&image)),
+        );
+
+        if self.all {
+            view.add("Checksum", &image.hash_alg.to_string());
+            view.add(
+                "Image File",
+                &format!("{}/{}", env.get_image_dir(), image.to_file_name()),
+            );
+            view.add("Image URL", &image.image_url);
+            view.add("Checksum URL", &image.checksum_url);
+        }
+
         view.print(console);
         Ok(())
     }

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -1,6 +1,7 @@
 use crate::commands::{self, Command};
 use crate::error::{Error, Result};
 use crate::models::InstanceName;
+use crate::util;
 use crate::view::{Console, MapView};
 use clap::Parser;
 
@@ -9,10 +10,15 @@ use clap::Parser;
 pub struct ShowInstanceCommand {
     /// Name of the virtual machine instance
     pub instance: InstanceName,
+
+    /// Show all available information
+    #[arg(short = 'a', long = "all")]
+    pub all: bool,
 }
 
 impl Command for ShowInstanceCommand {
     fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
+        let env = context.get_env();
         let instance_store = context.get_instance_store();
 
         if !instance_store.exists(self.instance.as_str()) {
@@ -20,8 +26,24 @@ impl Command for ShowInstanceCommand {
         }
 
         let instance = instance_store.load(self.instance.as_str())?;
+        let ssh_key = env.get_ssh_private_key_file(&instance.name);
 
         let mut view = MapView::new();
+        view.add(
+            "Status",
+            if instance_store.is_running(&instance) {
+                "running"
+            } else {
+                "stopped"
+            },
+        );
+        view.add(
+            "PID",
+            &instance_store
+                .get_pid(&instance)
+                .map(|pid| pid.to_string())
+                .unwrap_or("n/a".to_string()),
+        );
         view.add("Arch", &instance.arch.to_string());
         view.add("CPUs", &instance.cpus.to_string());
         view.add("Memory", &instance.mem.to_size());
@@ -34,16 +56,38 @@ impl Command for ShowInstanceCommand {
         );
         view.add("Disk Total", &instance.disk_capacity.to_size());
         view.add("User", &instance.user);
-        view.add("Isolated", if instance.isolate { "yes" } else { "no" });
+        view.add("Isolated", util::to_yes_no(instance.isolate));
         view.add("SSH Port", &instance.ssh_port.to_string());
         view.add(
-            "SSH",
-            &format!("ssh -p {} {}@localhost", instance.ssh_port, instance.user),
+            "Monitor Port",
+            &instance
+                .monitor_port
+                .map(|port| port.to_string())
+                .unwrap_or("n/a".to_string()),
         );
+        view.add(
+            "Console Port",
+            &instance
+                .console_port
+                .map(|port| port.to_string())
+                .unwrap_or("n/a".to_string()),
+        );
+        if self.all {
+            view.add("Disk Image", &env.get_instance_image_file(&instance.name));
+            view.add("Config", &env.get_instance_toml_config_file(&instance.name));
+            view.add("SSH Key", &ssh_key);
+            view.add(
+                "SSH",
+                &format!(
+                    "ssh -i {} -p {} {}@localhost",
+                    ssh_key, instance.ssh_port, instance.user
+                ),
+            );
 
-        for (index, rule) in instance.hostfwd.iter().enumerate() {
-            let key = if index == 0 { "Forward" } else { "" };
-            view.add(key, &rule.to_string());
+            for (index, rule) in instance.hostfwd.iter().enumerate() {
+                let key = if index == 0 { "Forward" } else { "" };
+                view.add(key, &rule.to_string());
+            }
         }
 
         view.print(console);
@@ -86,6 +130,7 @@ mod tests {
 
         ShowInstanceCommand {
             instance: InstanceName::from_str("test").unwrap(),
+            all: false,
         }
         .run(console, &context)
         .unwrap();
@@ -93,15 +138,18 @@ mod tests {
         assert_eq!(
             console.get_output(),
             "\
-Arch:       amd64
-CPUs:       1
-Memory:     1.0 KiB
-Disk Used:  n/a
-Disk Total: 1.0 MiB
-User:       myuser
-Isolated:   no
-SSH Port:   9000
-SSH:        ssh -p 9000 myuser@localhost
+Status:       stopped
+PID:          n/a
+Arch:         amd64
+CPUs:         1
+Memory:       1.0 KiB
+Disk Used:    n/a
+Disk Total:   1.0 MiB
+User:         myuser
+Isolated:     no
+SSH Port:     9000
+Monitor Port: n/a
+Console Port: n/a
 "
         );
     }
@@ -124,7 +172,9 @@ SSH:        ssh -p 9000 myuser@localhost
             mem: DataSize::new(1),
             disk_capacity: DataSize::new(1),
             ssh_port: 8000,
-            hostfwd: Vec::new(),
+            monitor_port: Some(8001),
+            console_port: Some(8002),
+            hostfwd: vec!["127.0.0.1:4000:40/tcp".parse().unwrap()],
             isolate: true,
             ..Instance::default()
         }]);
@@ -132,6 +182,7 @@ SSH:        ssh -p 9000 myuser@localhost
 
         ShowInstanceCommand {
             instance: InstanceName::from_str("test").unwrap(),
+            all: true,
         }
         .run(console, &context)
         .unwrap();
@@ -139,15 +190,23 @@ SSH:        ssh -p 9000 myuser@localhost
         assert_eq!(
             console.get_output(),
             "\
-Arch:       arm64
-CPUs:       2
-Memory:     1   B
-Disk Used:  n/a
-Disk Total: 1   B
-User:       john
-Isolated:   yes
-SSH Port:   8000
-SSH:        ssh -p 8000 john@localhost
+Status:       stopped
+PID:          n/a
+Arch:         arm64
+CPUs:         2
+Memory:       1   B
+Disk Used:    n/a
+Disk Total:   1   B
+User:         john
+Isolated:     yes
+SSH Port:     8000
+Monitor Port: 8001
+Console Port: 8002
+Disk Image:   machines/test/machine.img
+Config:       machines/test/instance.toml
+SSH Key:      machines/test/ssh_client_key
+SSH:          ssh -i machines/test/ssh_client_key -p 8000 john@localhost
+Forward:      127.0.0.1:4000:40/tcp
 "
         );
     }
@@ -167,7 +226,8 @@ SSH:        ssh -p 8000 john@localhost
 
         assert!(matches!(
             ShowInstanceCommand {
-                instance: InstanceName::from_str("test").unwrap()
+                instance: InstanceName::from_str("test").unwrap(),
+                all: false,
             }
             .run(console, &context),
             Err(Error::UnknownInstance(_))

--- a/src/models/environment.rs
+++ b/src/models/environment.rs
@@ -118,6 +118,13 @@ impl Environment {
             .into_owned()
     }
 
+    pub fn get_ssh_private_key_file(&self, instance: &str) -> String {
+        PathBuf::from(self.get_instance_dir2(instance))
+            .join("ssh_client_key")
+            .to_string_lossy()
+            .into_owned()
+    }
+
     pub fn get_ssh_private_key_paths(&self, fs: &FS, instances: Vec<String>) -> Vec<String> {
         let mut private_keys = instances
             .iter()

--- a/src/models/image.rs
+++ b/src/models/image.rs
@@ -1,11 +1,22 @@
 use crate::models::Arch;
 use serde::{Deserialize, Serialize};
 use std::cmp::{Ord, Ordering};
+use std::fmt;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum HashAlg {
     Sha512,
     Sha256,
+}
+
+impl fmt::Display for HashAlg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            HashAlg::Sha512 => "sha512",
+            HashAlg::Sha256 => "sha256",
+        };
+        write!(f, "{name}")
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Add a -a/--all flag to `cubic show` that splits the output into a concise default view and a full view with all available details.

Surface more useful information by default, such as the instance run state and ports or the image architecture and size, and fix the printed SSH command to include the instance private key.