### PR TITLE
Document Windows winget Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ sudo snap connect cubic:kvm
 brew install cubic-vm/cubic/cubic
 ```
 
+**Windows** (winget)
+```
+winget install cubic-vm.cubic
+```
+
 **Others** (Cargo)
 
 Install the [Rust toolchain](https://rustup.rs) and then build Cubic:

--- a/docs/howto/install.rst
+++ b/docs/howto/install.rst
@@ -23,11 +23,51 @@ You can install Cubic on macOS with the following methods:
 Install on Windows
 ------------------
 
-You can install Cubic on Windows with the following methods:
+You can install Cubic on Windows with the following method:
 
-* `Install with Snap`_ (in WSL; **recommended**)
+* `Install with Winget`_  (**recommended**)
 * `Install with Cargo`_
-* `Install with Homebrew`_ (in WSL)
+
+Install with Snap
+-----------------
+
+Use the following command to install Cubic with `Snap`_:
+
+.. code-block::
+
+       $ sudo snap install cubic
+
+Connect the KVM interface to accelerate the virtual machine (recommended):
+
+.. code-block::
+
+       $ sudo snap connect cubic:kvm
+
+.. _Snap: https://snapcraft.io/cubic
+
+Install with Homebrew
+---------------------
+
+Use the following command to install Cubic via `Homebrew`_:
+
+.. code-block::
+
+       $ brew install cubic-vm/cubic/cubic
+
+.. _Homebrew: https://github.com/cubic-vm/homebrew-cubic
+
+Install with Winget
+-------------------
+
+Use the following command to install Cubic via `Winget`_:
+
+.. code-block::
+
+       $ winget install cubic-vm.cubic
+
+QEMU is installed automatically as a dependency.
+
+.. _Winget: https://learn.microsoft.com/windows/package-manager/winget/
 
 Install with Cargo
 ------------------
@@ -123,33 +163,3 @@ Check if Cubic is installed correctly:
 .. code-block::
 
     cubic --help
-
-Install with Homebrew
----------------------
-
-Use the following command to install Cubic via `Homebrew`_:
-
-.. code-block::
-
-       $ brew install cubic-vm/cubic/cubic
-
-.. _Homebrew: https://github.com/cubic-vm/homebrew-cubic
-
-
-
-Install with Snap
------------------
-
-Use the following command to install Cubic with `Snap`_:
-
-.. code-block::
-
-       $ sudo snap install cubic
-
-Connect the KVM interface to accelerate the virtual machine (recommended):
-
-.. code-block::
-
-       $ sudo snap connect cubic:kvm
-
-.. _Snap: https://snapcraft.io/cubic

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,7 +103,7 @@
     /* Install */
     .install-grid {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(4, 1fr);
       gap: 16px;
     }
     .install-block h3 {
@@ -222,6 +222,13 @@ sudo snap connect cubic:kvm</code></pre>
         <h3>macOS (Homebrew)</h3>
         <div class="cmd">
           <pre><code>brew install cubic-vm/cubic/cubic</code></pre>
+          <button class="copy" type="button" aria-label="Copy command">Copy</button>
+        </div>
+      </div>
+      <div class="install-block">
+        <h3>Windows (winget)</h3>
+        <div class="cmd">
+          <pre><code>winget install cubic-vm.cubic</code></pre>
           <button class="copy" type="button" aria-label="Copy command">Copy</button>
         </div>
       </div>


### PR DESCRIPTION
Cubic is now installable on Windows via winget, which pulls in QEMU automatically as a dependency. Document it in the README, the project website install grid, and the install how-to guide, placed between Homebrew and Cargo to match the recommended path.