### PR TITLE
feat: fit machine to free memory on start

### DIFF
--- a/src/commands/console_command.rs
+++ b/src/commands/console_command.rs
@@ -33,6 +33,7 @@ impl Command for ConsoleCommand {
         commands::StartCommand {
             qemu_args: None,
             wait: false,
+            yes: commands::YesArg { value: false },
             instances: vec![self.instance.to_string()],
         }
         .run(console, context)?;

--- a/src/commands/exec_command.rs
+++ b/src/commands/exec_command.rs
@@ -32,6 +32,7 @@ impl Command for ExecCommand {
         commands::StartCommand {
             qemu_args: None,
             wait: true,
+            yes: commands::YesArg { value: false },
             instances: vec![name.to_string()],
         }
         .run(console, context)?;

--- a/src/commands/restart_command.rs
+++ b/src/commands/restart_command.rs
@@ -32,6 +32,7 @@ impl Command for RestartCommand {
         commands::StartCommand {
             qemu_args: None,
             wait: true,
+            yes: commands::YesArg { value: false },
             instances: self.instances.to_vec(),
         }
         .run(console, context)

--- a/src/commands/ssh_command.rs
+++ b/src/commands/ssh_command.rs
@@ -33,6 +33,7 @@ impl Command for SshCommand {
         commands::StartCommand {
             qemu_args: None,
             wait: true,
+            yes: commands::YesArg { value: false },
             instances: vec![name.to_string()],
         }
         .run(console, context)?;

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -1,12 +1,16 @@
 use crate::actions::StartInstanceAction;
 use crate::commands::{self, Command};
 use crate::error::{Error, Result};
+use crate::instance::InstanceStore;
+use crate::models::{DataSize, HOST_MEMORY_RESERVE, Instance, ResourceAllocator};
 use crate::ssh_cmd::PortChecker;
+use crate::util;
 use crate::view::Console;
 use crate::view::SpinnerView;
 use clap::Parser;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
+use sysinfo::System;
 
 /// Start VM instances
 ///
@@ -33,6 +37,8 @@ pub struct StartCommand {
     /// Wait until the VM instance has started
     #[clap(short, long, default_value_t = false)]
     pub wait: bool,
+    #[clap(flatten)]
+    pub yes: commands::YesArg,
     /// Name of the virtual machine instances to start
     pub instances: Vec<String>,
 }
@@ -53,6 +59,8 @@ impl Command for StartCommand {
                     instance.ssh_port = port_checker.get_new_port()?;
                     instance_store.store(instance)?;
                 }
+
+                self.fit_to_available_memory(console, instance_store, instance)?;
 
                 let mut action = StartInstanceAction::new(instance);
                 action.run(context, &self.qemu_args, verbosity.is_verbose())?;
@@ -76,5 +84,51 @@ impl Command for StartCommand {
         }
 
         Ok(())
+    }
+}
+
+impl StartCommand {
+    /// Reduce an instance to a size that fits the host's available memory.
+    ///
+    /// QEMU fails to start when the host cannot back the requested memory, so
+    /// this proposes the largest resource level that fits the available memory
+    /// minus a host reserve. The reduced size is persisted on accept. The start
+    /// is aborted when the user declines or nothing fits.
+    fn fit_to_available_memory(
+        &self,
+        console: &mut dyn Console,
+        instance_store: &dyn InstanceStore,
+        instance: &mut Instance,
+    ) -> Result<()> {
+        let mut system = System::new();
+        system.refresh_memory();
+        let available = system.available_memory() as usize;
+
+        if available.saturating_sub(HOST_MEMORY_RESERVE) >= instance.mem.get_bytes() {
+            return Ok(());
+        }
+
+        let (cpus, mem) = ResourceAllocator::get_resources_for_budget(available)
+            .ok_or_else(|| Error::NotEnoughMemory(instance.name.clone()))?;
+        let cpus = cpus.min(instance.cpus);
+
+        console.info(&format!(
+            "Instance '{}' requests {} vCPUs and {} but only {} is available.\nIt can be started with {} vCPUs and {} instead.",
+            instance.name,
+            instance.cpus,
+            instance.mem.to_size(),
+            DataSize::new(available).to_size(),
+            cpus,
+            mem.to_size(),
+        ));
+
+        if self.yes.value || util::confirm("Reduce and start? [y/n]: ") {
+            instance.cpus = cpus;
+            instance.mem = mem;
+            instance_store.store(instance)?;
+            Ok(())
+        } else {
+            Err(Error::NotEnoughMemory(instance.name.clone()))
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,11 @@ pub enum Error {
     StartTimeout,
 
     #[error(
+        "Not enough free memory to start instance '{0}'.\n\nTroubleshoot:\n  - Free up memory by stopping other instances or processes\n  - Reduce the instance memory: `cubic modify {0} --memory <size>`\n  - Accept the proposed smaller size by running with --yes\n"
+    )]
+    NotEnoughMemory(String),
+
+    #[error(
         "Instance name '{0}' is already taken.\n\nOptions:\n  - Choose a different name\n  - Connect to existing instance: `cubic ssh {0}`"
     )]
     InstanceAlreadyExists(String),

--- a/src/models/resource_allocator.rs
+++ b/src/models/resource_allocator.rs
@@ -4,6 +4,10 @@ use sysinfo::System;
 const MIB: usize = 1024 * 1024;
 const GIB: usize = 1024 * MIB;
 
+/// Memory kept aside for the host and QEMU overhead so a machine never claims
+/// all of the available memory.
+pub const HOST_MEMORY_RESERVE: usize = GIB;
+
 /// Decides the default vCPU count and memory for a new machine based on the
 /// resources of the host it runs on.
 ///
@@ -60,7 +64,21 @@ impl ResourceAllocator {
     pub fn get_default_resources(&self) -> (u16, DataSize) {
         let by_threads = self.host_threads as usize / 4;
         let by_memory = self.host_mem_bytes / (4 * GIB);
-        let level = by_threads.min(by_memory).saturating_sub(1);
+        Self::resources_for_level(by_threads.min(by_memory).saturating_sub(1))
+    }
+
+    /// Return the largest level whose memory fits in `available_bytes` after
+    /// holding back the host reserve. Level N is 2N vCPUs and N GiB, so the
+    /// level is the budget in whole GiB. Falls back to 1 vCPU and 512 MiB and
+    /// returns None when not even that fits.
+    pub fn get_resources_for_budget(available_bytes: usize) -> Option<(u16, DataSize)> {
+        let budget = available_bytes.saturating_sub(HOST_MEMORY_RESERVE);
+        (budget >= 512 * MIB).then(|| Self::resources_for_level(budget / GIB))
+    }
+
+    /// Map a level to its machine size. Level N is 2N vCPUs and N GiB, and the
+    /// level 0 floor is 1 vCPU and 512 MiB.
+    fn resources_for_level(level: usize) -> (u16, DataSize) {
         if level == 0 {
             (1, DataSize::new(512 * MIB))
         } else {
@@ -151,5 +169,38 @@ mod tests {
     fn test_small_host_falls_back_to_one_core() {
         assert_resources(4, 4, 1, 512 * MIB);
         assert_resources(1, 1, 1, 512 * MIB);
+    }
+
+    #[test]
+    fn test_budget_reserves_host_memory() {
+        // 5 GiB available minus the 1 GiB reserve leaves a 4 GiB budget.
+        assert_eq!(
+            ResourceAllocator::get_resources_for_budget(5 * GIB),
+            Some((8, DataSize::new(4 * GIB)))
+        );
+    }
+
+    #[test]
+    fn test_budget_rounds_down_to_whole_gib() {
+        // 3.5 GiB available, 2.5 GiB budget, fits level 2.
+        assert_eq!(
+            ResourceAllocator::get_resources_for_budget(3 * GIB + 512 * MIB),
+            Some((4, DataSize::new(2 * GIB)))
+        );
+    }
+
+    #[test]
+    fn test_budget_falls_back_to_512_mib() {
+        // Budget between 512 MiB and 1 GiB yields the smallest machine.
+        assert_eq!(
+            ResourceAllocator::get_resources_for_budget(GIB + 512 * MIB),
+            Some((1, DataSize::new(512 * MIB)))
+        );
+    }
+
+    #[test]
+    fn test_budget_too_small_returns_none() {
+        assert_eq!(ResourceAllocator::get_resources_for_budget(GIB), None);
+        assert_eq!(ResourceAllocator::get_resources_for_budget(0), None);
     }
 }


### PR DESCRIPTION
Check the host's available memory before starting a machine. When it does not fit, propose reducing it to a resource allocator level that does, ask to confirm, persist the smaller size, and start. Abort with a clear error when declined or nothing fits, with -y/--yes to accept automatically.