### PR TITLE
chore: release v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "cubic"
-version = "0.0.0-dev"
+version = "0.24.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubic"
-version = "0.0.0-dev"
+version = "0.24.0"
 authors = ["Roger Knecht <rknecht@pm.me>"]
 license = "MIT OR Apache-2.0"
 description = "Cubic spins up Linux virtual machines on Linux, macOS and Windows with a single command."


### PR DESCRIPTION
Bump version in Cargo.toml and Cargo.lock.