### PR TITLE
fix: enable ANSI virtual terminal processing on Windows

### DIFF
--- a/src/view/stdio.rs
+++ b/src/view/stdio.rs
@@ -7,6 +7,9 @@ pub struct Stdio {
 
 impl Stdio {
     pub fn new() -> Self {
+        #[cfg(windows)]
+        crossterm::ansi_support::supports_ansi();
+
         Self {
             verbosity: Verbosity::new(false, false),
         }


### PR DESCRIPTION
Windows printed raw escape codes instead of colors and cursor movement from the guest SSH shell. The console never had ANSI virtual terminal processing turned on for its output.

This change turns on ANSI support on Windows when the console starts up. Other platforms are unaffected.