### PR TITLE
fix: resolve username from environment variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0"
 sha2 = "0.11"
-sysinfo = { version = "0", default-features = false, features = ["system", "user"] }
+sysinfo = { version = "0", default-features = false, features = ["system"] }
 thiserror = "2"
 tokio = { version = "1", default-features = false, features = ["fs", "io-std"] }
 toml = "1"

--- a/src/env/environment_factory.rs
+++ b/src/env/environment_factory.rs
@@ -1,10 +1,10 @@
 use crate::error::{Error, Result};
 use crate::models::Environment;
 use std::env;
-use sysinfo::{ProcessesToUpdate, System, Users};
 
 const ROOT_USERNAME: &str = "root";
 pub const DEFAULT_USERNAME: &str = "cubic";
+const USERNAME_ENV_VARS: [&str; 3] = ["USER", "LOGNAME", "USERNAME"];
 
 pub struct EnvironmentFactory;
 
@@ -14,14 +14,7 @@ impl EnvironmentFactory {
     }
 
     fn read_current_username() -> Option<String> {
-        let pid = sysinfo::get_current_pid().ok()?;
-        let mut system = System::new();
-        system.refresh_processes(ProcessesToUpdate::Some(&[pid]), false);
-        let uid = system.process(pid)?.user_id()?;
-        let users = Users::new_with_refreshed_list();
-        users
-            .get_user_by_id(uid)
-            .map(|user| user.name().to_string())
+        USERNAME_ENV_VARS.iter().find_map(|var| env::var(var).ok())
     }
 
     pub fn get_username() -> String {


### PR DESCRIPTION
## Summary

Username resolution used to scan the system user database through `sysinfo` for the current process owner. That database is not reachable from inside Snap confinement, so every Snap install silently fell back to the default username instead of showing the real one. This switches the lookup to read `USER`, `LOGNAME`, and `USERNAME` environment variables instead, which Snap passes through and which cover Unix and Windows conventions in one cross platform check. The now unused `sysinfo` `user` feature is also dropped.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Ran `make test` and `make lint` locally, all passing. Manually reasoned through the fallback order (USER, then LOGNAME, then USERNAME, then default) and the existing root-to-default collapse, both unchanged from prior behavior.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed