### PR TITLE
docs: add GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+A clear and concise description of what this pull request changes and why.
+
+## Related Issue(s)
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Other
+
+## Test Plan
+
+Describe how you verified this change works as intended.
+
+## Checklist
+
+- [ ] This pull request has exactly one intent
+- [ ] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
+- [ ] Formatting, lint, and tests pass locally
+- [ ] Documentation was updated if needed


### PR DESCRIPTION
Add .github/PULL_REQUEST_TEMPLATE.md so new pull requests are pre-filled with a consistent structure: summary, related issues, type of change, test plan, and a checklist pointing back to the rules already documented in CONTRIBUTING.md (signed-off commits, Conventional Commit prefixes, one intent per PR).

Matches the plain heading style already used in the existing .github/ISSUE_TEMPLATE files.