### PR TITLE
fix: update yanked spin dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
## Summary

spin 0.9.8 was yanked from crates.io. It's pulled in transitively via lazy_static (used by both rcgen's x509-parser and rsa's num-bigint-dig). Bump it to 0.9.9, which lazy_static's existing `^0.9.8` requirement already allows, so no `Cargo.toml` change is needed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

- `make audit` no longer reports the yanked-crate warning for `spin`.
- `make test` passes (150 tests).

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed