### PR TITLE
refactor: read host username via sysinfo instead of whoami

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
- "whoami",
 ]
 
 [[package]]
@@ -1391,15 +1390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libredox"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,15 +1564,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-system-configuration"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
-dependencies = [
  "objc2-core-foundation",
 ]
 
@@ -3113,18 +3094,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "whoami"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
-dependencies = [
- "libc",
- "libredox",
- "objc2-system-configuration",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0"
 sha2 = "0.11"
-sysinfo = { version = "0", default-features = false, features = ["system"] }
+sysinfo = { version = "0", default-features = false, features = ["system", "user"] }
 thiserror = "2"
 tokio = { version = "1", default-features = false, features = ["fs", "io-std"] }
 toml = "1"
-whoami = { version = "2", default-features = false, features = ["std"] }
 
 [profile.release]
 opt-level = 'z'

--- a/src/env/environment_factory.rs
+++ b/src/env/environment_factory.rs
@@ -1,6 +1,7 @@
 use crate::error::{Error, Result};
 use crate::models::Environment;
 use std::env;
+use sysinfo::{ProcessesToUpdate, System, Users};
 
 const ROOT_USERNAME: &str = "root";
 pub const DEFAULT_USERNAME: &str = "cubic";
@@ -12,8 +13,19 @@ impl EnvironmentFactory {
         env::var(var).map_err(|_| Error::UnsetEnvVar(var.to_string()))
     }
 
+    fn read_current_username() -> Option<String> {
+        let pid = sysinfo::get_current_pid().ok()?;
+        let mut system = System::new();
+        system.refresh_processes(ProcessesToUpdate::Some(&[pid]), false);
+        let uid = system.process(pid)?.user_id()?;
+        let users = Users::new_with_refreshed_list();
+        users
+            .get_user_by_id(uid)
+            .map(|user| user.name().to_string())
+    }
+
     pub fn get_username() -> String {
-        let username = whoami::username().unwrap_or(DEFAULT_USERNAME.to_string());
+        let username = Self::read_current_username().unwrap_or(DEFAULT_USERNAME.to_string());
         if username == ROOT_USERNAME {
             DEFAULT_USERNAME.to_string()
         } else {


### PR DESCRIPTION
Cubic already uses sysinfo for host details, so reading the current username through it as well removes the redundant whoami dependency without changing behavior.