### PR TITLE
ci: pin cargo-audit install to its own lockfile

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - check: rustup component add rustfmt && cargo fmt --check
           - check: rustup component add clippy && cargo clippy --version && cargo clippy --locked -- -D warnings
-          - check: cargo install cargo-audit && cargo audit
+          - check: cargo install cargo-audit --locked && cargo audit
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

cargo install cargo-audit resolves dependencies fresh instead of using cargo-audit's bundled Cargo.lock. That let it pull in a kstring release requiring rustc 1.96.0, breaking the check under this repo's pinned rustc 1.92.0 toolchain. Passing --locked makes cargo install respect cargo-audit's shipped lockfile, avoiding the unwanted dependency bump.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed
