### PR TITLE
Docker Clean up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ ENV XDG_RUNTIME_DIR=/tmp/runtime
 RUN apt update && \
     apt install -y \
         qemu-utils \
-        genisoimage \
         qemu-system-x86 \
         qemu-system-arm \
         python3-sphinx \

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ DOCKER_CMD=docker run --rm -v .:/usr/local/app \
 	-v ${IMAGE_VOLUME}:/tmp/cache \
 	-v ${INSTANCE_VOLUME}:/tmp/data \
 	-v ${BUILD_VOLUME}:/usr/local/app/target \
-	-v ${CARGO_VOLUME}:/usr/local/cargo \
-	-p 4000:4000
+	-v ${CARGO_VOLUME}:/usr/local/cargo
 IMAGE=cubic:latest
 
 CMDS= run create instances images ports show modify console ssh scp start stop \
@@ -61,7 +60,7 @@ build: build-image
 
 doc: build-image
 	@${DOCKER_CMD} -it ${IMAGE} ./scripts/generate-page.sh v0.0.0-dev
-	@${DOCKER_CMD} -it ${IMAGE} python3 -m http.server -d target/page 4000
+	@${DOCKER_CMD} -p 4000:4000 -it ${IMAGE} python3 -m http.server -d target/page 4000
 
 suppress: build-image
 	@${DOCKER_CMD} -it ${IMAGE} /root/bin/vulnlog suppress vulnlog.yml -o .cargo/audit.toml


### PR DESCRIPTION
## Summary
- Remove the unused `genisoimage` package from the Docker build image, since cloud-init seeds are now built with a pure Rust writer (Fixes #467)
- Scope port 4000 publishing to the doc target only, since it is the sole target that serves anything on it