### PR TITLE
fix: make cubic report failure to the shell

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,15 @@ mod web;
 use crate::commands::CommandDispatcher;
 use crate::view::Console;
 use clap::Parser;
+use std::process::ExitCode;
 
-fn main() {
+fn main() -> ExitCode {
     let console = &mut view::Stdio::new();
-    CommandDispatcher::parse()
-        .dispatch(console)
-        .map_err(|e| console.error(&e.to_string()))
-        .ok();
+    match CommandDispatcher::parse().dispatch(console) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            console.error(&e.to_string());
+            ExitCode::FAILURE
+        }
+    }
 }


### PR DESCRIPTION
Cubic always exited with a success status, even when a command failed. Callers had no reliable way to detect failures, which is a problem for scripts and CI pipelines that check the exit code.

Cubic now exits with a non zero status whenever a command fails.

Fixes #441