### PR TITLE
Small Clean ups

### DIFF
--- a/src/commands/exec_command.rs
+++ b/src/commands/exec_command.rs
@@ -42,7 +42,7 @@ impl Command for ExecCommand {
             .target
             .get_user()
             .map(|user| user.to_string())
-            .unwrap_or(instance.user.to_string());
+            .unwrap_or_else(|| instance.user.to_string());
         let ssh_port = instance.ssh_port;
         let client_key = env.get_ssh_private_key_file(name.as_str());
         console.debug(&format!(

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -48,11 +48,7 @@ impl Command for ListInstanceCommand {
                 .add(&instance.cpus.to_string(), Alignment::Right)
                 .add(&instance.mem.to_size(), Alignment::Right)
                 .add(
-                    &instance
-                        .disk_used
-                        .as_ref()
-                        .map(|size| size.to_size())
-                        .unwrap_or("n/a".to_string()),
+                    &util::format_or_na(instance.disk_used.as_ref().map(|size| size.to_size())),
                     Alignment::Right,
                 )
                 .add(&instance.disk_capacity.to_size(), Alignment::Right)

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -21,10 +21,11 @@ impl Command for ShowImageCommand {
         let env = context.get_env();
         let image = fetch_image_info(console, env, &self.name)?;
 
-        let size = image
-            .size
-            .map(|size| DataSize::new(size as usize).to_size())
-            .unwrap_or("n/a".to_string());
+        let size = util::format_or_na(
+            image
+                .size
+                .map(|size| DataSize::new(size as usize).to_size()),
+        );
 
         let mut view = MapView::new();
         view.add("Name", &image.get_image_names());

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -34,7 +34,7 @@ impl Command for ShowInstanceCommand {
         );
         view.add(
             "PID",
-            &util::format_or_na(instance_store.get_pid(&instance).ok()),
+            &util::format_or_na(instance_store.get_pid(&instance)),
         );
         view.add("Arch", &instance.arch.to_string());
         view.add("CPUs", &instance.cpus.to_string());

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -34,39 +34,21 @@ impl Command for ShowInstanceCommand {
         );
         view.add(
             "PID",
-            &instance_store
-                .get_pid(&instance)
-                .map(|pid| pid.to_string())
-                .unwrap_or("n/a".to_string()),
+            &util::format_or_na(instance_store.get_pid(&instance).ok()),
         );
         view.add("Arch", &instance.arch.to_string());
         view.add("CPUs", &instance.cpus.to_string());
         view.add("Memory", &instance.mem.to_size());
         view.add(
             "Disk Used",
-            &instance
-                .disk_used
-                .map(|size| size.to_size())
-                .unwrap_or("n/a".to_string()),
+            &util::format_or_na(instance.disk_used.map(|size| size.to_size())),
         );
         view.add("Disk Total", &instance.disk_capacity.to_size());
         view.add("User", &instance.user);
         view.add("Isolated", util::to_yes_no(instance.isolate));
         view.add("SSH Port", &instance.ssh_port.to_string());
-        view.add(
-            "Monitor Port",
-            &instance
-                .monitor_port
-                .map(|port| port.to_string())
-                .unwrap_or("n/a".to_string()),
-        );
-        view.add(
-            "Console Port",
-            &instance
-                .console_port
-                .map(|port| port.to_string())
-                .unwrap_or("n/a".to_string()),
-        );
+        view.add("Monitor Port", &util::format_or_na(instance.monitor_port));
+        view.add("Console Port", &util::format_or_na(instance.console_port));
 
         // Port forwarding
         for (index, rule) in instance.hostfwd.iter().enumerate() {

--- a/src/commands/ssh_command.rs
+++ b/src/commands/ssh_command.rs
@@ -43,7 +43,7 @@ impl Command for SshCommand {
             .target
             .get_user()
             .map(|user| user.to_string())
-            .unwrap_or(instance.user.to_string());
+            .unwrap_or_else(|| instance.user.to_string());
         let ssh_port = instance.ssh_port;
         let client_key = env.get_ssh_private_key_file(name.as_str());
         console.debug(&format!(

--- a/src/env/environment_factory.rs
+++ b/src/env/environment_factory.rs
@@ -25,7 +25,8 @@ impl EnvironmentFactory {
     }
 
     pub fn get_username() -> String {
-        let username = Self::read_current_username().unwrap_or(DEFAULT_USERNAME.to_string());
+        let username =
+            Self::read_current_username().unwrap_or_else(|| DEFAULT_USERNAME.to_string());
         if username == ROOT_USERNAME {
             DEFAULT_USERNAME.to_string()
         } else {
@@ -36,7 +37,7 @@ impl EnvironmentFactory {
     #[cfg(target_os = "linux")]
     pub fn create_env() -> Result<Environment> {
         let data_dir = Self::read_env("SNAP_USER_COMMON")
-            .or(Self::read_env("XDG_DATA_HOME"))
+            .or_else(|_| Self::read_env("XDG_DATA_HOME"))
             .or_else(|_| Self::read_env("HOME").map(|home| format!("{home}/.local/share")))?;
         let cache_dir = Self::read_env("XDG_CACHE_HOME")
             .or_else(|_| Self::read_env("HOME").map(|home| format!("{home}/.cache")))?;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub struct FS;
 
@@ -10,12 +10,8 @@ impl FS {
     }
 
     pub fn create_dir(&self, path: &str) -> Result<()> {
-        if !Path::new(path).exists() {
-            return fs::create_dir_all(path)
-                .map_err(|e| Error::FS(format!("Cannot create directory '{path}' ({e})")));
-        }
-
-        Ok(())
+        fs::create_dir_all(path)
+            .map_err(|e| Error::FS(format!("Cannot create directory '{path}' ({e})")))
     }
 
     pub fn read_dir(&self, path: &str) -> Result<fs::ReadDir> {

--- a/src/image/image_cache.rs
+++ b/src/image/image_cache.rs
@@ -16,7 +16,7 @@ pub struct ImageCache {
 impl ImageCache {
     pub fn new(images: Vec<Image>) -> Self {
         ImageCache {
-            images: images.to_vec(),
+            images,
             timestamp: Self::get_timestamp(),
         }
     }

--- a/src/image/image_cache.rs
+++ b/src/image/image_cache.rs
@@ -39,10 +39,8 @@ impl ImageCache {
 
     fn deserialize(reader: &mut dyn Read) -> Option<ImageCache> {
         let mut data = String::new();
-        match reader.read_to_string(&mut data).is_ok() {
-            true => toml::from_str(&data).ok(),
-            false => None,
-        }
+        reader.read_to_string(&mut data).ok()?;
+        toml::from_str(&data).ok()
     }
 
     fn serialize(&self, writer: &mut dyn Write) -> Result<()> {

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -209,7 +209,7 @@ impl ImageFactory {
                 images
                     .into_iter()
                     .next()
-                    .ok_or(Error::UnknownImage(name.to_string()))
+                    .ok_or_else(|| Error::UnknownImage(name.to_string()))
             })
     }
 }

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -8,7 +8,6 @@ use crate::models::{DataSize, Environment, Instance, InstanceName};
 use crate::qemu::Monitor;
 use crate::qemu::QemuImg;
 use crate::ssh_cmd::PortChecker;
-use std::fs::DirEntry;
 use std::path::Path;
 use std::str;
 use std::str::FromStr;
@@ -63,21 +62,17 @@ impl InstanceStore for InstanceDao {
         let mut instances: Vec<String> = self
             .fs
             .read_dir(&self.env.get_instance_dir())
-            .map_err(|_| ())
-            .and_then(|entries| {
-                entries
-                    .collect::<std::result::Result<Vec<DirEntry>, _>>()
-                    .map_err(|_| ())
-            })
+            .ok()
+            .and_then(|entries| entries.collect::<std::io::Result<Vec<_>>>().ok())
             .map(|entries| {
                 entries
                     .iter()
-                    .filter_map(|entry| entry.file_name().to_str().map(|x| x.to_string()))
-                    .filter(|entry| InstanceName::from_str(entry).is_ok())
-                    .collect::<Vec<String>>()
+                    .filter_map(|entry| entry.file_name().into_string().ok())
+                    .filter(|name| InstanceName::from_str(name).is_ok())
+                    .collect()
             })
             .unwrap_or_default();
-        instances.sort_by_key(|a| a.to_lowercase());
+        instances.sort_by_key(|name| name.to_lowercase());
         instances
     }
 

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -197,14 +197,14 @@ impl InstanceStore for InstanceDao {
         self.read_running_pid(instance).is_some()
     }
 
-    fn get_pid(&self, instance: &Instance) -> std::result::Result<u64, ()> {
-        self.read_running_pid(instance).ok_or(())
+    fn get_pid(&self, instance: &Instance) -> Option<u64> {
+        self.read_running_pid(instance)
     }
 
     fn kill(&self, instance: &Instance) -> Result<()> {
         let pid = self
             .get_pid(instance)
-            .map_err(|_| Error::InstanceNotRunning(instance.name.clone()))?;
+            .ok_or_else(|| Error::InstanceNotRunning(instance.name.clone()))?;
 
         let sys_pid = sysinfo::Pid::from_u32(pid as u32);
         let mut system = sysinfo::System::new();

--- a/src/instance/instance_store.rs
+++ b/src/instance/instance_store.rs
@@ -14,7 +14,7 @@ pub trait InstanceStore {
     fn delete(&self, instance: &Instance) -> Result<()>;
 
     fn is_running(&self, instance: &Instance) -> bool;
-    fn get_pid(&self, instance: &Instance) -> std::result::Result<u64, ()>;
+    fn get_pid(&self, instance: &Instance) -> Option<u64>;
     fn kill(&self, instance: &Instance) -> Result<()>;
 
     fn get_monitor(&self, instance: &Instance) -> Result<Monitor>;

--- a/src/instance/instance_store_mock.rs
+++ b/src/instance/instance_store_mock.rs
@@ -53,8 +53,8 @@ pub mod tests {
             false
         }
 
-        fn get_pid(&self, _instance: &Instance) -> std::result::Result<u64, ()> {
-            std::result::Result::Err(())
+        fn get_pid(&self, _instance: &Instance) -> Option<u64> {
+            None
         }
 
         fn kill(&self, _instance: &Instance) -> Result<()> {

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -15,15 +15,13 @@ impl TomlInstanceDeserializer {
 impl InstanceDeserializer for TomlInstanceDeserializer {
     fn deserialize(&self, name: &str, reader: &mut dyn Read) -> Option<Instance> {
         let mut data = String::new();
-        match reader.read_to_string(&mut data).is_ok() {
-            true => toml::from_str(&data)
-                .map(|mut instance: Instance| {
-                    instance.name = name.to_string();
-                    instance
-                })
-                .ok(),
-            false => None,
-        }
+        reader.read_to_string(&mut data).ok()?;
+        toml::from_str(&data)
+            .map(|mut instance: Instance| {
+                instance.name = name.to_string();
+                instance
+            })
+            .ok()
     }
 }
 

--- a/src/models/arch.rs
+++ b/src/models/arch.rs
@@ -1,6 +1,7 @@
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::str::FromStr;
 
 #[derive(Eq, Hash, PartialEq, Default, Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum Arch {
@@ -10,14 +11,6 @@ pub enum Arch {
 }
 
 impl Arch {
-    pub fn from_str(arch: &str) -> Result<Arch> {
-        match arch {
-            "amd64" => Ok(Arch::AMD64),
-            "arm64" => Ok(Arch::ARM64),
-            _ => Err(Error::UnknownArch(arch.to_string())),
-        }
-    }
-
     pub fn as_vendor_str(&self) -> &str {
         match &self {
             Arch::AMD64 => "amd64",
@@ -29,6 +22,18 @@ impl Arch {
         match &self {
             Arch::AMD64 => "x86_64",
             Arch::ARM64 => "aarch64",
+        }
+    }
+}
+
+impl FromStr for Arch {
+    type Err = Error;
+
+    fn from_str(arch: &str) -> Result<Arch> {
+        match arch {
+            "amd64" => Ok(Arch::AMD64),
+            "arm64" => Ok(Arch::ARM64),
+            _ => Err(Error::UnknownArch(arch.to_string())),
         }
     }
 }

--- a/src/models/arch.rs
+++ b/src/models/arch.rs
@@ -12,14 +12,14 @@ pub enum Arch {
 
 impl Arch {
     pub fn as_vendor_str(&self) -> &str {
-        match &self {
+        match self {
             Arch::AMD64 => "amd64",
             Arch::ARM64 => "arm64",
         }
     }
 
     pub fn as_canonical_str(&self) -> &str {
-        match &self {
+        match self {
             Arch::AMD64 => "x86_64",
             Arch::ARM64 => "aarch64",
         }

--- a/src/models/port_forward.rs
+++ b/src/models/port_forward.rs
@@ -89,7 +89,7 @@ impl PortForward {
             if let Some(ip) = host_ip {
                 ip.parse::<IpAddr>().map_err(|_| ())?
             } else {
-                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
+                IpAddr::V4(Ipv4Addr::LOCALHOST)
             },
             host_port.parse::<u16>().map_err(|_| ())?,
             guest_port.parse::<u16>().map_err(|_| ())?,

--- a/src/models/port_forward.rs
+++ b/src/models/port_forward.rs
@@ -104,7 +104,7 @@ impl PortForward {
     pub fn from_qemu(value: &str) -> Result<Self, String> {
         let caps: Vec<_> = QEMU_PORT_REGEX
             .captures(value)
-            .ok_or(QEMU_FORMAT_ERROR.to_string())?
+            .ok_or_else(|| QEMU_FORMAT_ERROR.to_string())?
             .iter()
             .collect();
 
@@ -145,7 +145,7 @@ impl FromStr for PortForward {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let caps: Vec<_> = PORT_REGEX
             .captures(value)
-            .ok_or(FORMAT_ERROR.to_string())?
+            .ok_or_else(|| FORMAT_ERROR.to_string())?
             .iter()
             .collect();
 

--- a/src/models/port_forward.rs
+++ b/src/models/port_forward.rs
@@ -14,7 +14,7 @@ static PORT_REGEX: LazyLock<Regex> =
 const FORMAT_ERROR: &str = "Must comply with format: [host_ip:]host_port:guest_port[/(udp|tcp)] (e.g. -p 8000:80 or -p 127.0.0.1:9000:90/tcp)";
 const QEMU_FORMAT_ERROR: &str = "Must comply with format: [tcp|udp]:[hostaddr]:hostport-[guestaddr]:guestport (e.g. ::8000-:80 or -p tcp:127.0.0.1:9000-:90)";
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Protocol {
     Udp,
     Tcp,
@@ -45,7 +45,7 @@ impl Display for Protocol {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PortForward {
     host_ip: IpAddr,
     host_port: u16,
@@ -76,7 +76,7 @@ impl PortForward {
     }
 
     pub fn get_protocol(&self) -> Protocol {
-        self.protocol.clone()
+        self.protocol
     }
 
     fn from_value(

--- a/src/models/target.rs
+++ b/src/models/target.rs
@@ -46,12 +46,10 @@ impl FromStr for Target {
 
 impl fmt::Display for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        let mut result = Ok(());
-
         if let Some(user) = self.user.as_ref() {
-            result = write!(f, "{user}@")
+            write!(f, "{user}@")?;
         }
-        result.or(write!(f, "{}", self.instance))
+        write!(f, "{}", self.instance)
     }
 }
 

--- a/src/models/target_instance_path.rs
+++ b/src/models/target_instance_path.rs
@@ -1,9 +1,5 @@
 use crate::models::Instance;
-use regex::Regex;
-use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
-
-static HOME_DIR_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new("^~").unwrap());
+use std::path::PathBuf;
 
 #[derive(Clone)]
 pub struct TargetInstancePath {
@@ -14,19 +10,15 @@ pub struct TargetInstancePath {
 
 impl TargetInstancePath {
     pub fn to_pathbuf(&self) -> PathBuf {
-        let path = if let Some(user) = self
+        let user = self
             .user
-            .clone()
-            .or(self.instance.as_ref().map(|i| i.user.clone()))
-        {
-            HOME_DIR_REGEX
-                .replace_all(&self.path, &format!("/home/{user}"))
-                .to_string()
-        } else {
-            self.path.to_string()
-        };
+            .as_deref()
+            .or(self.instance.as_ref().map(|i| i.user.as_str()));
 
-        Path::new(&path).to_path_buf()
+        match (user, self.path.strip_prefix('~')) {
+            (Some(user), Some(rest)) => PathBuf::from(format!("/home/{user}{rest}")),
+            _ => PathBuf::from(&self.path),
+        }
     }
 }
 

--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -343,7 +343,7 @@ impl Russh {
         channel
             .request_pty(
                 false,
-                &env::var("TERM").unwrap_or("xterm".into()),
+                &env::var("TERM").unwrap_or_else(|_| "xterm".into()),
                 w,
                 h,
                 0,

--- a/src/ssh_cmd/sftp_path.rs
+++ b/src/ssh_cmd/sftp_path.rs
@@ -52,7 +52,7 @@ impl SftpPath {
                     metadata
                         .size
                         .map(|size| size as usize)
-                        .ok_or(Error::InvalidPath(self.to_str().to_string()))
+                        .ok_or_else(|| Error::InvalidPath(self.to_str().to_string()))
                 }),
         }
     }

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -13,6 +13,10 @@ pub fn to_yes_no(condition: bool) -> &'static str {
     if condition { "yes" } else { "no" }
 }
 
+pub fn format_or_na<T: ToString>(value: Option<T>) -> String {
+    value.map_or_else(|| "n/a".to_string(), |value| value.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -32,5 +36,12 @@ mod tests {
     fn test_to_yes_no() {
         assert_eq!(to_yes_no(true), "yes");
         assert_eq!(to_yes_no(false), "no");
+    }
+
+    #[test]
+    fn test_format_or_na() {
+        assert_eq!(format_or_na(Some(8001)), "8001");
+        assert_eq!(format_or_na(Some("1.0 GiB".to_string())), "1.0 GiB");
+        assert_eq!(format_or_na(None::<u16>), "n/a");
     }
 }


### PR DESCRIPTION
### Summary

This PR is a pure idiom cleanup pass across the codebase, no intended behavior change, split into thirteen focused commits so each intent lands on its own and can be reviewed or bisected independently.

Covers: `Protocol`/`Arch` gaining `Copy` and `Eq`, `Target` display and tilde expansion rewritten without regex, lazy `_else` fallback conversions, a new `format_or_na` helper deduping "n/a" rendering, `InstanceStore::get_pid` returning `Option` instead of a meaningless unit `Result`, TOML deserializer and instance listing plumbing simplified to `Option` combinators, and `create_dir` dropping a racy exists check.