### PR TITLE
fix: show the configured username in console credentials

### DIFF
--- a/src/commands/console_command.rs
+++ b/src/commands/console_command.rs
@@ -37,10 +37,11 @@ impl Command for ConsoleCommand {
         }
         .run(console, context)?;
 
-        console.info("Default credentials: cubic / cubic");
+        let instance = context.get_instance_store().load(&self.instance)?;
+
+        console.info(&format!("Default credentials: {} / cubic", instance.user));
         console.info("Press CTRL+W to exit the console.");
 
-        let instance = context.get_instance_store().load(&self.instance)?;
         let port = instance
             .console_port
             .ok_or_else(|| Error::InstanceNotRunning(self.instance.clone()))?;


### PR DESCRIPTION
The console command printed a hardcoded username in the login credentials, which was wrong whenever the instance username differed from the default, either because of the -u flag at create time or because the host username differs. Print the instance's actual username instead.