### PR TITLE
feat: prefer cubic SSH key and deprecate legacy auth and config

### DIFF
--- a/src/commands/exec_command.rs
+++ b/src/commands/exec_command.rs
@@ -43,11 +43,12 @@ impl Command for ExecCommand {
             .map(|user| user.to_string())
             .unwrap_or(instance.user.to_string());
         let ssh_port = instance.ssh_port;
+        let client_key = env.get_ssh_private_key_file(name.as_str());
         let mut ssh = Russh::new();
-        ssh.set_private_keys(env.get_ssh_private_key_paths(&FS::new(), vec![name.to_string()]));
+        ssh.set_private_keys(env.get_home_ssh_private_key_paths(&FS::new()));
         ssh.set_cmd(Some(self.cmd.clone()));
         ssh.set_env_vars(self.env_args.env_vars.clone());
-        ssh.shell(console, &user, ssh_port);
+        ssh.shell(console, name.as_str(), &client_key, &user, ssh_port);
         Ok(())
     }
 }

--- a/src/commands/run_command.rs
+++ b/src/commands/run_command.rs
@@ -42,7 +42,6 @@ impl Command for RunCommand {
         self.create_cmd.run(console, context)?;
         commands::SshCommand {
             target: Target::from_instance_name(self.create_cmd.instance_name.clone()),
-            cmd: None,
             env_args: self.env_args.clone(),
         }
         .run(console, context)

--- a/src/commands/scp_command.rs
+++ b/src/commands/scp_command.rs
@@ -52,27 +52,29 @@ impl Command for ScpCommand {
         check_target_is_running(instance_store, &self.from)?;
         check_target_is_running(instance_store, &self.to)?;
 
+        let env = context.get_env();
         let root_dir = env::var("SNAP").unwrap_or_default();
+
+        let from = resolve_target_path(&self.from, instance_store)?;
+        let to = resolve_target_path(&self.to, instance_store)?;
+        let from_key = from
+            .instance
+            .as_ref()
+            .map(|instance| env.get_ssh_private_key_file(&instance.name));
+        let to_key = to
+            .instance
+            .as_ref()
+            .map(|instance| env.get_ssh_private_key_file(&instance.name));
+
         let mut ssh = Russh::new();
-
-        let pubkeys = context.get_env().get_ssh_private_key_paths(
-            &FS::new(),
-            [&self.from, &self.to]
-                .iter()
-                .filter_map(|target_path| {
-                    target_path
-                        .get_target()
-                        .map(|target| target.get_instance().to_string())
-                })
-                .collect(),
-        );
-
-        ssh.set_private_keys(pubkeys);
+        ssh.set_private_keys(env.get_home_ssh_private_key_paths(&FS::new()));
         ssh.copy(
             console,
             &root_dir,
-            &resolve_target_path(&self.from, instance_store)?,
-            &resolve_target_path(&self.to, instance_store)?,
+            &from,
+            from_key.as_deref(),
+            &to,
+            to_key.as_deref(),
         )?;
         Ok(())
     }

--- a/src/commands/ssh_command.rs
+++ b/src/commands/ssh_command.rs
@@ -21,21 +21,12 @@ pub struct SshCommand {
     pub target: Target,
     #[clap(flatten)]
     pub env_args: commands::EnvArgs,
-    /// Command to execute in the virtual machine instance
-    #[clap(hide = true)]
-    pub cmd: Option<String>,
 }
 
 impl Command for SshCommand {
     fn run(&self, console: &mut dyn Console, context: &commands::Context) -> Result<()> {
         let env = context.get_env();
         let instance_store = context.get_instance_store();
-
-        if self.cmd.is_some() {
-            console.info(
-                "Note: cubic ssh with cmd is deprecated - use 'cubic exec <instance> <cmd>' instead",
-            );
-        }
 
         let name = self.target.get_instance();
 
@@ -55,7 +46,6 @@ impl Command for SshCommand {
         let ssh_port = instance.ssh_port;
         let mut ssh = Russh::new();
         ssh.set_private_keys(env.get_ssh_private_key_paths(&FS::new(), vec![name.to_string()]));
-        ssh.set_cmd(self.cmd.clone());
         ssh.set_env_vars(self.env_args.env_vars.clone());
         ssh.shell(console, &user, ssh_port);
         Ok(())

--- a/src/commands/ssh_command.rs
+++ b/src/commands/ssh_command.rs
@@ -44,10 +44,11 @@ impl Command for SshCommand {
             .map(|user| user.to_string())
             .unwrap_or(instance.user.to_string());
         let ssh_port = instance.ssh_port;
+        let client_key = env.get_ssh_private_key_file(name.as_str());
         let mut ssh = Russh::new();
-        ssh.set_private_keys(env.get_ssh_private_key_paths(&FS::new(), vec![name.to_string()]));
+        ssh.set_private_keys(env.get_home_ssh_private_key_paths(&FS::new()));
         ssh.set_env_vars(self.env_args.env_vars.clone());
-        ssh.shell(console, &user, ssh_port);
+        ssh.shell(console, name.as_str(), &client_key, &user, ssh_port);
         Ok(())
     }
 }

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -93,12 +93,12 @@ impl InstanceStore for InstanceDao {
         let yaml_path = &self.env.get_instance_yaml_config_file(name);
         let toml_path = &self.env.get_instance_toml_config_file(name);
 
-        let (path, deserializer): (&str, Box<dyn InstanceDeserializer>) =
-            if Path::new(toml_path).exists() {
-                (toml_path, Box::new(TomlInstanceDeserializer::new()))
-            } else {
-                (yaml_path, Box::new(YamlInstanceDeserializer::new()))
-            };
+        let from_yaml = !Path::new(toml_path).exists();
+        let (path, deserializer): (&str, Box<dyn InstanceDeserializer>) = if from_yaml {
+            (yaml_path, Box::new(YamlInstanceDeserializer::new()))
+        } else {
+            (toml_path, Box::new(TomlInstanceDeserializer::new()))
+        };
 
         let instance = self
             .fs
@@ -106,6 +106,11 @@ impl InstanceStore for InstanceDao {
             .ok()
             .and_then(|mut file| deserializer.deserialize(name, &mut file))
             .map(|mut instance| {
+                // migrate the deprecated yaml config to the toml format
+                if from_yaml {
+                    self.store(&instance).ok();
+                }
+
                 let size = QemuImg::new()
                     .get_image_info(&self.env, &instance)
                     .map(|info| DataSize::new(info.actual_size as usize));

--- a/src/models/environment.rs
+++ b/src/models/environment.rs
@@ -125,16 +125,8 @@ impl Environment {
             .into_owned()
     }
 
-    pub fn get_ssh_private_key_paths(&self, fs: &FS, instances: Vec<String>) -> Vec<String> {
-        let mut private_keys = instances
-            .iter()
-            .map(|name| {
-                PathBuf::from(self.get_instance_dir2(name))
-                    .join("ssh_client_key")
-                    .to_string_lossy()
-                    .into_owned()
-            })
-            .collect::<Vec<String>>();
+    pub fn get_home_ssh_private_key_paths(&self, fs: &FS) -> Vec<String> {
+        let mut private_keys = Vec::new();
 
         let search_dirs: Vec<String> = ["SNAP_REAL_HOME", "HOME"]
             .iter()

--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::models::{Instance, TargetInstancePath};
-use crate::ssh_cmd::SftpPath;
+use crate::ssh_cmd::{SftpPath, SshKeyGenerator};
 use crate::util;
 use crate::view::{Console, SpinnerView};
 use russh::keys::*;
@@ -8,9 +8,16 @@ use russh::*;
 use russh_sftp::client::SftpSession;
 use std::env;
 use std::io::{Cursor, Write};
+use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 use tokio::{io::AsyncReadExt, sync::Mutex};
+
+#[derive(PartialEq)]
+enum AuthMethod {
+    ClientKey,
+    Deprecated,
+}
 
 async fn read_password(console: &mut dyn Console, user: &str) -> Result<String, ()> {
     let mut stdout = std::io::stdout();
@@ -143,18 +150,18 @@ impl Russh {
         if let Ok(true) = auth { Ok(()) } else { Err(()) }
     }
 
-    async fn authenticate_with_pubkey(
+    async fn authenticate_with_keys(
         &self,
         session: &mut russh::client::Handle<Client>,
         user: &str,
-    ) -> Result<(), ()> {
-        let hash_alg = session
-            .best_supported_rsa_hash()
-            .await
-            .map_err(|_| ())?
-            .flatten();
+        keys: &[String],
+    ) -> bool {
+        let Ok(hash_alg) = session.best_supported_rsa_hash().await else {
+            return false;
+        };
+        let hash_alg = hash_alg.flatten();
 
-        for key in &self.private_keys {
+        for key in keys {
             if let Ok(key_pair) = load_secret_key(key, None)
                 && let Ok(auth) = session
                     .authenticate_publickey(
@@ -164,11 +171,11 @@ impl Russh {
                     .await
                 && auth.success()
             {
-                return Ok(());
+                return true;
             }
         }
 
-        Err(())
+        false
     }
 
     async fn authenticate_with_password(
@@ -198,26 +205,72 @@ impl Russh {
         console: &mut dyn Console,
         session: &mut russh::client::Handle<Client>,
         user: &str,
-    ) -> Result<(), ()> {
+        client_key: &str,
+    ) -> Result<AuthMethod, ()> {
+        // The cubic per-instance ssh_client_key is the only supported method.
+        // Everything below is a deprecated fallback.
+        if self
+            .authenticate_with_keys(session, user, &[client_key.to_string()])
+            .await
+        {
+            return Ok(AuthMethod::ClientKey);
+        }
+
+        if self
+            .authenticate_with_keys(session, user, &self.private_keys)
+            .await
+        {
+            return Ok(AuthMethod::Deprecated);
+        }
+
         if self
             .authenticate_with_default_password(session, user)
             .await
             .is_ok()
         {
-            return Ok(());
-        }
-
-        if self.authenticate_with_pubkey(session, user).await.is_ok() {
-            return Ok(());
+            return Ok(AuthMethod::Deprecated);
         }
 
         self.authenticate_with_password(console, session, user)
             .await
+            .map(|_| AuthMethod::Deprecated)
+    }
+
+    fn warn_deprecated_auth(
+        &self,
+        console: &mut dyn Console,
+        machine: &str,
+        client_key: &str,
+    ) -> Result<(), ()> {
+        // create the cubic ssh key if it does not exist yet
+        if !Path::new(client_key).exists() {
+            SshKeyGenerator::new()
+                .generate_key(Path::new(client_key))
+                .map_err(|_| ())?;
+        }
+
+        let pubkey = SshKeyGenerator::new()
+            .generate_public_key(Path::new(client_key))
+            .map_err(|_| ())?;
+
+        console.info(&format!(
+            "WARN: Connected to '{machine}' using a deprecated authentication method."
+        ));
+        console.info(&format!(
+            "Add the following cubic SSH key on '{machine}' to ~/.ssh/authorized_keys:"
+        ));
+        console.info("");
+        console.info(&pubkey);
+        console.info("");
+
+        Ok(())
     }
 
     async fn open_channel(
         &self,
         console: &mut dyn Console,
+        machine: &str,
+        client_key: &str,
         user: &str,
         port: u16,
     ) -> Result<Channel<russh::client::Msg>, ()> {
@@ -239,7 +292,13 @@ impl Russh {
             s.stop()
         }
 
-        self.authenticate(console, &mut session, user).await?;
+        if self
+            .authenticate(console, &mut session, user, client_key)
+            .await?
+            == AuthMethod::Deprecated
+        {
+            self.warn_deprecated_auth(console, machine, client_key).ok();
+        }
 
         session.channel_open_session().await.map_err(|_| ())
     }
@@ -247,10 +306,14 @@ impl Russh {
     async fn handle_interactive_shell(
         &self,
         console: &mut dyn Console,
+        machine: &str,
+        client_key: &str,
         user: &str,
         port: u16,
     ) -> Result<(), ()> {
-        let channel = self.open_channel(console, user, port).await?;
+        let channel = self
+            .open_channel(console, machine, client_key, user, port)
+            .await?;
         let (w, h) = console.get_geometry().unwrap();
         channel
             .request_pty(
@@ -300,10 +363,11 @@ impl Russh {
         console: &mut dyn Console,
         instance: &Instance,
         user: &Option<String>,
+        client_key: &str,
     ) -> Rc<SftpSession> {
         let user = user.as_ref().unwrap_or(&instance.user);
         let channel = self
-            .open_channel(console, user, instance.ssh_port)
+            .open_channel(console, &instance.name, client_key, user, instance.ssh_port)
             .await
             .unwrap();
         channel.request_subsystem(true, "sftp").await.unwrap();
@@ -314,9 +378,18 @@ impl Russh {
         &self,
         console: &mut dyn Console,
         path: &TargetInstancePath,
+        client_key: Option<&str>,
     ) -> SftpPath {
         let sftp = if let Some(instance) = &path.instance {
-            Some(self.open_sftp(console, instance, &path.user).await)
+            Some(
+                self.open_sftp(
+                    console,
+                    instance,
+                    &path.user,
+                    client_key.unwrap_or_default(),
+                )
+                .await,
+            )
         } else {
             None
         };
@@ -331,10 +404,12 @@ impl Russh {
         console: &mut dyn Console,
         _root_dir: &str,
         from: &TargetInstancePath,
+        from_key: Option<&str>,
         to: &TargetInstancePath,
+        to_key: Option<&str>,
     ) -> Result<(), Error> {
-        let source = self.open_target_fs(console, from).await;
-        let target = self.open_target_fs(console, to).await;
+        let source = self.open_target_fs(console, from, from_key).await;
+        let target = self.open_target_fs(console, to, to_key).await;
 
         source.copy(target).await
     }
@@ -351,9 +426,16 @@ impl Russh {
         self.env_vars = env_vars;
     }
 
-    pub fn shell(&mut self, console: &mut dyn Console, user: &str, port: u16) -> bool {
+    pub fn shell(
+        &mut self,
+        console: &mut dyn Console,
+        machine: &str,
+        client_key: &str,
+        user: &str,
+        port: u16,
+    ) -> bool {
         util::AsyncCaller::new()
-            .call(self.handle_interactive_shell(console, user, port))
+            .call(self.handle_interactive_shell(console, machine, client_key, user, port))
             .is_ok()
     }
 
@@ -362,8 +444,11 @@ impl Russh {
         console: &mut dyn Console,
         root_dir: &str,
         from: &TargetInstancePath,
+        from_key: Option<&str>,
         to: &TargetInstancePath,
+        to_key: Option<&str>,
     ) -> Result<(), Error> {
-        util::AsyncCaller::new().call(self.async_copy(console, root_dir, from, to))
+        util::AsyncCaller::new()
+            .call(self.async_copy(console, root_dir, from, from_key, to, to_key))
     }
 }


### PR DESCRIPTION
## Summary

Modernizes how cubic authenticates to and configures instances, deprecating the old mechanisms in favor of safer, automatic defaults.

- Authentication now prefers each instance's dedicated cubic SSH key, with passwords and personal home keys kept only as deprecated fallbacks that warn the user.
- Legacy `machine.yaml` config is automatically migrated to `instance.toml` on load.
- The long-deprecated trailing command argument on `cubic ssh` is removed in favor of `cubic exec`.