### PR TITLE
docs: allow ci, test, perf, style, build commit prefixes

### DIFF
--- a/.github/scripts/check-pr-commits.sh
+++ b/.github/scripts/check-pr-commits.sh
@@ -19,7 +19,7 @@ for revision in "$base_sha" "$head_sha"; do
 done
 
 # Match the commit type prefixes documented in CONTRIBUTING.md.
-commit_subject='^(feat|fix|refactor|docs|chore|revert): .+'
+commit_subject='^(feat|fix|perf|refactor|style|docs|test|build|ci|chore|revert): .+'
 
 has_error=0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,8 +150,13 @@ General guideline:
 - Each Git commit message must start with either:
   - `feat: ...` for features
   - `fix: ...` for bug and security fixes
+  - `perf: ...` for performance improvements
   - `refactor: ...` for code refactorings
+  - `style: ...` for formatting or whitespace changes with no logic change
   - `docs: ...` for documentation changes
+  - `test: ...` for adding or correcting tests
+  - `build: ...` for build system or dependency changes
+  - `ci: ...` for CI/CD pipeline changes
   - `chore: ...` for changes not related to source code
   - `revert: ...` for reverting a previous commit
 


### PR DESCRIPTION
The commit message check only allowed feat, fix, refactor, docs, chore, and revert. This was missing common types like ci and test, even though old commits in this repo already used them.

Add perf, style, test, build, and ci to both the check script and the contributing guide, so the full standard set of commit types is now allowed.