### PR TITLE
docs: document minimum Rust version and dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Then clone the repository:
 ```bash
 git clone https://github.com/cubic-vm/cubic.git
 cd cubic/
-rustup toolchain add 1.92.0
+rustup toolchain install stable
 ```
 
 ## How to build?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/cubic-vm/cubic"
 keywords = ["cli", "vm", "qemu", "virtual-machine", "cloud-init"]
 categories = ["command-line-utilities"]
 edition = "2024"
+rust-version = "1.92"
 
 [features]
 qemu-sandbox = []

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![github.com](https://github.com/cubic-vm/cubic/actions/workflows/build.yml/badge.svg)](https://github.com/cubic-vm/cubic/actions/workflows/build.yml)
 [![crates.io](https://img.shields.io/crates/v/cubic.svg)](https://crates.io/crates/cubic)
+[![MSRV](https://img.shields.io/crates/msrv/cubic.svg)](https://crates.io/crates/cubic)
 [![snapcraft.io](https://snapcraft.io/cubic/badge.svg)](https://snapcraft.io/cubic)
 
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,36 @@ We are actively looking for help to improve Cubic. You can help in various ways:
 - :construction_worker: If you are a developer and you want to submit a change, please have a look at the [contribution page](CONTRIBUTING.md)!
 - :pencil: If you are a technical writer and you want to improve the documentation, please have a look at the [contribution page](CONTRIBUTING.md)!
 
+# :package: Dependencies
+
+Cubic keeps its dependency tree small and lean, acting as thin glue over proven
+tools rather than reinventing them.
+
+At runtime Cubic has a single dependency: **QEMU**, the virtualization engine it
+drives to run every VM.
+
+| Rust Crate | Usage |
+|------------|-------|
+| clap | Parse CLI commands, arguments, and flags |
+| clap_complete | Generate shell completion scripts |
+| crossterm | Terminal control for the interactive console and views |
+| getrandom | Secure randomness for SSH key generation |
+| regex | Parse image and instance names and scrape image version listings |
+| rcgen | Generate the per-instance self-signed certificates for QEMU mTLS |
+| reqwest | Download cloud images over HTTPS |
+| russh | Pure-Rust SSH client to connect into VMs |
+| russh-sftp | SFTP file transfer over the SSH connection |
+| rustls | TLS for the QEMU mTLS control channel |
+| rustls-pki-types | Shared certificate and key types backing rustls |
+| serde | Derive serialization for config and QMP messages |
+| serde_json | QMP protocol and firmware descriptor parsing |
+| serde_yaml | Parse cloud-init and instance YAML |
+| sha2 | Verify downloaded image checksums |
+| sysinfo | Read the host username and detect running QEMU processes |
+| thiserror | Derive the crate's error types |
+| tokio | Async runtime for SSH and SFTP transfers |
+| toml | Read and write the `instance.toml` config |
+
 # :page_with_curl: License
 
 Cubic is dual-licensed under [Apache](LICENSE-APACHE) and [MIT](LICENSE-MIT).

--- a/docs/howto/install.rst
+++ b/docs/howto/install.rst
@@ -81,7 +81,7 @@ Install the `Rust toolchain`_:
 
 .. code-block::
 
-    rustup toolchain add 1.92.0
+    rustup toolchain install stable
 
 .. _Rust toolchain: https://rustup.rs
 


### PR DESCRIPTION
## Document the minimum Rust version and dependencies

Makes the project's Rust requirements and dependency surface explicit and
self-documenting, with `Cargo.toml` as the single source of truth.

### Changes

- **Declare the MSRV** — add `rust-version = "1.92"` to `Cargo.toml` so
  `cargo` enforces the minimum toolchain with a clear error instead of a
  deep compile failure.
- **Surface it in the README** — add an MSRV badge that auto-reads
  `rust-version` from crates.io, so it never needs manual updating.
- **Drop hardcoded versions from docs** — replace `rustup toolchain add
  1.92.0` with `rustup toolchain install stable` in `CONTRIBUTING.md` and
  `docs/howto/install.rst`, removing duplicated version numbers.
- **Document dependencies** — add a "Dependencies" section to the README
  listing every direct Rust crate with its purpose, plus QEMU as the sole
  runtime dependency, reflecting the project's lean dependency policy.