### PR TITLE
chore: lock cargo commands in pull request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         include:
           - check: rustup component add rustfmt && cargo fmt --check
-          - check: rustup component add clippy && cargo clippy --version && cargo clippy -- -D warnings
-          - check: cargo test
+          - check: rustup component add clippy && cargo clippy --version && cargo clippy --locked -- -D warnings
+          - check: cargo test --locked
           - check: cargo install cargo-audit && cargo audit
 
     runs-on: ubuntu-latest
@@ -78,7 +78,7 @@ jobs:
           rustup override set 1.92.0
 
       - name: Build Source Code
-        run: cargo build
+        run: cargo build --locked
 
       - name: Run Source Code
-        run: cargo run -- --help
+        run: cargo run --locked -- --help


### PR DESCRIPTION
Run clippy, test, build and run with --locked so a stale or dirty Cargo.lock fails on the pull request instead of only surfacing at release time.

Fixes #465