### PR TITLE
Test Suite Clean up

### DIFF
--- a/src/actions/stop_instance_action.rs
+++ b/src/actions/stop_instance_action.rs
@@ -33,3 +33,81 @@ impl StopInstanceAction {
         !instance_dao.is_running(&self.instance)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instance::InstanceStoreMock;
+
+    fn build_instance(name: &str) -> Instance {
+        Instance {
+            name: name.to_string(),
+            ..Instance::default()
+        }
+    }
+
+    #[test]
+    fn test_stop_rejects_unknown_instance() {
+        let store = InstanceStoreMock::new(Vec::new());
+
+        let result = StopInstanceAction::new(&build_instance("missing")).run(&store, false);
+
+        assert!(matches!(
+            result,
+            Err(Error::UnknownInstance(ref name)) if name == "missing"
+        ));
+    }
+
+    #[test]
+    fn test_stop_kills_running_instance() {
+        let instance = build_instance("test");
+        let store = InstanceStoreMock::new_with_running(vec![instance.clone()], &["test"]);
+
+        StopInstanceAction::new(&instance)
+            .run(&store, true)
+            .unwrap();
+
+        assert_eq!(store.get_killed(), ["test"]);
+    }
+
+    #[test]
+    fn test_stop_skips_stopped_instance() {
+        let instance = build_instance("test");
+        let store = InstanceStoreMock::new(vec![instance.clone()]);
+
+        StopInstanceAction::new(&instance)
+            .run(&store, true)
+            .unwrap();
+
+        assert!(store.get_killed().is_empty());
+    }
+
+    #[test]
+    fn test_stop_without_kill_requests_monitor_shutdown() {
+        let instance = build_instance("test");
+        let store = InstanceStoreMock::new_with_running(vec![instance.clone()], &["test"]);
+
+        // The mock has no monitor, so reaching the monitor path surfaces
+        // its InstanceNotRunning error instead of a kill.
+        let result = StopInstanceAction::new(&instance).run(&store, false);
+
+        assert!(result.is_err());
+        assert!(store.get_killed().is_empty());
+    }
+
+    #[test]
+    fn test_is_done_when_instance_is_stopped() {
+        let instance = build_instance("test");
+        let store = InstanceStoreMock::new(vec![instance.clone()]);
+
+        assert!(StopInstanceAction::new(&instance).is_done(&store));
+    }
+
+    #[test]
+    fn test_is_not_done_while_instance_is_running() {
+        let instance = build_instance("test");
+        let store = InstanceStoreMock::new_with_running(vec![instance.clone()], &["test"]);
+
+        assert!(!StopInstanceAction::new(&instance).is_done(&store));
+    }
+}

--- a/src/cloudinit/user_data_factory.rs
+++ b/src/cloudinit/user_data_factory.rs
@@ -83,4 +83,17 @@ bootcmd:
             "\nActual: {actual}\nExpected: {expected}\n"
         )
     }
+
+    #[test]
+    fn test_write_user_data_escapes_execute() {
+        let actual = UserDataFactory::default().create("tux", "pubkey", Some("a\\b\t\"c\"\nd\re"));
+
+        let expected_bootcmd = r#"bootcmd:
+  - "a\\b\t\"c\"\nd\re"
+"#;
+        assert!(
+            actual.ends_with(expected_bootcmd),
+            "\nActual: {actual}\nExpected suffix: {expected_bootcmd}\n"
+        )
+    }
 }

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -115,6 +115,39 @@ mod tests {
     }
 
     #[test]
+    fn test_clone_rejects_running_source() {
+        let console = &mut ConsoleMock::new();
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
+        let context = Context::new(
+            env,
+            Box::new(ImageStoreMock::default()),
+            Box::new(InstanceStoreMock::new_with_running(
+                vec![Instance {
+                    name: "test".to_string(),
+                    ..Instance::default()
+                }],
+                &["test"],
+            )),
+        );
+
+        let result = CloneCommand {
+            name: InstanceName::from_str("test").unwrap(),
+            new_name: InstanceName::from_str("newname").unwrap(),
+        }
+        .run(console, &context);
+
+        assert!(matches!(
+            result,
+            Err(Error::InstanceNotStopped(ref name)) if name == "test"
+        ));
+    }
+
+    #[test]
     fn test_clone_rejects_unknown_source() {
         let console = &mut ConsoleMock::new();
         let context = build_context(Vec::new());

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -63,3 +63,71 @@ impl Command for CloneCommand {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image::ImageStoreMock;
+    use crate::instance::InstanceStoreMock;
+    use crate::models::Environment;
+    use crate::models::Instance;
+    use crate::view::ConsoleMock;
+    use std::str::FromStr;
+
+    fn build_context(instances: Vec<Instance>) -> Context {
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
+        Context::new(
+            env,
+            Box::new(ImageStoreMock::default()),
+            Box::new(InstanceStoreMock::new(instances)),
+        )
+    }
+
+    #[test]
+    fn test_clone_rejects_existing_target_name() {
+        let console = &mut ConsoleMock::new();
+        let context = build_context(vec![
+            Instance {
+                name: "test".to_string(),
+                ..Instance::default()
+            },
+            Instance {
+                name: "test2".to_string(),
+                ..Instance::default()
+            },
+        ]);
+
+        let result = CloneCommand {
+            name: InstanceName::from_str("test").unwrap(),
+            new_name: InstanceName::from_str("test2").unwrap(),
+        }
+        .run(console, &context);
+
+        assert!(matches!(
+            result,
+            Err(Error::InstanceAlreadyExists(ref name)) if name == "test2"
+        ));
+    }
+
+    #[test]
+    fn test_clone_rejects_unknown_source() {
+        let console = &mut ConsoleMock::new();
+        let context = build_context(Vec::new());
+
+        let result = CloneCommand {
+            name: InstanceName::from_str("missing").unwrap(),
+            new_name: InstanceName::from_str("newname").unwrap(),
+        }
+        .run(console, &context);
+
+        assert!(matches!(
+            result,
+            Err(Error::UnknownInstance(ref name)) if name == "missing"
+        ));
+    }
+}

--- a/src/commands/console_command.rs
+++ b/src/commands/console_command.rs
@@ -79,11 +79,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_valid_name() {
-        assert!(ConsoleCommand::try_parse_from(["console", "my-instance"]).is_ok());
-    }
-
-    #[test]
     fn test_reject_path_traversal() {
         assert!(ConsoleCommand::try_parse_from(["console", "../../etc"]).is_err());
     }

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -128,3 +128,40 @@ impl Command for CreateCommand {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image::ImageStoreMock;
+    use crate::instance::InstanceStoreMock;
+    use crate::models::Environment;
+    use crate::view::ConsoleMock;
+
+    #[test]
+    fn test_create_rejects_existing_instance_name() {
+        let console = &mut ConsoleMock::new();
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
+        let context = Context::new(
+            env,
+            Box::new(ImageStoreMock::default()),
+            Box::new(InstanceStoreMock::new(vec![Instance {
+                name: "test".to_string(),
+                ..Instance::default()
+            }])),
+        );
+
+        let result = CreateCommand::try_parse_from(["create", "test", "-i", "debian:bookworm"])
+            .unwrap()
+            .run(console, &context);
+
+        assert!(matches!(
+            result,
+            Err(Error::InstanceAlreadyExists(ref name)) if name == "test"
+        ));
+    }
+}

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -78,11 +78,6 @@ mod tests {
     use crate::view::ConsoleMock;
 
     #[test]
-    fn test_parse_valid_names() {
-        assert!(DeleteCommand::try_parse_from(["delete", "trixie", "noble"]).is_ok());
-    }
-
-    #[test]
     fn test_reject_path_traversal() {
         assert!(DeleteCommand::try_parse_from(["delete", "../../etc"]).is_err());
     }

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -47,3 +47,36 @@ pub fn fetch_image(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image::ImageStoreMock;
+    use crate::models::{Arch, HashAlg};
+    use crate::view::ConsoleMock;
+
+    #[test]
+    fn test_fetch_image_skips_cached_image() {
+        let console = &mut ConsoleMock::new();
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
+        let image = Image {
+            vendor: "debian".to_string(),
+            names: vec!["12".to_string(), "bookworm".to_string()],
+            arch: Arch::AMD64,
+            image_url: String::new(),
+            checksum_url: String::new(),
+            hash_alg: HashAlg::Sha512,
+            size: None,
+        };
+        let image_store = ImageStoreMock::new(vec![image.clone()]);
+
+        // A cached image must return without touching the image directory
+        // or the network.
+        fetch_image(console, &env, &image_store, &image).unwrap();
+    }
+}

--- a/src/commands/list_port_command.rs
+++ b/src/commands/list_port_command.rs
@@ -63,3 +63,69 @@ impl Command for ListPortCommand {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image::ImageStoreMock;
+    use crate::instance::InstanceStoreMock;
+    use crate::models::{Environment, Instance};
+    use crate::view::ConsoleMock;
+
+    fn build_context(instances: Vec<Instance>) -> commands::Context {
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
+        commands::Context::new(
+            env,
+            Box::new(ImageStoreMock::default()),
+            Box::new(InstanceStoreMock::new(instances)),
+        )
+    }
+
+    #[test]
+    fn test_list_ports_empty() {
+        let console = &mut ConsoleMock::new();
+        let context = build_context(Vec::new());
+
+        ListPortCommand {}.run(console, &context).unwrap();
+
+        assert_eq!(
+            console.get_output(),
+            "Instance   Host   Guest   Protocol   In Use\n"
+        );
+    }
+
+    #[test]
+    fn test_list_ports_adds_row_per_forward_rule() {
+        let console = &mut ConsoleMock::new();
+        let context = build_context(vec![
+            Instance {
+                name: "test".to_string(),
+                ssh_port: 9000,
+                ..Instance::default()
+            },
+            Instance {
+                name: "test2".to_string(),
+                ssh_port: 8000,
+                hostfwd: vec!["127.0.0.1:4000:40/tcp".parse().unwrap()],
+                ..Instance::default()
+            },
+        ]);
+
+        ListPortCommand {}.run(console, &context).unwrap();
+
+        assert_eq!(
+            console.get_output(),
+            "\
+Instance   Host             Guest   Protocol   In Use
+test       127.0.0.1:9000   :22     /tcp       no
+test2      127.0.0.1:8000   :22     /tcp       no
+test2      127.0.0.1:4000   :40     /tcp       no
+"
+        );
+    }
+}

--- a/src/commands/modify_command.rs
+++ b/src/commands/modify_command.rs
@@ -104,11 +104,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_valid_name() {
-        assert!(ModifyCommand::try_parse_from(["modify", "my-instance", "--cpus", "2"]).is_ok());
-    }
-
-    #[test]
     fn test_reject_path_traversal() {
         assert!(ModifyCommand::try_parse_from(["modify", "../../etc"]).is_err());
     }

--- a/src/commands/modify_command.rs
+++ b/src/commands/modify_command.rs
@@ -102,9 +102,65 @@ impl Command for ModifyCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::image::ImageStoreMock;
+    use crate::instance::InstanceStoreMock;
+    use crate::models::{Environment, Instance};
+    use crate::view::ConsoleMock;
+
+    fn build_context(instance_store: InstanceStoreMock) -> commands::Context {
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
+        commands::Context::new(
+            env,
+            Box::new(ImageStoreMock::default()),
+            Box::new(instance_store),
+        )
+    }
 
     #[test]
     fn test_reject_path_traversal() {
         assert!(ModifyCommand::try_parse_from(["modify", "../../etc"]).is_err());
+    }
+
+    #[test]
+    fn test_modify_stopped_instance_prints_nothing() {
+        let console = &mut ConsoleMock::new();
+        let context = build_context(InstanceStoreMock::new(vec![Instance {
+            name: "test".to_string(),
+            ..Instance::default()
+        }]));
+
+        ModifyCommand::try_parse_from(["modify", "test", "--cpus", "2"])
+            .unwrap()
+            .run(console, &context)
+            .unwrap();
+
+        assert_eq!(console.get_output(), "");
+    }
+
+    #[test]
+    fn test_modify_running_instance_notes_restart() {
+        let console = &mut ConsoleMock::new();
+        let context = build_context(InstanceStoreMock::new_with_running(
+            vec![Instance {
+                name: "test".to_string(),
+                ..Instance::default()
+            }],
+            &["test"],
+        ));
+
+        ModifyCommand::try_parse_from(["modify", "test", "--cpus", "2"])
+            .unwrap()
+            .run(console, &context)
+            .unwrap();
+
+        assert_eq!(
+            console.get_output(),
+            "info: Note: changes will be applied after the next restart.\n"
+        );
     }
 }

--- a/src/commands/rename_command.rs
+++ b/src/commands/rename_command.rs
@@ -30,3 +30,62 @@ impl Command for RenameCommand {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+    use crate::image::ImageStoreMock;
+    use crate::instance::InstanceStoreMock;
+    use crate::models::{Environment, Instance};
+    use crate::view::ConsoleMock;
+    use std::str::FromStr;
+
+    fn build_context(instances: Vec<Instance>) -> commands::Context {
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
+        commands::Context::new(
+            env,
+            Box::new(ImageStoreMock::default()),
+            Box::new(InstanceStoreMock::new(instances)),
+        )
+    }
+
+    #[test]
+    fn test_rename_rejects_unknown_instance() {
+        let console = &mut ConsoleMock::new();
+        let context = build_context(Vec::new());
+
+        let result = RenameCommand {
+            old_name: InstanceName::from_str("missing").unwrap(),
+            new_name: InstanceName::from_str("newname").unwrap(),
+        }
+        .run(console, &context);
+
+        assert!(matches!(
+            result,
+            Err(Error::UnknownInstance(ref name)) if name == "missing"
+        ));
+    }
+
+    #[test]
+    fn test_rename_delegates_to_store() {
+        let console = &mut ConsoleMock::new();
+        let context = build_context(vec![Instance {
+            name: "test".to_string(),
+            ..Instance::default()
+        }]);
+
+        let result = RenameCommand {
+            old_name: InstanceName::from_str("test").unwrap(),
+            new_name: InstanceName::from_str("newname").unwrap(),
+        }
+        .run(console, &context);
+
+        assert!(result.is_ok());
+    }
+}

--- a/src/commands/restart_command.rs
+++ b/src/commands/restart_command.rs
@@ -44,11 +44,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_valid_names() {
-        assert!(RestartCommand::try_parse_from(["restart", "trixie", "noble"]).is_ok());
-    }
-
-    #[test]
     fn test_reject_path_traversal() {
         assert!(RestartCommand::try_parse_from(["restart", "../../etc"]).is_err());
     }

--- a/src/commands/scp_command.rs
+++ b/src/commands/scp_command.rs
@@ -81,3 +81,44 @@ impl Command for ScpCommand {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instance::InstanceStoreMock;
+    use crate::models::Instance;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_check_local_path_needs_no_instance() {
+        let store = InstanceStoreMock::new(Vec::new());
+        let path = TargetPath::from_str("/home/cubic/file").unwrap();
+
+        assert!(check_target_is_running(&store, &path).is_ok());
+    }
+
+    #[test]
+    fn test_check_rejects_unknown_instance() {
+        let store = InstanceStoreMock::new(Vec::new());
+        let path = TargetPath::from_str("missing:~/file").unwrap();
+
+        assert!(matches!(
+            check_target_is_running(&store, &path),
+            Err(Error::UnknownInstance(ref name)) if name == "missing"
+        ));
+    }
+
+    #[test]
+    fn test_check_rejects_stopped_instance() {
+        let store = InstanceStoreMock::new(vec![Instance {
+            name: "test".to_string(),
+            ..Instance::default()
+        }]);
+        let path = TargetPath::from_str("test:~/file").unwrap();
+
+        assert!(matches!(
+            check_target_is_running(&store, &path),
+            Err(Error::InstanceNotRunning(ref name)) if name == "test"
+        ));
+    }
+}

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -77,3 +77,63 @@ impl Command for ShowCommand {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+    use crate::image::ImageStoreMock;
+    use crate::instance::InstanceStoreMock;
+    use crate::models::{Environment, Instance};
+    use crate::view::ConsoleMock;
+    use std::str::FromStr;
+
+    fn build_context(instances: Vec<Instance>) -> commands::Context {
+        let env = Environment::new(
+            "cubic".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
+        commands::Context::new(
+            env,
+            Box::new(ImageStoreMock::default()),
+            Box::new(InstanceStoreMock::new(instances)),
+        )
+    }
+
+    #[test]
+    fn test_show_routes_plain_name_to_instance_view() {
+        let console = &mut ConsoleMock::new();
+        let context = build_context(vec![Instance {
+            name: "test".to_string(),
+            ..Instance::default()
+        }]);
+
+        ShowCommand {
+            name: InstanceImageName::from_str("test").unwrap(),
+            all: false,
+        }
+        .run(console, &context)
+        .unwrap();
+
+        assert!(console.get_output().starts_with("Running:"));
+    }
+
+    #[test]
+    fn test_show_rejects_unknown_instance() {
+        let console = &mut ConsoleMock::new();
+        let context = build_context(Vec::new());
+
+        let result = ShowCommand {
+            name: InstanceImageName::from_str("missing").unwrap(),
+            all: false,
+        }
+        .run(console, &context);
+
+        assert!(matches!(
+            result,
+            Err(Error::UnknownInstance(ref name)) if name == "missing"
+        ));
+    }
+}

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -85,7 +85,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_show_command1() {
+    fn test_show_basic_fields() {
         let console = &mut ConsoleMock::new();
         let env = Environment::new(
             "myuser".to_string(),
@@ -135,7 +135,7 @@ Forward:      127.0.0.1:4000:40/tcp
     }
 
     #[test]
-    fn test_show_command2() {
+    fn test_show_all_fields() {
         let console = &mut ConsoleMock::new();
         let env = Environment::new(
             "cubic".to_string(),

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -155,11 +155,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_valid_names() {
-        assert!(StartCommand::try_parse_from(["start", "trixie", "noble"]).is_ok());
-    }
-
-    #[test]
     fn test_reject_path_traversal() {
         assert!(StartCommand::try_parse_from(["start", "../../etc"]).is_err());
     }

--- a/src/commands/stop_command.rs
+++ b/src/commands/stop_command.rs
@@ -86,11 +86,6 @@ mod tests {
     use crate::view::ConsoleMock;
 
     #[test]
-    fn test_parse_valid_names() {
-        assert!(StopCommand::try_parse_from(["stop", "trixie", "noble"]).is_ok());
-    }
-
-    #[test]
     fn test_reject_path_traversal() {
         assert!(StopCommand::try_parse_from(["stop", "../../etc"]).is_err());
     }

--- a/src/image/almalinux_image_provider.rs
+++ b/src/image/almalinux_image_provider.rs
@@ -39,3 +39,40 @@ impl ImageProvider for AlmaLinuxImageProvider {
         HashAlg::Sha256
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn test_find_image_names_in_listing() {
+        let listing = r#"<a href="8/">8/</a>
+<a href="9/">9/</a>
+<a href="almalinux/">almalinux/</a>"#;
+
+        assert_eq!(
+            AlmaLinuxImageProvider {}.find_image_names(listing),
+            ["8", "9"]
+        );
+    }
+
+    #[test]
+    fn test_get_image_dir_path_uses_canonical_arch() {
+        assert_eq!(
+            AlmaLinuxImageProvider {}.get_image_dir_path("9", Arch::AMD64),
+            "9/cloud/x86_64/images/"
+        );
+    }
+
+    #[test]
+    fn test_image_file_pattern_matches_image_file() {
+        let pattern = AlmaLinuxImageProvider {}.get_image_file_pattern("9", Arch::AMD64);
+
+        assert!(
+            Regex::new(&pattern)
+                .unwrap()
+                .is_match("AlmaLinux-9-GenericCloud-latest.x86_64.qcow2")
+        );
+    }
+}

--- a/src/image/archlinux_image_provider.rs
+++ b/src/image/archlinux_image_provider.rs
@@ -37,3 +37,37 @@ impl ImageProvider for ArchLinuxImageProvider {
         HashAlg::Sha256
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn test_find_image_names_is_always_latest() {
+        assert_eq!(ArchLinuxImageProvider {}.find_image_names(""), ["latest"]);
+    }
+
+    #[test]
+    fn test_image_file_pattern_matches_image_file() {
+        let pattern = ArchLinuxImageProvider {}.get_image_file_pattern("latest", Arch::AMD64);
+
+        assert!(
+            Regex::new(&pattern)
+                .unwrap()
+                .is_match("Arch-Linux-x86_64-cloudimg.qcow2")
+        );
+    }
+
+    #[test]
+    fn test_get_checksum_file_appends_suffix() {
+        assert_eq!(
+            ArchLinuxImageProvider {}.get_checksum_file(
+                "Arch-Linux-x86_64-cloudimg.qcow2",
+                "latest",
+                Arch::AMD64
+            ),
+            "Arch-Linux-x86_64-cloudimg.qcow2.SHA256"
+        );
+    }
+}

--- a/src/image/debian_image_provider.rs
+++ b/src/image/debian_image_provider.rs
@@ -51,3 +51,40 @@ impl ImageProvider for DebianImageProvider {
         HashAlg::Sha512
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn test_find_image_names_in_listing() {
+        let listing = r#"<a href="bookworm/">bookworm/</a>
+<a href="trixie/">trixie/</a>
+<a href="OpenStack/">OpenStack/</a>"#;
+
+        assert_eq!(
+            DebianImageProvider {}.find_image_names(listing),
+            ["bookworm", "trixie"]
+        );
+    }
+
+    #[test]
+    fn test_get_image_names_extracts_version() {
+        assert_eq!(
+            DebianImageProvider {}.get_image_names("debian-12-generic-amd64.qcow2", "bookworm"),
+            ["12", "bookworm"]
+        );
+    }
+
+    #[test]
+    fn test_image_file_pattern_matches_image_file() {
+        let pattern = DebianImageProvider {}.get_image_file_pattern("bookworm", Arch::AMD64);
+
+        assert!(
+            Regex::new(&pattern)
+                .unwrap()
+                .is_match("debian-12-generic-amd64.qcow2")
+        );
+    }
+}

--- a/src/image/fedora_image_provider.rs
+++ b/src/image/fedora_image_provider.rs
@@ -46,3 +46,54 @@ impl ImageProvider for FedoraImageProvider {
         HashAlg::Sha256
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn test_find_image_names_keeps_versions_above_forty() {
+        let listing = r#"<a href="39/">39/</a>
+<a href="40/">40/</a>
+<a href="41/">41/</a>
+<a href="42/">42/</a>
+<a href="test/">test/</a>"#;
+
+        assert_eq!(
+            FedoraImageProvider {}.find_image_names(listing),
+            ["41", "42"]
+        );
+    }
+
+    #[test]
+    fn test_get_image_dir_path_uses_canonical_arch() {
+        assert_eq!(
+            FedoraImageProvider {}.get_image_dir_path("42", Arch::ARM64),
+            "42/Cloud/aarch64/images/"
+        );
+    }
+
+    #[test]
+    fn test_image_file_pattern_matches_image_file() {
+        let pattern = FedoraImageProvider {}.get_image_file_pattern("42", Arch::AMD64);
+
+        assert!(
+            Regex::new(&pattern)
+                .unwrap()
+                .is_match("Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2")
+        );
+    }
+
+    #[test]
+    fn test_get_checksum_file_rewrites_image_file() {
+        assert_eq!(
+            FedoraImageProvider {}.get_checksum_file(
+                "Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2",
+                "42",
+                Arch::AMD64
+            ),
+            "Fedora-Cloud-42-1.1-x86_64-CHECKSUM"
+        );
+    }
+}

--- a/src/image/gentoo_image_provider.rs
+++ b/src/image/gentoo_image_provider.rs
@@ -38,3 +38,40 @@ impl ImageProvider for GentooImageProvider {
         HashAlg::Sha256
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn test_get_image_dir_path_uses_vendor_arch() {
+        assert_eq!(
+            GentooImageProvider {}.get_image_dir_path("latest", Arch::AMD64),
+            "amd64/autobuilds/current-di-amd64-cloudinit/"
+        );
+    }
+
+    #[test]
+    fn test_image_file_pattern_matches_image_file() {
+        let pattern = GentooImageProvider {}.get_image_file_pattern("latest", Arch::AMD64);
+
+        assert!(
+            Regex::new(&pattern)
+                .unwrap()
+                .is_match("di-amd64-cloudinit-20250706T165243Z.qcow2")
+        );
+    }
+
+    #[test]
+    fn test_get_checksum_file_appends_suffix() {
+        assert_eq!(
+            GentooImageProvider {}.get_checksum_file(
+                "di-amd64-cloudinit-20250706T165243Z.qcow2",
+                "latest",
+                Arch::AMD64
+            ),
+            "di-amd64-cloudinit-20250706T165243Z.qcow2.sha256"
+        );
+    }
+}

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -275,4 +275,19 @@ mod tests {
 
         assert_eq!(ImageFactory::find_matching_image(&[], &filter), None);
     }
+
+    #[test]
+    fn test_filter_arch_without_filter_keeps_all_arches() {
+        assert_eq!(
+            ImageFactory::filter_arch(None),
+            vec![Arch::AMD64, Arch::ARM64]
+        );
+    }
+
+    #[test]
+    fn test_filter_arch_keeps_only_filtered_arch() {
+        let filter = ImageName::from_str("debian:bookworm:arm64").unwrap();
+
+        assert_eq!(ImageFactory::filter_arch(Some(filter)), vec![Arch::ARM64]);
+    }
 }

--- a/src/image/image_store_mock.rs
+++ b/src/image/image_store_mock.rs
@@ -9,6 +9,12 @@ pub mod tests {
         images: Vec<Image>,
     }
 
+    impl ImageStoreMock {
+        pub fn new(images: Vec<Image>) -> Self {
+            Self { images }
+        }
+    }
+
     impl ImageStore for ImageStoreMock {
         fn exists(&self, image: &Image) -> bool {
             self.images.contains(image)

--- a/src/image/opensuse_image_provider.rs
+++ b/src/image/opensuse_image_provider.rs
@@ -38,3 +38,40 @@ impl ImageProvider for OpenSuseImageProvider {
         HashAlg::Sha256
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn test_find_image_names_extracts_leap_versions() {
+        let listing = r#"<a href="Leap_15.5/">Leap_15.5/</a>
+<a href="Leap_15.6/">Leap_15.6/</a>
+<a href="Images/">Images/</a>"#;
+
+        assert_eq!(
+            OpenSuseImageProvider {}.find_image_names(listing),
+            ["15.5", "15.6"]
+        );
+    }
+
+    #[test]
+    fn test_get_image_dir_path_restores_leap_prefix() {
+        assert_eq!(
+            OpenSuseImageProvider {}.get_image_dir_path("15.6", Arch::AMD64),
+            "Leap_15.6/images/"
+        );
+    }
+
+    #[test]
+    fn test_image_file_pattern_matches_image_file() {
+        let pattern = OpenSuseImageProvider {}.get_image_file_pattern("15.6", Arch::AMD64);
+
+        assert!(
+            Regex::new(&pattern)
+                .unwrap()
+                .is_match("openSUSE-Leap-15.6.x86_64-NoCloud.qcow2")
+        );
+    }
+}

--- a/src/image/rockylinux_image_provider.rs
+++ b/src/image/rockylinux_image_provider.rs
@@ -39,3 +39,52 @@ impl ImageProvider for RockyLinuxImageProvider {
         HashAlg::Sha256
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn test_find_image_names_in_listing() {
+        let listing = r#"<a href="8/">8/</a>
+<a href="9/">9/</a>
+<a href="sig/">sig/</a>"#;
+
+        assert_eq!(
+            RockyLinuxImageProvider {}.find_image_names(listing),
+            ["8", "9"]
+        );
+    }
+
+    #[test]
+    fn test_get_image_dir_path_uses_canonical_arch() {
+        assert_eq!(
+            RockyLinuxImageProvider {}.get_image_dir_path("9", Arch::ARM64),
+            "9/images/aarch64/"
+        );
+    }
+
+    #[test]
+    fn test_image_file_pattern_matches_image_file() {
+        let pattern = RockyLinuxImageProvider {}.get_image_file_pattern("9", Arch::AMD64);
+
+        assert!(
+            Regex::new(&pattern)
+                .unwrap()
+                .is_match("Rocky-9-GenericCloud-Base.latest.x86_64.qcow2")
+        );
+    }
+
+    #[test]
+    fn test_get_checksum_file_appends_suffix() {
+        assert_eq!(
+            RockyLinuxImageProvider {}.get_checksum_file(
+                "Rocky-9-GenericCloud-Base.latest.x86_64.qcow2",
+                "9",
+                Arch::AMD64
+            ),
+            "Rocky-9-GenericCloud-Base.latest.x86_64.qcow2.CHECKSUM"
+        );
+    }
+}

--- a/src/image/ubuntu_image_provider.rs
+++ b/src/image/ubuntu_image_provider.rs
@@ -51,3 +51,40 @@ impl ImageProvider for UbuntuImageProvider {
         HashAlg::Sha256
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn test_find_image_names_in_listing() {
+        let listing = r#"<a href="jammy/">jammy/</a>
+<a href="noble/">noble/</a>"#;
+
+        assert_eq!(
+            UbuntuImageProvider {}.find_image_names(listing),
+            ["jammy", "noble"]
+        );
+    }
+
+    #[test]
+    fn test_get_image_names_extracts_version() {
+        assert_eq!(
+            UbuntuImageProvider {}
+                .get_image_names("ubuntu-24.04-minimal-cloudimg-amd64.img", "noble"),
+            ["24.04", "noble"]
+        );
+    }
+
+    #[test]
+    fn test_image_file_pattern_matches_image_file() {
+        let pattern = UbuntuImageProvider {}.get_image_file_pattern("noble", Arch::ARM64);
+
+        assert!(
+            Regex::new(&pattern)
+                .unwrap()
+                .is_match("ubuntu-24.04-minimal-cloudimg-arm64.img")
+        );
+    }
+}

--- a/src/instance/instance_store_mock.rs
+++ b/src/instance/instance_store_mock.rs
@@ -5,14 +5,29 @@ pub mod tests {
     use crate::instance::InstanceStore;
     use crate::models::Instance;
     use crate::qemu::Monitor;
+    use std::sync::Mutex;
 
     pub struct InstanceStoreMock {
         instances: Vec<Instance>,
+        running: Vec<String>,
+        killed: Mutex<Vec<String>>,
     }
 
     impl InstanceStoreMock {
         pub fn new(instances: Vec<Instance>) -> Self {
-            Self { instances }
+            Self::new_with_running(instances, &[])
+        }
+
+        pub fn new_with_running(instances: Vec<Instance>, running: &[&str]) -> Self {
+            Self {
+                instances,
+                running: running.iter().map(|name| name.to_string()).collect(),
+                killed: Mutex::new(Vec::new()),
+            }
+        }
+
+        pub fn get_killed(&self) -> Vec<String> {
+            self.killed.lock().unwrap().clone()
         }
     }
 
@@ -49,15 +64,16 @@ pub mod tests {
             Ok(())
         }
 
-        fn is_running(&self, _instance: &Instance) -> bool {
-            false
+        fn is_running(&self, instance: &Instance) -> bool {
+            self.running.contains(&instance.name)
         }
 
         fn get_pid(&self, _instance: &Instance) -> Option<u64> {
             None
         }
 
-        fn kill(&self, _instance: &Instance) -> Result<()> {
+        fn kill(&self, instance: &Instance) -> Result<()> {
+            self.killed.lock().unwrap().push(instance.name.clone());
             Ok(())
         }
 

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -63,7 +63,7 @@ ssh_port = 14357
         assert_eq!(instance.ssh_port, 14357);
         assert!(instance.hostfwd.is_empty());
         assert_eq!(instance.execute, None);
-        assert_eq!(instance.isolate, false);
+        assert!(!instance.isolate);
     }
 
     #[test]
@@ -100,7 +100,7 @@ isolate = true
             ["tcp:127.0.0.1:8000-:8000", "tcp:127.0.0.1:9000-:10000"]
         );
         assert_eq!(instance.execute, Some("sudo apt update".to_string()));
-        assert_eq!(instance.isolate, true);
+        assert!(instance.isolate);
     }
 
     #[test]
@@ -127,6 +127,6 @@ ssh_port = 14357
         assert_eq!(instance.ssh_port, 14357);
         assert!(instance.hostfwd.is_empty());
         assert_eq!(instance.execute, None);
-        assert_eq!(instance.isolate, false);
+        assert!(!instance.isolate);
     }
 }

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -102,31 +102,4 @@ isolate = true
         assert_eq!(instance.execute, Some("sudo apt update".to_string()));
         assert!(instance.isolate);
     }
-
-    #[test]
-    fn test_deserialize_desktop_config() {
-        let reader = &mut BufReader::new(
-            r#"
-user = "tux"
-cpus = 1
-mem = 1073741824
-disk_capacity = 2361393152
-ssh_port = 14357
-"#
-            .as_bytes(),
-        );
-
-        let instance = TomlInstanceDeserializer::new()
-            .deserialize("test", reader)
-            .expect("Cannot parse config");
-        assert_eq!(instance.name, "test");
-        assert_eq!(instance.user, "tux");
-        assert_eq!(instance.cpus, 1);
-        assert_eq!(instance.mem.get_bytes(), 1073741824);
-        assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
-        assert_eq!(instance.ssh_port, 14357);
-        assert!(instance.hostfwd.is_empty());
-        assert_eq!(instance.execute, None);
-        assert!(!instance.isolate);
-    }
 }

--- a/src/instance/yaml_instance_deserializer.rs
+++ b/src/instance/yaml_instance_deserializer.rs
@@ -96,11 +96,10 @@ machine:
     }
 
     #[test]
-    fn test_deserialize_desktop_config() {
+    fn test_deserialize_null_hostfwd() {
         let reader = &mut BufReader::new(
             r#"
 machine:
-  user: tux
   cpus: 1
   mem: 1073741824
   disk_capacity: 2361393152
@@ -113,12 +112,6 @@ machine:
         let instance = YamlInstanceDeserializer::new()
             .deserialize("test", reader)
             .expect("Cannot parse config");
-        assert_eq!(instance.name, "test");
-        assert_eq!(instance.user, "tux");
-        assert_eq!(instance.cpus, 1);
-        assert_eq!(instance.mem.get_bytes(), 1073741824);
-        assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
-        assert_eq!(instance.ssh_port, 14357);
         assert!(instance.hostfwd.is_empty());
     }
 }

--- a/src/iso9660/dir_record.rs
+++ b/src/iso9660/dir_record.rs
@@ -76,4 +76,18 @@ mod tests {
         assert_eq!(&result[33..39], &[102, 111, 111, 98, 97, 114]);
         assert_eq!(result[39], 0);
     }
+
+    #[test]
+    fn test_write_dir_record_with_odd_file_id_skips_padding() {
+        let writer = &mut BinaryWriter::new(Cursor::new(Vec::new()));
+        let mut dir = DirRecord::default();
+        dir.file_id_len = 5;
+        dir.file_id = "fooba".to_string();
+        dir.write(writer).unwrap();
+
+        let result = writer.get_writer().get_ref();
+        assert_eq!(result.len(), 38);
+        assert_eq!(result[32], 5);
+        assert_eq!(&result[33..38], "fooba".as_bytes());
+    }
 }

--- a/src/iso9660/primary_volume_desc.rs
+++ b/src/iso9660/primary_volume_desc.rs
@@ -93,7 +93,18 @@ mod tests {
         pvd.optional_lpath_table_loc = 0x789ABCDE;
         pvd.mpath_table_loc = 0x89ABCDEF;
         pvd.optional_mpath_table_loc = 0x9ABCDEF0;
-        pvd.root_dir = DirRecord::default();
+        pvd.root_dir = DirRecord {
+            len: 34,
+            extend_attr_len: 0x12,
+            extend_loc: 0x11223344,
+            data_len: 0x55667788,
+            file_flags: 0x02,
+            file_unit_size: 0x34,
+            interleave_gap_size: 0x56,
+            volume_sequence_number: 0x789A,
+            file_id_len: 1,
+            file_id: "A".to_string(),
+        };
         pvd.volume_set_id = "volume set id".to_string();
         pvd.publisher_id = "publisher id".to_string();
         pvd.data_prepare_id = "data prepare id".to_string();
@@ -135,7 +146,20 @@ mod tests {
         assert_eq!(&result[144..148], &[0xDE, 0xBC, 0x9A, 0x78]);
         assert_eq!(&result[148..152], &[0x89, 0xAB, 0xCD, 0xEF]);
         assert_eq!(&result[152..156], &[0x9A, 0xBC, 0xDE, 0xF0]);
-        //assert_eq!(&result[156..190], ...);
+        assert_eq!(result[156], 34);
+        assert_eq!(result[157], 0x12);
+        assert_eq!(&result[158..162], &[0x44, 0x33, 0x22, 0x11]);
+        assert_eq!(&result[162..166], &[0x11, 0x22, 0x33, 0x44]);
+        assert_eq!(&result[166..170], &[0x88, 0x77, 0x66, 0x55]);
+        assert_eq!(&result[170..174], &[0x55, 0x66, 0x77, 0x88]);
+        assert_eq!(&result[174..181], &[0u8; 7]);
+        assert_eq!(result[181], 0x02);
+        assert_eq!(result[182], 0x34);
+        assert_eq!(result[183], 0x56);
+        assert_eq!(&result[184..186], &[0x9A, 0x78]);
+        assert_eq!(&result[186..188], &[0x78, 0x9A]);
+        assert_eq!(result[188], 1);
+        assert_eq!(result[189], b'A');
         assert_eq!(&result[190..318], "volume set id                                                                                                                   ".as_bytes());
         assert_eq!(&result[318..446], "publisher id                                                                                                                    ".as_bytes());
         assert_eq!(&result[446..574], "data prepare id                                                                                                                 ".as_bytes());
@@ -160,5 +184,20 @@ mod tests {
         assert_eq!(result[882], 0);
         assert_eq!(&result[883..1395], &[0u8; 512]);
         assert_eq!(&result[1395..2048], &[0u8; 653]);
+    }
+
+    #[test]
+    fn test_new_sets_primary_volume_defaults() {
+        let pvd = PrimaryVolumeDesc::new();
+
+        let writer = &mut BinaryWriter::new(Cursor::new(Vec::new()));
+        pvd.write(writer).unwrap();
+
+        let result = writer.get_writer().get_ref();
+        assert_eq!(result[0], 1); // Volume descriptor type
+        assert_eq!(&result[1..6], "CD001".as_bytes());
+        assert_eq!(&result[128..130], &[0x00, 0x08]); // Block size 2048 LE
+        assert_eq!(&result[130..132], &[0x08, 0x00]); // Block size 2048 BE
+        assert_eq!(result[881], 1); // File structure version
     }
 }

--- a/src/models/arch.rs
+++ b/src/models/arch.rs
@@ -43,3 +43,44 @@ impl fmt::Display for Arch {
         write!(f, "{}", self.as_vendor_str())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_amd64() {
+        assert_eq!(Arch::from_str("amd64").unwrap(), Arch::AMD64);
+    }
+
+    #[test]
+    fn test_parse_arm64() {
+        assert_eq!(Arch::from_str("arm64").unwrap(), Arch::ARM64);
+    }
+
+    #[test]
+    fn test_reject_unknown_arch() {
+        assert!(matches!(
+            Arch::from_str("mips"),
+            Err(Error::UnknownArch(ref arch)) if arch == "mips"
+        ));
+    }
+
+    #[test]
+    fn test_vendor_str() {
+        assert_eq!(Arch::AMD64.as_vendor_str(), "amd64");
+        assert_eq!(Arch::ARM64.as_vendor_str(), "arm64");
+    }
+
+    #[test]
+    fn test_canonical_str() {
+        assert_eq!(Arch::AMD64.as_canonical_str(), "x86_64");
+        assert_eq!(Arch::ARM64.as_canonical_str(), "aarch64");
+    }
+
+    #[test]
+    fn test_to_string() {
+        assert_eq!(Arch::AMD64.to_string(), "amd64");
+        assert_eq!(Arch::ARM64.to_string(), "arm64");
+    }
+}

--- a/src/models/data_size.rs
+++ b/src/models/data_size.rs
@@ -102,7 +102,7 @@ mod tests {
     }
 
     #[test]
-    fn test_terrabyte_to_size() {
+    fn test_terabyte_to_size() {
         assert_eq!(&DataSize::new(1024_usize.pow(4)).to_size(), "1.0 TiB")
     }
 
@@ -133,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_terrabyte() {
+    fn test_from_terabyte() {
         assert_eq!(
             DataSize::from_str("1T").unwrap().get_bytes(),
             1024_usize.pow(4)

--- a/src/models/environment.rs
+++ b/src/models/environment.rs
@@ -175,7 +175,10 @@ mod tests {
 
         assert_eq!(env.get_username(), "testuser");
         assert_eq!(env.get_cache_dir(), "/cache/cubic");
-        assert_eq!(env.get_cache_dir(), "/cache/cubic");
+        assert_eq!(
+            env.get_ssh_private_key_file("mymachine"),
+            "/data/cubic/machines/mymachine/ssh_client_key"
+        );
         assert_eq!(env.get_runtime_dir(), "/runtime/cubic");
         assert_eq!(env.get_instance_dir(), "/data/cubic/machines");
         assert_eq!(env.get_image_dir(), "/cache/cubic/images");

--- a/src/models/image.rs
+++ b/src/models/image.rs
@@ -90,3 +90,88 @@ impl PartialOrd for Image {
         Some(self.cmp(other))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_image(vendor: &str, names: &[&str]) -> Image {
+        Image {
+            vendor: vendor.to_string(),
+            names: names.iter().map(|name| name.to_string()).collect(),
+            arch: Arch::AMD64,
+            image_url: String::new(),
+            checksum_url: String::new(),
+            hash_alg: HashAlg::Sha512,
+            size: None,
+        }
+    }
+
+    #[test]
+    fn test_get_version_is_first_name() {
+        assert_eq!(
+            build_image("debian", &["12", "bookworm"]).get_version(),
+            "12"
+        );
+    }
+
+    #[test]
+    fn test_get_name_prefers_second_name() {
+        assert_eq!(
+            build_image("debian", &["12", "bookworm"]).get_name(),
+            "bookworm"
+        );
+    }
+
+    #[test]
+    fn test_get_name_falls_back_to_single_name() {
+        assert_eq!(build_image("debian", &["bookworm"]).get_name(), "bookworm");
+    }
+
+    #[test]
+    fn test_get_image_names_joins_multiple_names() {
+        assert_eq!(
+            build_image("debian", &["12", "bookworm"]).get_image_names(),
+            "debian:{12, bookworm}"
+        );
+    }
+
+    #[test]
+    fn test_get_image_names_with_single_name() {
+        assert_eq!(
+            build_image("debian", &["bookworm"]).get_image_names(),
+            "debian:bookworm"
+        );
+    }
+
+    #[test]
+    fn test_to_name_uses_version_and_arch() {
+        assert_eq!(
+            build_image("debian", &["12", "bookworm"]).to_name(),
+            "debian:12:amd64"
+        );
+    }
+
+    #[test]
+    fn test_to_file_name_uses_name_and_arch() {
+        assert_eq!(
+            build_image("debian", &["12", "bookworm"]).to_file_name(),
+            "debian_bookworm_amd64"
+        );
+    }
+
+    #[test]
+    fn test_ord_compares_numeric_versions_numerically() {
+        assert!(build_image("debian", &["10"]) > build_image("debian", &["9"]));
+    }
+
+    #[test]
+    fn test_ord_falls_back_to_lexical_comparison() {
+        assert!(build_image("ubuntu", &["noble"]) > build_image("ubuntu", &["jammy"]));
+    }
+
+    #[test]
+    fn test_ord_compares_vendor_first() {
+        assert!(build_image("alma", &["9"]) < build_image("debian", &["1"]));
+    }
+}

--- a/src/models/image_name.rs
+++ b/src/models/image_name.rs
@@ -79,7 +79,7 @@ mod tests {
     }
 
     #[test]
-    fn test_debian_bookworm_amd64() {
+    fn test_debian_buster_amd64() {
         let image = ImageName::from_str("debian:buster:amd64").unwrap();
         assert_eq!(image.get_vendor(), "debian");
         assert_eq!(image.get_name(), "buster");

--- a/src/models/image_name.rs
+++ b/src/models/image_name.rs
@@ -17,7 +17,7 @@ pub fn get_default_arch() -> Arch {
     Arch::AMD64
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ImageName {
     vendor: String,
     name: String,
@@ -92,5 +92,25 @@ mod tests {
         assert_eq!(image.get_vendor(), "debian");
         assert_eq!(image.get_name(), "bookworm");
         assert_eq!(image.get_arch(), Arch::ARM64);
+    }
+
+    #[test]
+    fn test_reject_name_without_vendor() {
+        assert!(ImageName::from_str("debian").is_err());
+    }
+
+    #[test]
+    fn test_reject_unknown_arch() {
+        assert!(ImageName::from_str("debian:bookworm:mips").is_err());
+    }
+
+    #[test]
+    fn test_to_string() {
+        assert_eq!(
+            ImageName::from_str("debian:bookworm:arm64")
+                .unwrap()
+                .to_string(),
+            "debian:bookworm:arm64"
+        );
     }
 }

--- a/src/models/instance_cert_paths.rs
+++ b/src/models/instance_cert_paths.rs
@@ -23,3 +23,31 @@ impl InstanceCertPaths {
         self.ca_cert.exists()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_builds_paths_in_instance_dir() {
+        let paths = InstanceCertPaths::load(Path::new("/data/machines/test"));
+
+        assert_eq!(paths.ca_cert, Path::new("/data/machines/test/ca-cert.pem"));
+        assert_eq!(
+            paths.server_cert,
+            Path::new("/data/machines/test/server-cert.pem")
+        );
+        assert_eq!(
+            paths.server_key,
+            Path::new("/data/machines/test/server-key.pem")
+        );
+        assert_eq!(
+            paths.client_cert,
+            Path::new("/data/machines/test/client-cert.pem")
+        );
+        assert_eq!(
+            paths.client_key,
+            Path::new("/data/machines/test/client-key.pem")
+        );
+    }
+}

--- a/src/models/instance_image_name.rs
+++ b/src/models/instance_image_name.rs
@@ -2,7 +2,7 @@ use crate::models::{ImageName, InstanceName};
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum InstanceImageName {
     Image(ImageName),
     Instance(InstanceName),
@@ -29,5 +29,49 @@ impl fmt::Display for InstanceImageName {
             InstanceImageName::Image(image) => image.fmt(f),
             InstanceImageName::Instance(instance) => instance.fmt(f),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_image_name_takes_precedence() {
+        assert!(matches!(
+            InstanceImageName::from_str("debian:bookworm").unwrap(),
+            InstanceImageName::Image(_)
+        ));
+    }
+
+    #[test]
+    fn test_plain_name_parses_as_instance() {
+        assert!(matches!(
+            InstanceImageName::from_str("mymachine").unwrap(),
+            InstanceImageName::Instance(_)
+        ));
+    }
+
+    #[test]
+    fn test_reject_name_combines_both_errors() {
+        let error = InstanceImageName::from_str("foo/bar").unwrap_err();
+        assert!(error.contains("Image name"));
+        assert!(error.contains("Instance name"));
+    }
+
+    #[test]
+    fn test_to_string() {
+        assert_eq!(
+            InstanceImageName::from_str("debian:bookworm:arm64")
+                .unwrap()
+                .to_string(),
+            "debian:bookworm:arm64"
+        );
+        assert_eq!(
+            InstanceImageName::from_str("mymachine")
+                .unwrap()
+                .to_string(),
+            "mymachine"
+        );
     }
 }

--- a/src/models/instance_name.rs
+++ b/src/models/instance_name.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 static INSTANCE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new("^[\\w_-]+$").unwrap());
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct InstanceName {
     name: String,
 }
@@ -86,5 +86,10 @@ mod tests {
     #[test]
     fn test_reject_absolute_path() {
         assert!(InstanceName::from_str("/abs/path").is_err());
+    }
+
+    #[test]
+    fn test_reject_empty_name() {
+        assert!(InstanceName::from_str("").is_err());
     }
 }

--- a/src/models/port_forward.rs
+++ b/src/models/port_forward.rs
@@ -196,6 +196,63 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_reject_unparsable_forward() {
+        assert!("abc".parse::<PortForward>().is_err());
+    }
+
+    #[test]
+    fn test_reject_host_port_overflow() {
+        assert!("99999:80".parse::<PortForward>().is_err());
+    }
+
+    #[test]
+    fn test_reject_invalid_host_ip() {
+        assert!("999.0.0.1:8000:80".parse::<PortForward>().is_err());
+    }
+
+    #[test]
+    fn test_reject_unparsable_qemu_forward() {
+        assert!(PortForward::from_qemu("garbage").is_err());
+    }
+
+    #[test]
+    fn test_reject_qemu_guest_port_overflow() {
+        assert!(PortForward::from_qemu("tcp:127.0.0.1:8000-:99999").is_err());
+    }
+
+    #[test]
+    fn test_reject_unknown_protocol() {
+        assert!(Protocol::from_str("sctp").is_err());
+    }
+
+    #[test]
+    fn test_protocol_to_string() {
+        assert_eq!(Protocol::Udp.to_string(), "udp");
+        assert_eq!(Protocol::Tcp.to_string(), "tcp");
+    }
+
+    #[test]
+    fn test_serde_round_trip_uses_qemu_format() {
+        let forward = PortForward::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            8000,
+            80,
+            Protocol::Tcp,
+        );
+
+        let serialized = serde_json::to_string(&forward).unwrap();
+        assert_eq!(serialized, "\"tcp:127.0.0.1:8000-:80\"");
+
+        let deserialized: PortForward = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, forward);
+    }
+
+    #[test]
+    fn test_deserialize_rejects_invalid_forward() {
+        assert!(serde_json::from_str::<PortForward>("\"garbage\"").is_err());
+    }
+
+    #[test]
     fn test_basic_parsing() {
         assert_eq!(
             "1000:10".parse(),

--- a/src/models/port_forward.rs
+++ b/src/models/port_forward.rs
@@ -366,20 +366,6 @@ mod tests {
     }
 
     #[test]
-    fn test_localhost_to_string() {
-        assert_eq!(
-            PortForward::new(
-                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                2000,
-                20,
-                Protocol::Tcp
-            )
-            .to_string(),
-            "127.0.0.1:2000:20/tcp"
-        )
-    }
-
-    #[test]
     fn test_udp_to_string() {
         assert_eq!(
             PortForward::new(
@@ -390,20 +376,6 @@ mod tests {
             )
             .to_string(),
             "127.0.0.1:3000:30/udp".to_string()
-        )
-    }
-
-    #[test]
-    fn test_tcp_to_string() {
-        assert_eq!(
-            PortForward::new(
-                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                4000,
-                40,
-                Protocol::Tcp
-            )
-            .to_string(),
-            "127.0.0.1:4000:40/tcp",
         )
     }
 
@@ -450,20 +422,6 @@ mod tests {
     }
 
     #[test]
-    fn test_qemu_localhost_to_string() {
-        assert_eq!(
-            PortForward::new(
-                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                2000,
-                20,
-                Protocol::Tcp
-            )
-            .to_qemu(),
-            "tcp:127.0.0.1:2000-:20"
-        )
-    }
-
-    #[test]
     fn test_qemu_udp_to_string() {
         assert_eq!(
             PortForward::new(
@@ -474,20 +432,6 @@ mod tests {
             )
             .to_qemu(),
             "udp:127.0.0.1:3000-:30".to_string()
-        )
-    }
-
-    #[test]
-    fn test_qemu_tcp_to_string() {
-        assert_eq!(
-            PortForward::new(
-                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                4000,
-                40,
-                Protocol::Tcp
-            )
-            .to_qemu(),
-            "tcp:127.0.0.1:4000-:40",
         )
     }
 

--- a/src/models/target.rs
+++ b/src/models/target.rs
@@ -80,4 +80,20 @@ mod tests {
     fn test_invalid_target() {
         assert!(Target::from_str("cubic@my@machine").is_err());
     }
+
+    #[test]
+    fn test_to_string_without_user() {
+        assert_eq!(
+            Target::from_str("mymachine").unwrap().to_string(),
+            "mymachine"
+        );
+    }
+
+    #[test]
+    fn test_to_string_with_user() {
+        assert_eq!(
+            Target::from_str("cubic@mymachine").unwrap().to_string(),
+            "cubic@mymachine"
+        );
+    }
 }

--- a/src/models/target_path.rs
+++ b/src/models/target_path.rs
@@ -65,4 +65,24 @@ mod tests {
         let path = TargetPath::from_str("cubic@mymachine:/home/cubic").unwrap();
         assert_eq!(path.to_string().as_str(), "cubic@mymachine:/home/cubic");
     }
+
+    #[test]
+    fn test_reject_too_many_colons() {
+        assert!(TargetPath::from_str("a:b:c").is_err());
+    }
+
+    #[test]
+    fn test_get_target_of_instance_path() {
+        let path = TargetPath::from_str("mymachine:/home/cubic").unwrap();
+        assert_eq!(
+            path.get_target().unwrap().get_instance().as_str(),
+            "mymachine"
+        );
+    }
+
+    #[test]
+    fn test_get_target_of_local_path() {
+        let path = TargetPath::from_str("/home/cubic").unwrap();
+        assert!(path.get_target().is_none());
+    }
 }

--- a/src/qemu/qemu_img.rs
+++ b/src/qemu/qemu_img.rs
@@ -96,7 +96,6 @@ mod tests {
         }
         "#;
 
-        println!("{input}");
         let result: ImageInfo = serde_json::from_str(input).unwrap();
         assert_eq!(result.actual_size, 200704);
     }

--- a/src/qemu/qemu_path_builder.rs
+++ b/src/qemu/qemu_path_builder.rs
@@ -35,6 +35,10 @@ impl QemuPathBuilder {
         // Add default paths
         dirs.extend(DEFAULT_DIRS.iter().map(PathBuf::from));
 
+        Self::new_from_dirs(dirs)
+    }
+
+    pub fn new_from_dirs(mut dirs: Vec<PathBuf>) -> Self {
         // Preserve order, drop duplicates
         let mut seen = Vec::new();
         dirs.retain(|dir| {
@@ -84,33 +88,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_dirs_include_path_and_defaults() {
-        let builder = QemuPathBuilder::new();
-        let dirs = builder.get_dirs();
-        // The first default dir is present on every supported platform.
-        let expected = PathBuf::from(DEFAULT_DIRS[0]);
-        assert!(dirs.contains(&expected));
+    fn test_new_from_dirs_keeps_order_and_drops_duplicates() {
+        let builder = QemuPathBuilder::new_from_dirs(
+            ["/a", "/b", "/a", "/c", "/b"].map(PathBuf::from).to_vec(),
+        );
+
+        assert_eq!(builder.get_dirs(), ["/a", "/b", "/c"].map(PathBuf::from));
     }
 
     #[test]
     fn test_build_round_trips_through_path() {
-        let builder = QemuPathBuilder::new();
+        let builder =
+            QemuPathBuilder::new_from_dirs(["/a", "/b", "/c"].map(PathBuf::from).to_vec());
+
         let joined = builder.build();
+
         let split: Vec<PathBuf> = std::env::split_paths(&joined).collect();
         assert_eq!(split, builder.get_dirs());
-    }
-
-    #[test]
-    fn test_dirs_are_deduped() {
-        let builder = QemuPathBuilder::new();
-        let dirs = builder.get_dirs();
-        let mut sorted = dirs.to_vec();
-        sorted.sort();
-        sorted.dedup();
-        assert_eq!(
-            sorted.len(),
-            dirs.len(),
-            "dirs should contain no duplicates"
-        );
     }
 }

--- a/src/util/async_caller.rs
+++ b/src/util/async_caller.rs
@@ -31,13 +31,6 @@ mod tests {
     }
 
     #[test]
-    fn test_two_async_calls() {
-        let caller = AsyncCaller::new();
-        assert_eq!(5, caller.call(sum(2, 3)));
-        assert_eq!(3, caller.call(sum(1, 2)));
-    }
-
-    #[test]
     fn test_multiple_runtime_async_calls() {
         let caller1 = AsyncCaller::new();
         let caller2 = AsyncCaller::new();

--- a/src/util/hex.rs
+++ b/src/util/hex.rs
@@ -14,4 +14,14 @@ mod tests {
     fn test_hex_encode_foobar() {
         assert_eq!(hex_encode("foobar".as_bytes()).as_str(), "666f6f626172");
     }
+
+    #[test]
+    fn test_hex_encode_pads_small_bytes_with_zero() {
+        assert_eq!(hex_encode(&[0x00, 0x0f, 0xa0]).as_str(), "000fa0");
+    }
+
+    #[test]
+    fn test_hex_encode_empty_input() {
+        assert_eq!(hex_encode(&[]).as_str(), "");
+    }
 }

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -33,6 +33,11 @@ mod tests {
     }
 
     #[test]
+    fn test_find_extract_without_match() {
+        assert!(find_and_extract(">([a-z]+)/<", "no listing here").is_empty());
+    }
+
+    #[test]
     fn test_to_yes_no() {
         assert_eq!(to_yes_no(true), "yes");
         assert_eq!(to_yes_no(false), "no");

--- a/src/util/system_command.rs
+++ b/src/util/system_command.rs
@@ -180,22 +180,4 @@ mod tests {
             "cubic -a -b"
         )
     }
-
-    #[test]
-    fn test_run_reports_missing_system_command() {
-        let program = "cubic-missing-command-test";
-
-        let err = SystemCommand::new(program).run().unwrap_err();
-
-        assert!(matches!(err, Error::SystemCommandNotFound(ref missing) if missing == program));
-    }
-
-    #[test]
-    fn test_output_reports_missing_system_command() {
-        let program = "cubic-missing-command-test";
-
-        let err = SystemCommand::new(program).output().unwrap_err();
-
-        assert!(matches!(err, Error::SystemCommandNotFound(ref missing) if missing == program));
-    }
 }


### PR DESCRIPTION
## Summary

This cleans up the test suite. It fixes broken tests, removes flaky and duplicate tests, and adds coverage for parts of the code that had none.

## Changes

* Fixed broken assertions and misleading test names
* Made `QemuPathBuilder` testable by injecting the directory list instead of reading the environment
* Removed tests that depended on the host environment or repeated the same check
* Added tests for error paths in parsers and models
* Added tests for image provider parsing
* Added tests for port listing and command guards
* Made test mocks more flexible so more code paths can be tested