### PR TITLE
feat: add colored info/warn/error console output

### DIFF
--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -41,9 +41,9 @@ impl Command for DeleteCommand {
         }
 
         // Print instances to be deleted
-        console.info("The following VM instances are going to be deleted:");
+        console.print("The following VM instances are going to be deleted:");
         for instance in &self.instances {
-            console.info(&format!("  - {instance}"));
+            console.print(&format!("  - {instance}"));
         }
 
         // Ask for confirmation

--- a/src/commands/prune_command.rs
+++ b/src/commands/prune_command.rs
@@ -31,12 +31,12 @@ impl Command for PruneCommand {
         )
         .to_size();
 
-        console.info("The following items will be deleted:");
-        console.info("  - VM image list cache");
-        console.info("  - Downloaded VM images");
+        console.print("The following items will be deleted:");
+        console.print("  - VM image list cache");
+        console.print("  - Downloaded VM images");
 
         // Print size of files to be deleted
-        console.info(&format!("\nTotal size: {total}\n"));
+        console.print(&format!("\nTotal size: {total}\n"));
 
         if self.yes.value || util::confirm("Are you sure you want to continue? [y/N]") {
             // Delete files
@@ -44,7 +44,7 @@ impl Command for PruneCommand {
             fs.remove_dir(&env.get_image_dir()).ok();
 
             // Print size of deleted files
-            console.info(&format!("Successfully freed {total} of disk space."));
+            console.print(&format!("Successfully freed {total} of disk space."));
         }
 
         Ok(())

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -116,7 +116,7 @@ impl StartCommand {
             .ok_or_else(|| Error::NotEnoughMemory(instance.name.clone()))?;
         let cpus = cpus.min(instance.cpus);
 
-        console.info(&format!(
+        console.warn(&format!(
             "Instance '{}' requests {} vCPUs and {} but only {} is available.\nIt can be started with {} vCPUs and {} instead.",
             instance.name,
             instance.cpus,

--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -253,15 +253,15 @@ impl Russh {
             .generate_public_key(Path::new(client_key))
             .map_err(|_| ())?;
 
-        console.info(&format!(
-            "WARN: Connected to '{machine}' using a deprecated authentication method."
+        console.warn(&format!(
+            "Connected to '{machine}' using a deprecated authentication method."
         ));
-        console.info(&format!(
+        console.warn(&format!(
             "Add the following cubic SSH key on '{machine}' to ~/.ssh/authorized_keys:"
         ));
-        console.info("");
-        console.info(&pubkey);
-        console.info("");
+        console.print("");
+        console.print(&pubkey);
+        console.print("");
 
         Ok(())
     }

--- a/src/view/console.rs
+++ b/src/view/console.rs
@@ -5,7 +5,9 @@ use std::sync::{Arc, Mutex};
 pub trait Console {
     fn get_verbosity(&mut self) -> Verbosity;
     fn set_verbosity(&mut self, verbosity: Verbosity);
+    fn print(&mut self, msg: &str);
     fn info(&mut self, msg: &str);
+    fn warn(&mut self, msg: &str);
     fn error(&mut self, msg: &str);
 
     fn get_geometry(&self) -> Option<(u32, u32)>;

--- a/src/view/console_mock.rs
+++ b/src/view/console_mock.rs
@@ -30,12 +30,20 @@ pub mod tests {
             Verbosity::Normal
         }
 
-        fn info(&mut self, msg: &str) {
+        fn print(&mut self, msg: &str) {
             self.log(msg)
         }
 
+        fn info(&mut self, msg: &str) {
+            self.log(&format!("info: {msg}"))
+        }
+
+        fn warn(&mut self, msg: &str) {
+            self.log(&format!("warn: {msg}"))
+        }
+
         fn error(&mut self, msg: &str) {
-            self.log(msg)
+            self.log(&format!("error: {msg}"))
         }
 
         fn get_geometry(&self) -> Option<(u32, u32)> {

--- a/src/view/map_view.rs
+++ b/src/view/map_view.rs
@@ -27,7 +27,7 @@ impl MapView {
             if !key.is_empty() {
                 key += ":";
             }
-            console.info(&format!("{key:max_key_length$} {value}"));
+            console.print(&format!("{key:max_key_length$} {value}"));
         });
     }
 }

--- a/src/view/stdio.rs
+++ b/src/view/stdio.rs
@@ -2,14 +2,41 @@ use crate::commands::Verbosity;
 use crate::view::{Animation, Console};
 use crossterm::QueueableCommand;
 use crossterm::cursor::MoveToColumn;
-use crossterm::style::Print;
+use crossterm::style::{Attribute, Color, Print, SetAttribute, SetForegroundColor};
 use crossterm::terminal::{Clear, ClearType};
-use std::io::{IsTerminal, Stdout, Write, stdout};
+use std::io::{IsTerminal, Stdout, Write, stderr, stdout};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 const ANIMATION_TICK_MS: u64 = 100;
+
+fn is_no_color() -> bool {
+    std::env::var_os("NO_COLOR").is_some()
+}
+
+// On Windows, ANSI escape codes are only interpreted once virtual terminal
+// processing is turned on for the console; this call is a no-op elsewhere.
+#[cfg(windows)]
+fn enable_ansi_support() {
+    crossterm::ansi_support::supports_ansi();
+}
+
+#[cfg(not(windows))]
+fn enable_ansi_support() {}
+
+fn colorize(label: &str, color: Color, enabled: bool) -> String {
+    if enabled {
+        format!(
+            "{}{}{label}{}",
+            SetForegroundColor(color),
+            SetAttribute(Attribute::Bold),
+            SetAttribute(Attribute::Reset)
+        )
+    } else {
+        label.to_string()
+    }
+}
 
 struct AnimationState {
     inner: Mutex<AnimationInner>,
@@ -27,10 +54,22 @@ enum Stream {
 }
 
 impl Stream {
-    fn print(self, msg: &str) {
+    fn is_terminal(&self) -> bool {
         match self {
-            Stream::Stdout => println!("{msg}"),
-            Stream::Stderr => eprintln!("{msg}"),
+            Stream::Stdout => stdout().is_terminal(),
+            Stream::Stderr => stderr().is_terminal(),
+        }
+    }
+
+    fn print(self, msg: &str, style: Option<(&str, Color)>) {
+        let enabled = style.is_some() && self.is_terminal() && !is_no_color();
+        let text = match style {
+            Some((label, color)) => format!("{} {msg}", colorize(label, color, enabled)),
+            None => msg.to_string(),
+        };
+        match self {
+            Stream::Stdout => println!("{text}"),
+            Stream::Stderr => eprintln!("{text}"),
         }
     }
 }
@@ -44,6 +83,7 @@ pub struct Stdio {
 
 impl Stdio {
     pub fn new() -> Self {
+        enable_ansi_support();
         Self {
             verbosity: Verbosity::new(false, false),
             is_tty: stdout().is_terminal(),
@@ -62,14 +102,14 @@ impl Stdio {
     // animation is playing the render thread is held off (it only writes while
     // holding the state lock): clear its line, print the message, then redraw a
     // fresh frame immediately so the live line stays just below the output.
-    fn emit(&self, stream: Stream, msg: &str) {
+    fn emit(&self, stream: Stream, msg: &str, style: Option<(&str, Color)>) {
         let inner = self.state.inner.lock().unwrap();
         let animation = inner.animation.clone();
         let mut stdout = stdout();
         if animation.is_some() {
             AnimationState::clear_line(&mut stdout);
         }
-        stream.print(msg);
+        stream.print(msg, style);
         if let Some(animation) = animation {
             AnimationState::draw_frame(&mut stdout, &animation);
         }
@@ -129,14 +169,22 @@ impl Console for Stdio {
         self.verbosity = verbosity;
     }
 
+    fn print(&mut self, msg: &str) {
+        self.emit(Stream::Stdout, msg, None);
+    }
+
     fn info(&mut self, msg: &str) {
         if !self.verbosity.is_quiet() {
-            self.emit(Stream::Stdout, msg);
+            self.emit(Stream::Stdout, msg, Some(("info:", Color::Blue)));
         }
     }
 
+    fn warn(&mut self, msg: &str) {
+        self.emit(Stream::Stderr, msg, Some(("warn:", Color::Yellow)));
+    }
+
     fn error(&mut self, msg: &str) {
-        self.emit(Stream::Stderr, msg);
+        self.emit(Stream::Stderr, msg, Some(("error:", Color::Red)));
     }
 
     fn get_geometry(&self) -> Option<(u32, u32)> {
@@ -185,5 +233,23 @@ impl Drop for Stdio {
         if let Some(thread) = self.thread.take() {
             thread.join().ok();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_colorize_wraps_label_when_enabled() {
+        let text = colorize("error:", Color::Red, true);
+        assert!(text.starts_with("\u{1b}["));
+        assert!(text.contains("error:"));
+        assert!(text.ends_with("\u{1b}[0m"));
+    }
+
+    #[test]
+    fn test_colorize_leaves_label_unchanged_when_disabled() {
+        assert_eq!(colorize("error:", Color::Red, false), "error:");
     }
 }

--- a/src/view/table_view.rs
+++ b/src/view/table_view.rs
@@ -58,7 +58,7 @@ impl TableView {
                 })
                 .collect::<Vec<_>>()
                 .join("   ");
-            console.info(line.trim_end());
+            console.print(line.trim_end());
             thread::sleep(Duration::from_millis(10));
         }
     }


### PR DESCRIPTION
Give the console real severity levels instead of a single info method. print keeps today's plain always-shown output, while the new info, warn and error methods print a bold blue, yellow or red label before the message, following the rustc and cargo convention. Color is skipped when NO_COLOR is set or the stream isn't a real terminal, and is enabled on Windows consoles at startup. Only info is suppressed under quiet mode, warn and error always show.