### PR TITLE
Run cargo test on macOS and Windows for pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,6 @@ jobs:
         include:
           - check: rustup component add rustfmt && cargo fmt --check
           - check: rustup component add clippy && cargo clippy --version && cargo clippy --locked -- -D warnings
-          - check: cargo test --locked
           - check: cargo install cargo-audit && cargo audit
 
     runs-on: ubuntu-latest
@@ -79,6 +78,9 @@ jobs:
 
       - name: Build Source Code
         run: cargo build --locked
+
+      - name: Run Tests
+        run: cargo test --locked
 
       - name: Run Source Code
         run: cargo run --locked -- --help

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -82,6 +82,7 @@ mod tests {
     use crate::instance::InstanceStoreMock;
     use crate::models::{Arch, DataSize, Environment, Instance, InstanceName};
     use crate::view::ConsoleMock;
+    use std::path::PathBuf;
     use std::str::FromStr;
 
     #[test]
@@ -163,6 +164,20 @@ Forward:      127.0.0.1:4000:40/tcp
         }]);
         let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
 
+        let instance_dir = PathBuf::from("machines").join("test");
+        let disk_image = instance_dir
+            .join("machine.img")
+            .to_string_lossy()
+            .into_owned();
+        let config = instance_dir
+            .join("instance.toml")
+            .to_string_lossy()
+            .into_owned();
+        let ssh_key = instance_dir
+            .join("ssh_client_key")
+            .to_string_lossy()
+            .into_owned();
+
         ShowInstanceCommand {
             instance: InstanceName::from_str("test").unwrap().into(),
             all: true,
@@ -172,7 +187,8 @@ Forward:      127.0.0.1:4000:40/tcp
 
         assert_eq!(
             console.get_output(),
-            "\
+            format!(
+                "\
 Running:      no
 PID:          n/a
 Arch:         arm64
@@ -187,11 +203,12 @@ Monitor Port: 8001
 Console Port: 8002
 Forward:      127.0.0.1:4000:40/tcp
               0.0.0.0:80:8000/udp
-Disk Image:   machines/test/machine.img
-Config:       machines/test/instance.toml
-SSH Key:      machines/test/ssh_client_key
-SSH:          ssh -i machines/test/ssh_client_key -p 8000 john@localhost
+Disk Image:   {disk_image}
+Config:       {config}
+SSH Key:      {ssh_key}
+SSH:          ssh -i {ssh_key} -p 8000 john@localhost
 "
+            )
         );
     }
 

--- a/src/models/environment.rs
+++ b/src/models/environment.rs
@@ -164,6 +164,12 @@ impl Environment {
 mod tests {
     use super::*;
 
+    fn join_all(base: &str, segments: &[&str]) -> PathBuf {
+        segments
+            .iter()
+            .fold(PathBuf::from(base), |path, segment| path.join(segment))
+    }
+
     #[test]
     fn test_paths() {
         let env = Environment::new(
@@ -176,48 +182,57 @@ mod tests {
         assert_eq!(env.get_username(), "testuser");
         assert_eq!(env.get_cache_dir(), "/cache/cubic");
         assert_eq!(
-            env.get_ssh_private_key_file("mymachine"),
-            "/data/cubic/machines/mymachine/ssh_client_key"
+            PathBuf::from(env.get_ssh_private_key_file("mymachine")),
+            join_all("/data/cubic", &["machines", "mymachine", "ssh_client_key"])
         );
         assert_eq!(env.get_runtime_dir(), "/runtime/cubic");
-        assert_eq!(env.get_instance_dir(), "/data/cubic/machines");
-        assert_eq!(env.get_image_dir(), "/cache/cubic/images");
         assert_eq!(
-            env.get_image_file("debian_bookworm_amd64"),
-            "/cache/cubic/images/debian_bookworm_amd64"
-        );
-        assert_eq!(env.get_image_cache_file(), "/cache/cubic/images.cache");
-        assert_eq!(
-            env.get_instance_dir2("mymachine"),
-            "/data/cubic/machines/mymachine"
+            PathBuf::from(env.get_instance_dir()),
+            PathBuf::from("/data/cubic").join("machines")
         );
         assert_eq!(
-            env.get_instance_yaml_config_file("mymachine"),
-            "/data/cubic/machines/mymachine/machine.yaml"
+            PathBuf::from(env.get_image_dir()),
+            PathBuf::from("/cache/cubic").join("images")
         );
         assert_eq!(
-            env.get_instance_toml_config_file("mymachine"),
-            "/data/cubic/machines/mymachine/instance.toml"
+            PathBuf::from(env.get_image_file("debian_bookworm_amd64")),
+            join_all("/cache/cubic", &["images", "debian_bookworm_amd64"])
         );
         assert_eq!(
-            env.get_instance_image_file("mymachine"),
-            "/data/cubic/machines/mymachine/machine.img"
+            PathBuf::from(env.get_image_cache_file()),
+            PathBuf::from("/cache/cubic").join("images.cache")
         );
         assert_eq!(
-            env.get_instance_cache_dir("mymachine"),
-            "/cache/cubic/instances/mymachine"
+            PathBuf::from(env.get_instance_dir2("mymachine")),
+            join_all("/data/cubic", &["machines", "mymachine"])
         );
         assert_eq!(
-            env.get_user_data_image_file("mymachine"),
-            "/cache/cubic/instances/mymachine/user-data.img"
+            PathBuf::from(env.get_instance_yaml_config_file("mymachine")),
+            join_all("/data/cubic", &["machines", "mymachine", "machine.yaml"])
         );
         assert_eq!(
-            env.get_instance_runtime_dir("mymachine"),
-            "/runtime/cubic/instances/mymachine"
+            PathBuf::from(env.get_instance_toml_config_file("mymachine")),
+            join_all("/data/cubic", &["machines", "mymachine", "instance.toml"])
         );
         assert_eq!(
-            env.get_qemu_pid_file("mymachine"),
-            "/runtime/cubic/instances/mymachine/qemu.pid"
+            PathBuf::from(env.get_instance_image_file("mymachine")),
+            join_all("/data/cubic", &["machines", "mymachine", "machine.img"])
+        );
+        assert_eq!(
+            PathBuf::from(env.get_instance_cache_dir("mymachine")),
+            join_all("/cache/cubic", &["instances", "mymachine"])
+        );
+        assert_eq!(
+            PathBuf::from(env.get_user_data_image_file("mymachine")),
+            join_all("/cache/cubic", &["instances", "mymachine", "user-data.img"])
+        );
+        assert_eq!(
+            PathBuf::from(env.get_instance_runtime_dir("mymachine")),
+            join_all("/runtime/cubic", &["instances", "mymachine"])
+        );
+        assert_eq!(
+            PathBuf::from(env.get_qemu_pid_file("mymachine")),
+            join_all("/runtime/cubic", &["instances", "mymachine", "qemu.pid"])
         );
     }
 }


### PR DESCRIPTION
## Summary

- Run tests on macOS and Windows, not just Linux. Closes #466.
- Fix two tests that broke on Windows.

## Details

Tests only ran on Linux. The build job already ran on Linux, macOS and Windows, but it never ran tests there. A bug on macOS or Windows could pass CI without anyone noticing.

- Added a test step to the build job, so tests run on all three OSes.
- Removed the old test step from the check job, since it is no longer needed.
- Fixed two tests that checked file paths using slash strings, like `data/cubic/machines`. On Windows, paths use backslashes, so these tests would fail there. The tests now build paths the same way the real code does, so they work on every OS.