### PR TITLE
Verbose debug logging and SSH connection spinners

### DIFF
--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -6,6 +6,7 @@ use crate::instance::InstanceCertGenerator;
 use crate::models::{Instance, InstanceCertPaths};
 use crate::qemu::{QemuFirmware, QemuInstall, QemuPathBuilder, QemuSystem};
 use crate::ssh_cmd::PortChecker;
+use crate::view::Console;
 use std::path::PathBuf;
 
 pub struct StartInstanceAction {
@@ -23,7 +24,7 @@ impl StartInstanceAction {
         &mut self,
         context: &Context,
         qemu_args: &Option<String>,
-        verbose: bool,
+        console: &mut dyn Console,
     ) -> Result<()> {
         if context.get_instance_store().is_running(&self.instance) {
             return Ok(());
@@ -47,18 +48,43 @@ impl StartInstanceAction {
         let mut qemu_system = QemuSystem::from(self.instance.arch)?;
 
         let path_builder = QemuPathBuilder::new();
+        console.debug(&format!(
+            "Searching for QEMU in: {}",
+            path_builder
+                .get_dirs()
+                .iter()
+                .map(|dir| dir.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
         let install = QemuInstall::find(path_builder.get_dirs());
+        match &install {
+            Some(install) => console.debug(&format!(
+                "Found QEMU install at '{}'",
+                install.get_prefix().display()
+            )),
+            None => console.debug("No QEMU install found"),
+        }
 
         let firmware = QemuFirmware::locate(path_builder.get_dirs(), self.instance.arch)
             .ok_or(Error::QemuNotFound)?;
+        console.debug(&format!("Using firmware '{}'", firmware.display()));
         qemu_system.set_firmware(&firmware);
 
         if let Some(install) = &install {
-            if let Some(module_dir) = install.find_module_dir() {
-                qemu_system.set_module_dir(&module_dir);
+            match install.find_module_dir() {
+                Some(module_dir) => {
+                    console.debug(&format!("Using module dir '{}'", module_dir.display()));
+                    qemu_system.set_module_dir(&module_dir);
+                }
+                None => console.debug("No module dir found"),
             }
-            if let Some(datadir) = install.find_datadir() {
-                qemu_system.add_datadir(&datadir);
+            match install.find_datadir() {
+                Some(datadir) => {
+                    console.debug(&format!("Using data dir '{}'", datadir.display()));
+                    qemu_system.add_datadir(&datadir);
+                }
+                None => console.debug("No data dir found"),
             }
         }
 
@@ -75,11 +101,10 @@ impl StartInstanceAction {
         if let Some(args) = qemu_args {
             qemu_system.set_qemu_args(args);
         }
-        qemu_system.set_verbose(verbose);
         qemu_system.set_pid_file(&env.get_qemu_pid_file(&self.instance.name));
 
         qemu_system.set_monitor(self.instance.monitor_port.unwrap(), &instance_dir);
-        qemu_system.run()
+        qemu_system.run(console)
     }
 
     pub fn is_done(&self) -> bool {

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -112,6 +112,15 @@ impl Command for CreateCommand {
             ..Instance::default()
         };
 
+        console.debug(&format!(
+            "Resolved instance '{}': {} vCPUs, {} memory, {} disk, ssh_port={}",
+            instance.name,
+            instance.cpus,
+            instance.mem.to_size(),
+            instance.disk_capacity.to_size(),
+            instance.ssh_port,
+        ));
+
         let image_path = &env.get_image_file(&image.to_file_name());
         CreateInstanceAction::new().run(context, &FS::new(), image_path, instance)?;
 

--- a/src/commands/exec_command.rs
+++ b/src/commands/exec_command.rs
@@ -45,6 +45,10 @@ impl Command for ExecCommand {
             .unwrap_or(instance.user.to_string());
         let ssh_port = instance.ssh_port;
         let client_key = env.get_ssh_private_key_file(name.as_str());
+        console.debug(&format!(
+            "Executing on '{name}' as '{user}' on port {ssh_port} using key '{client_key}': {}",
+            self.cmd
+        ));
         let mut ssh = Russh::new();
         ssh.set_private_keys(env.get_home_ssh_private_key_paths(&FS::new()));
         ssh.set_cmd(Some(self.cmd.clone()));

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -9,7 +9,9 @@ pub fn fetch_image_list(console: &mut dyn Console, env: &Environment) -> Vec<Ima
     console.play(Arc::new(Mutex::new(Spinner::new(
         "Fetching image list".to_string(),
     ))));
-    let images: Vec<Image> = ImageFactory::new(env).get_all_images().unwrap_or_default();
+    let images: Vec<Image> = ImageFactory::new(env)
+        .get_all_images(console)
+        .unwrap_or_default();
     console.stop();
     images
 }
@@ -24,7 +26,7 @@ pub fn fetch_image_info(
         image.get_vendor(),
         image.get_name()
     )))));
-    let image = ImageFactory::new(env).find_image(image);
+    let image = ImageFactory::new(env).find_image(console, image);
     console.stop();
     image
 }

--- a/src/commands/scp_command.rs
+++ b/src/commands/scp_command.rs
@@ -66,6 +66,8 @@ impl Command for ScpCommand {
             .as_ref()
             .map(|instance| env.get_ssh_private_key_file(&instance.name));
 
+        console.debug(&format!("Copying '{}' to '{}'", self.from, self.to));
+
         let mut ssh = Russh::new();
         ssh.set_private_keys(env.get_home_ssh_private_key_paths(&FS::new()));
         ssh.copy(

--- a/src/commands/ssh_command.rs
+++ b/src/commands/ssh_command.rs
@@ -46,6 +46,9 @@ impl Command for SshCommand {
             .unwrap_or(instance.user.to_string());
         let ssh_port = instance.ssh_port;
         let client_key = env.get_ssh_private_key_file(name.as_str());
+        console.debug(&format!(
+            "Connecting to '{name}' as '{user}' on port {ssh_port} using key '{client_key}'"
+        ));
         let mut ssh = Russh::new();
         ssh.set_private_keys(env.get_home_ssh_private_key_paths(&FS::new()));
         ssh.set_env_vars(self.env_args.env_vars.clone());

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -50,7 +50,6 @@ impl Command for StartCommand {
 
         let instance_store = context.get_instance_store();
 
-        let verbosity = console.get_verbosity();
         let port_checker = PortChecker::new();
 
         // Launch virtual machine instances
@@ -59,14 +58,19 @@ impl Command for StartCommand {
             let instance = &mut instance_store.load(name.as_str())?;
             if !instance_store.is_running(instance) {
                 if port_checker.is_open(instance.ssh_port) {
+                    let old_port = instance.ssh_port;
                     instance.ssh_port = port_checker.get_new_port()?;
                     instance_store.store(instance)?;
+                    console.debug(&format!(
+                        "Instance '{}' ssh_port {} is taken, reassigned to {}",
+                        instance.name, old_port, instance.ssh_port
+                    ));
                 }
 
                 self.fit_to_available_memory(console, instance_store, instance)?;
 
                 let mut action = StartInstanceAction::new(instance);
-                action.run(context, &self.qemu_args, verbosity.is_verbose())?;
+                action.run(context, &self.qemu_args, console)?;
 
                 actions.push(action);
             }
@@ -109,6 +113,14 @@ impl StartCommand {
         let mut system = System::new();
         system.refresh_memory();
         let available = system.available_memory() as usize;
+
+        console.debug(&format!(
+            "Instance '{}' requests {}, host has {} available with {} reserved",
+            instance.name,
+            instance.mem.to_size(),
+            DataSize::new(available).to_size(),
+            DataSize::new(HOST_MEMORY_RESERVE).to_size(),
+        ));
 
         if available.saturating_sub(HOST_MEMORY_RESERVE) >= instance.mem.get_bytes() {
             return Ok(());

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -2,6 +2,7 @@ use crate::error::{Error, Result};
 use crate::image::{self, ImageCache};
 use crate::models::{Arch, Environment, Image, ImageName};
 use crate::util;
+use crate::view::Console;
 use crate::web::WebClient;
 
 const IMAGE_PROVIDERS: &[&dyn image::ImageProvider] = &[
@@ -35,6 +36,7 @@ impl ImageFactory {
     }
 
     fn get_images_from_provider_name_arch(
+        console: &mut dyn Console,
         web: &mut WebClient,
         image_provider: &dyn image::ImageProvider,
         name: &str,
@@ -46,6 +48,9 @@ impl ImageFactory {
             image_provider.get_base_url(),
             &image_provider.get_image_dir_path(name, arch)
         );
+        console.debug(&format!(
+            "Fetching image directory listing '{image_dir_url}'"
+        ));
         let image_content = web.download_content(&image_dir_url).unwrap();
 
         let image_file = util::find_and_extract(
@@ -90,6 +95,7 @@ impl ImageFactory {
     }
 
     fn get_images_from_provider(
+        console: &mut dyn Console,
         web: &mut WebClient,
         image_provider: &dyn image::ImageProvider,
         filter: Option<ImageName>,
@@ -104,6 +110,7 @@ impl ImageFactory {
                             .into_iter()
                             .flat_map(|arch| {
                                 Self::get_images_from_provider_name_arch(
+                                    console,
                                     web,
                                     image_provider,
                                     &name,
@@ -118,17 +125,27 @@ impl ImageFactory {
             .unwrap_or_default()
     }
 
-    fn get_images(web: &mut WebClient, filter: Option<ImageName>) -> Vec<Image> {
+    fn get_images(
+        console: &mut dyn Console,
+        web: &mut WebClient,
+        filter: Option<ImageName>,
+    ) -> Vec<Image> {
         let mut images = IMAGE_PROVIDERS
             .iter()
             .filter(|p| filter.is_none() || filter.as_ref().unwrap().get_vendor() == p.get_vendor())
-            .flat_map(|provider| Self::get_images_from_provider(web, *provider, filter.clone()))
+            .flat_map(|provider| {
+                Self::get_images_from_provider(console, web, *provider, filter.clone())
+            })
             .collect::<Vec<_>>();
         images.sort();
         images
     }
 
-    fn read_images(&self, filter: Option<ImageName>) -> Result<Vec<Image>> {
+    fn read_images(
+        &self,
+        console: &mut dyn Console,
+        filter: Option<ImageName>,
+    ) -> Result<Vec<Image>> {
         // Read cache
         let cache = ImageCache::read_from_file(&self.env.get_image_cache_file());
 
@@ -136,6 +153,7 @@ impl ImageFactory {
         if let Some(cache) = &cache
             && cache.is_valid()
         {
+            console.debug("Using cached image list");
             if let Some(name) = filter {
                 if let Some(image) = cache.images.iter().find(|image| {
                     (image.vendor == name.get_vendor())
@@ -152,13 +170,15 @@ impl ImageFactory {
         }
 
         // Fetch image info
-        let images = Self::get_images(&mut WebClient::new()?, filter.clone());
+        console.debug("Image cache missing or stale, fetching image list from providers");
+        let images = Self::get_images(console, &mut WebClient::new()?, filter.clone());
 
         // Return cache if fetching failed
         Ok(
             if images.is_empty()
                 && let Some(cache) = &cache
             {
+                console.debug("Fetching image list failed, falling back to stale cache");
                 cache.images.clone()
             } else {
                 // Write cache
@@ -170,16 +190,17 @@ impl ImageFactory {
         )
     }
 
-    pub fn get_all_images(&self) -> Result<Vec<Image>> {
-        self.read_images(None)
+    pub fn get_all_images(&self, console: &mut dyn Console) -> Result<Vec<Image>> {
+        self.read_images(console, None)
     }
 
-    pub fn find_image(&self, name: &ImageName) -> Result<Image> {
-        self.read_images(Some(name.clone())).and_then(|images| {
-            images
-                .into_iter()
-                .next()
-                .ok_or(Error::UnknownImage(name.to_string()))
-        })
+    pub fn find_image(&self, console: &mut dyn Console, name: &ImageName) -> Result<Image> {
+        self.read_images(console, Some(name.clone()))
+            .and_then(|images| {
+                images
+                    .into_iter()
+                    .next()
+                    .ok_or(Error::UnknownImage(name.to_string()))
+            })
     }
 }

--- a/src/qemu/qemu_firmware.rs
+++ b/src/qemu/qemu_firmware.rs
@@ -35,6 +35,10 @@ impl QemuInstall {
         Some(Self { prefix })
     }
 
+    pub fn get_prefix(&self) -> &Path {
+        &self.prefix
+    }
+
     pub fn find_module_dir(&self) -> Option<PathBuf> {
         self.build_module_dir_candidates()
             .into_iter()

--- a/src/qemu/qemu_system.rs
+++ b/src/qemu/qemu_system.rs
@@ -4,10 +4,10 @@ use crate::error::{Error, Result};
 use crate::models::{Arch, PortForward};
 use crate::qemu::QemuPathBuilder;
 use crate::util::SystemCommand;
+use crate::view::Console;
 
 pub struct QemuSystem {
     command: SystemCommand,
-    verbose: bool,
 }
 
 impl QemuSystem {
@@ -79,14 +79,7 @@ impl QemuSystem {
         #[cfg(feature = "qemu-sandbox")]
         command.arg("-sandbox").arg("on");
 
-        Ok(QemuSystem {
-            command,
-            verbose: false,
-        })
-    }
-
-    pub fn set_verbose(&mut self, flag: bool) {
-        self.verbose = flag;
+        Ok(QemuSystem { command })
     }
 
     pub fn set_cpus(&mut self, cpus: u16) {
@@ -182,10 +175,8 @@ impl QemuSystem {
         }
     }
 
-    pub fn run(&mut self) -> Result<()> {
-        if self.verbose {
-            println!("{}", self.command.get_command());
-        }
+    pub fn run(&mut self, console: &mut dyn Console) -> Result<()> {
+        console.debug(&self.command.get_command());
 
         self.command.run_daemonized().map_err(Self::map_error)
     }

--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -307,14 +307,17 @@ impl Russh {
             }
         }
 
-        console.stop();
         console.debug(&format!("Connected to 127.0.0.1:{port}"));
+        console.play(Arc::new(std::sync::Mutex::new(Spinner::new(format!(
+            "Authenticating on {machine}"
+        )))));
 
-        if self
+        let auth_method = self
             .authenticate(console, &mut session, user, client_key)
-            .await?
-            == AuthMethod::Deprecated
-        {
+            .await;
+        console.stop();
+
+        if auth_method? == AuthMethod::Deprecated {
             self.warn_deprecated_auth(console, machine, client_key).ok();
         }
 
@@ -333,6 +336,10 @@ impl Russh {
             .open_channel(console, machine, client_key, user, port)
             .await?;
         let (w, h) = console.get_geometry().unwrap();
+
+        console.play(Arc::new(std::sync::Mutex::new(Spinner::new(format!(
+            "Opening shell on {machine}"
+        )))));
         channel
             .request_pty(
                 false,
@@ -366,6 +373,7 @@ impl Russh {
 
         let ssh_out = Arc::new(Mutex::new(ssh_out));
 
+        console.stop();
         console.raw_mode();
         tokio::select!(
             _ = ssh_geometry(console, ssh_out.clone()) => { console.reset(); std::process::exit(0); },

--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -209,28 +209,40 @@ impl Russh {
     ) -> Result<AuthMethod, ()> {
         // The cubic per-instance ssh_client_key is the only supported method.
         // Everything below is a deprecated fallback.
+        console.debug(&format!(
+            "Authenticating '{user}' with client key '{client_key}'"
+        ));
         if self
             .authenticate_with_keys(session, user, &[client_key.to_string()])
             .await
         {
+            console.debug("Authenticated with client key");
             return Ok(AuthMethod::ClientKey);
         }
 
+        console.debug(&format!(
+            "Client key failed, trying {} deprecated key(s)",
+            self.private_keys.len()
+        ));
         if self
             .authenticate_with_keys(session, user, &self.private_keys)
             .await
         {
+            console.debug("Authenticated with a deprecated private key");
             return Ok(AuthMethod::Deprecated);
         }
 
+        console.debug("Deprecated keys failed, trying the default password");
         if self
             .authenticate_with_default_password(session, user)
             .await
             .is_ok()
         {
+            console.debug("Authenticated with the default password");
             return Ok(AuthMethod::Deprecated);
         }
 
+        console.debug("Default password failed, prompting for a password");
         self.authenticate_with_password(console, session, user)
             .await
             .map(|_| AuthMethod::Deprecated)
@@ -279,6 +291,8 @@ impl Russh {
         console.play(Arc::new(std::sync::Mutex::new(Spinner::new(format!(
             "Connecting to {machine}"
         )))));
+        console.debug(&format!("Connecting to 127.0.0.1:{port}"));
+        let mut failed = false;
         loop {
             let sh = Client {};
             let addrs = ("127.0.0.1", port);
@@ -287,9 +301,14 @@ impl Russh {
                 session = s;
                 break;
             }
+            if !failed {
+                failed = true;
+                console.debug(&format!("Connection to 127.0.0.1:{port} failed, retrying"));
+            }
         }
 
         console.stop();
+        console.debug(&format!("Connected to 127.0.0.1:{port}"));
 
         if self
             .authenticate(console, &mut session, user, client_key)

--- a/src/view/console.rs
+++ b/src/view/console.rs
@@ -3,9 +3,9 @@ use crate::view::Animation;
 use std::sync::{Arc, Mutex};
 
 pub trait Console {
-    fn get_verbosity(&mut self) -> Verbosity;
     fn set_verbosity(&mut self, verbosity: Verbosity);
     fn print(&mut self, msg: &str);
+    fn debug(&mut self, msg: &str);
     fn info(&mut self, msg: &str);
     fn warn(&mut self, msg: &str);
     fn error(&mut self, msg: &str);

--- a/src/view/console_mock.rs
+++ b/src/view/console_mock.rs
@@ -26,12 +26,13 @@ pub mod tests {
 
     impl Console for ConsoleMock {
         fn set_verbosity(&mut self, _verbosity: Verbosity) {}
-        fn get_verbosity(&mut self) -> Verbosity {
-            Verbosity::Normal
-        }
 
         fn print(&mut self, msg: &str) {
             self.log(msg)
+        }
+
+        fn debug(&mut self, msg: &str) {
+            self.log(&format!("debug: {msg}"))
         }
 
         fn info(&mut self, msg: &str) {

--- a/src/view/stdio.rs
+++ b/src/view/stdio.rs
@@ -161,16 +161,18 @@ impl AnimationState {
 }
 
 impl Console for Stdio {
-    fn get_verbosity(&mut self) -> Verbosity {
-        self.verbosity
-    }
-
     fn set_verbosity(&mut self, verbosity: Verbosity) {
         self.verbosity = verbosity;
     }
 
     fn print(&mut self, msg: &str) {
         self.emit(Stream::Stdout, msg, None);
+    }
+
+    fn debug(&mut self, msg: &str) {
+        if self.verbosity.is_verbose() {
+            self.emit(Stream::Stdout, msg, Some(("debug:", Color::Green)));
+        }
     }
 
     fn info(&mut self, msg: &str) {


### PR DESCRIPTION
## Summary

Add `--verbose` diagnostics to help users troubleshoot stuck or failing commands, and show progress during SSH connections.

- Add `console.debug()`, a green, `--verbose`-gated output level on the `Console` trait
- Wire debug output into resolved instance settings, SSH port and memory-fit decisions, the SSH auth fallback chain, QEMU firmware discovery, and image list fetching
- Move the QEMU command line print (previously its own verbose flag) onto the same `console.debug()` path
- Remove `Console::get_verbosity()`, left unused by this change
- Add spinners for the connecting, authenticating, and shell setup phases of an SSH session
- Stop the authenticating spinner immediately when `authenticate()` returns, keeping it cleared after a failed login