### PR TITLE
refactor: add System trait for testable env var access

### DIFF
--- a/src/actions/create_instance_action.rs
+++ b/src/actions/create_instance_action.rs
@@ -32,7 +32,7 @@ impl CreateInstanceAction {
         // Create SSH key
         SshKeyGenerator::new().generate_key(&Path::new(tmp_dir).join("ssh_client_key"))?;
 
-        let qemu_img = QemuImg::new();
+        let qemu_img = QemuImg::new(context.get_system());
 
         // Create virtual machine instance image file
         qemu_img.convert(image_path, tmp_image)?;

--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -45,9 +45,10 @@ impl StartInstanceAction {
         self.instance.console_port = Some(port_checker.get_new_port()?);
         context.get_instance_store().store(&self.instance)?;
 
-        let mut qemu_system = QemuSystem::from(self.instance.arch)?;
+        let system = context.get_system();
+        let mut qemu_system = QemuSystem::from(system, self.instance.arch)?;
 
-        let path_builder = QemuPathBuilder::new();
+        let path_builder = QemuPathBuilder::new(system);
         console.debug(&format!(
             "Searching for QEMU in: {}",
             path_builder
@@ -66,7 +67,7 @@ impl StartInstanceAction {
             None => console.debug("No QEMU install found"),
         }
 
-        let firmware = QemuFirmware::locate(path_builder.get_dirs(), self.instance.arch)
+        let firmware = QemuFirmware::locate(system, path_builder.get_dirs(), self.instance.arch)
             .ok_or(Error::QemuNotFound)?;
         console.debug(&format!("Using firmware '{}'", firmware.display()));
         qemu_system.set_firmware(&firmware);

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -71,7 +71,9 @@ mod tests {
     use crate::instance::InstanceStoreMock;
     use crate::models::Environment;
     use crate::models::Instance;
+    use crate::platform::SystemMock;
     use crate::view::ConsoleMock;
+    use std::rc::Rc;
     use std::str::FromStr;
 
     fn build_context(instances: Vec<Instance>) -> Context {
@@ -82,6 +84,7 @@ mod tests {
             String::new(),
         );
         Context::new(
+            Rc::new(SystemMock::new()),
             env,
             Box::new(ImageStoreMock::default()),
             Box::new(InstanceStoreMock::new(instances)),
@@ -124,6 +127,7 @@ mod tests {
             String::new(),
         );
         let context = Context::new(
+            Rc::new(SystemMock::new()),
             env,
             Box::new(ImageStoreMock::default()),
             Box::new(InstanceStoreMock::new_with_running(

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -3,8 +3,10 @@ use crate::env::EnvironmentFactory;
 use crate::error::Result;
 use crate::image::ImageDao;
 use crate::instance::InstanceDao;
+use crate::platform::System;
 use crate::view::Console;
 use clap::{CommandFactory, Parser, Subcommand};
+use std::rc::Rc;
 
 #[derive(Subcommand)]
 pub enum Commands {
@@ -96,7 +98,7 @@ pub struct CommandDispatcher {
 }
 
 impl CommandDispatcher {
-    pub fn dispatch(self, console: &mut dyn Console) -> Result<()> {
+    pub fn dispatch(self, system: Rc<dyn System>, console: &mut dyn Console) -> Result<()> {
         let Some(command) = self.command else {
             println!("{}", CommandDispatcher::command().render_long_help());
             return Ok(());
@@ -106,11 +108,12 @@ impl CommandDispatcher {
             self.global.verbose,
             self.global.quiet,
         ));
-        let env = EnvironmentFactory::create_env()?;
+        let env = EnvironmentFactory::create_env(system.as_ref())?;
         let context = &commands::Context::new(
+            Rc::clone(&system),
             env.clone(),
             Box::new(ImageDao::new(&env)?),
-            Box::new(InstanceDao::new(&env)?),
+            Box::new(InstanceDao::new(Rc::clone(&system), &env)?),
         );
 
         let result = match &command {

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -1,8 +1,11 @@
 use crate::image::ImageStore;
 use crate::instance::InstanceStore;
 use crate::models::Environment;
+use crate::platform::System;
+use std::rc::Rc;
 
 pub struct Context {
+    system: Rc<dyn System>,
     env: Environment,
     image_store: Box<dyn ImageStore>,
     instance_store: Box<dyn InstanceStore>,
@@ -10,15 +13,21 @@ pub struct Context {
 
 impl Context {
     pub fn new(
+        system: Rc<dyn System>,
         env: Environment,
         image_store: Box<dyn ImageStore>,
         instance_store: Box<dyn InstanceStore>,
     ) -> Self {
         Self {
+            system,
             env,
             image_store,
             instance_store,
         }
+    }
+
+    pub fn get_system(&self) -> &dyn System {
+        self.system.as_ref()
     }
 
     pub fn get_env(&self) -> &Environment {

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -135,7 +135,9 @@ mod tests {
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
     use crate::models::Environment;
+    use crate::platform::SystemMock;
     use crate::view::ConsoleMock;
+    use std::rc::Rc;
 
     #[test]
     fn test_create_rejects_existing_instance_name() {
@@ -147,6 +149,7 @@ mod tests {
             String::new(),
         );
         let context = Context::new(
+            Rc::new(SystemMock::new()),
             env,
             Box::new(ImageStoreMock::default()),
             Box::new(InstanceStoreMock::new(vec![Instance {

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -75,7 +75,9 @@ mod tests {
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
     use crate::models::Environment;
+    use crate::platform::SystemMock;
     use crate::view::ConsoleMock;
+    use std::rc::Rc;
 
     #[test]
     fn test_reject_path_traversal() {
@@ -92,6 +94,7 @@ mod tests {
             String::new(),
         );
         let context = commands::Context::new(
+            Rc::new(SystemMock::new()),
             env,
             Box::new(ImageStoreMock::default()),
             Box::new(InstanceStoreMock::new(Vec::new())),

--- a/src/commands/exec_command.rs
+++ b/src/commands/exec_command.rs
@@ -49,8 +49,8 @@ impl Command for ExecCommand {
             "Executing on '{name}' as '{user}' on port {ssh_port} using key '{client_key}': {}",
             self.cmd
         ));
-        let mut ssh = Russh::new();
-        ssh.set_private_keys(env.get_home_ssh_private_key_paths(&FS::new()));
+        let mut ssh = Russh::new(context);
+        ssh.set_private_keys(env.get_home_ssh_private_key_paths(context.get_system(), &FS::new()));
         ssh.set_cmd(Some(self.cmd.clone()));
         ssh.set_env_vars(self.env_args.env_vars.clone());
         ssh.shell(console, name.as_str(), &client_key, &user, ssh_port);

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -68,7 +68,9 @@ mod tests {
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
     use crate::models::{Arch, DataSize, Environment, Instance};
+    use crate::platform::SystemMock;
     use crate::view::ConsoleMock;
+    use std::rc::Rc;
 
     #[test]
     fn test_list_instance_command() {
@@ -104,7 +106,12 @@ mod tests {
                 ..Instance::default()
             },
         ]);
-        let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
+        let context = commands::Context::new(
+            Rc::new(SystemMock::new()),
+            env,
+            Box::new(image_store),
+            Box::new(instance_store),
+        );
 
         ListInstanceCommand {}.run(console, &context).unwrap();
 
@@ -129,7 +136,12 @@ PID   Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
             String::new(),
             String::new(),
         );
-        let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
+        let context = commands::Context::new(
+            Rc::new(SystemMock::new()),
+            env,
+            Box::new(image_store),
+            Box::new(instance_store),
+        );
 
         ListInstanceCommand {}.run(console, &context).unwrap();
 

--- a/src/commands/list_port_command.rs
+++ b/src/commands/list_port_command.rs
@@ -70,7 +70,9 @@ mod tests {
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
     use crate::models::{Environment, Instance};
+    use crate::platform::SystemMock;
     use crate::view::ConsoleMock;
+    use std::rc::Rc;
 
     fn build_context(instances: Vec<Instance>) -> commands::Context {
         let env = Environment::new(
@@ -80,6 +82,7 @@ mod tests {
             String::new(),
         );
         commands::Context::new(
+            Rc::new(SystemMock::new()),
             env,
             Box::new(ImageStoreMock::default()),
             Box::new(InstanceStoreMock::new(instances)),

--- a/src/commands/modify_command.rs
+++ b/src/commands/modify_command.rs
@@ -105,7 +105,9 @@ mod tests {
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
     use crate::models::{Environment, Instance};
+    use crate::platform::SystemMock;
     use crate::view::ConsoleMock;
+    use std::rc::Rc;
 
     fn build_context(instance_store: InstanceStoreMock) -> commands::Context {
         let env = Environment::new(
@@ -115,6 +117,7 @@ mod tests {
             String::new(),
         );
         commands::Context::new(
+            Rc::new(SystemMock::new()),
             env,
             Box::new(ImageStoreMock::default()),
             Box::new(instance_store),

--- a/src/commands/rename_command.rs
+++ b/src/commands/rename_command.rs
@@ -38,7 +38,9 @@ mod tests {
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
     use crate::models::{Environment, Instance};
+    use crate::platform::SystemMock;
     use crate::view::ConsoleMock;
+    use std::rc::Rc;
     use std::str::FromStr;
 
     fn build_context(instances: Vec<Instance>) -> commands::Context {
@@ -49,6 +51,7 @@ mod tests {
             String::new(),
         );
         commands::Context::new(
+            Rc::new(SystemMock::new()),
             env,
             Box::new(ImageStoreMock::default()),
             Box::new(InstanceStoreMock::new(instances)),

--- a/src/commands/scp_command.rs
+++ b/src/commands/scp_command.rs
@@ -6,7 +6,6 @@ use crate::models::TargetPath;
 use crate::ssh_cmd::Russh;
 use crate::view::Console;
 use clap::Parser;
-use std::env;
 
 fn check_target_is_running(instance_store: &dyn InstanceStore, target: &TargetPath) -> Result<()> {
     if let Some(target) = target.get_target() {
@@ -53,7 +52,10 @@ impl Command for ScpCommand {
         check_target_is_running(instance_store, &self.to)?;
 
         let env = context.get_env();
-        let root_dir = env::var("SNAP").unwrap_or_default();
+        let root_dir = context
+            .get_system()
+            .read_env_var("SNAP")
+            .unwrap_or_default();
 
         let from = resolve_target_path(&self.from, instance_store)?;
         let to = resolve_target_path(&self.to, instance_store)?;
@@ -68,8 +70,8 @@ impl Command for ScpCommand {
 
         console.debug(&format!("Copying '{}' to '{}'", self.from, self.to));
 
-        let mut ssh = Russh::new();
-        ssh.set_private_keys(env.get_home_ssh_private_key_paths(&FS::new()));
+        let mut ssh = Russh::new(context);
+        ssh.set_private_keys(env.get_home_ssh_private_key_paths(context.get_system(), &FS::new()));
         ssh.copy(
             console,
             &root_dir,

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -85,7 +85,9 @@ mod tests {
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
     use crate::models::{Environment, Instance};
+    use crate::platform::SystemMock;
     use crate::view::ConsoleMock;
+    use std::rc::Rc;
     use std::str::FromStr;
 
     fn build_context(instances: Vec<Instance>) -> commands::Context {
@@ -96,6 +98,7 @@ mod tests {
             String::new(),
         );
         commands::Context::new(
+            Rc::new(SystemMock::new()),
             env,
             Box::new(ImageStoreMock::default()),
             Box::new(InstanceStoreMock::new(instances)),

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -81,8 +81,10 @@ mod tests {
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
     use crate::models::{Arch, DataSize, Environment, Instance, InstanceName};
+    use crate::platform::SystemMock;
     use crate::view::ConsoleMock;
     use std::path::PathBuf;
+    use std::rc::Rc;
     use std::str::FromStr;
 
     #[test]
@@ -106,7 +108,12 @@ mod tests {
             hostfwd: vec!["127.0.0.1:4000:40/tcp".parse().unwrap()],
             ..Instance::default()
         }]);
-        let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
+        let context = commands::Context::new(
+            Rc::new(SystemMock::new()),
+            env,
+            Box::new(image_store),
+            Box::new(instance_store),
+        );
 
         ShowInstanceCommand {
             instance: InstanceName::from_str("test").unwrap().into(),
@@ -162,7 +169,12 @@ Forward:      127.0.0.1:4000:40/tcp
             isolate: true,
             ..Instance::default()
         }]);
-        let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
+        let context = commands::Context::new(
+            Rc::new(SystemMock::new()),
+            env,
+            Box::new(image_store),
+            Box::new(instance_store),
+        );
 
         let instance_dir = PathBuf::from("machines").join("test");
         let disk_image = instance_dir
@@ -223,7 +235,12 @@ SSH:          ssh -i {ssh_key} -p 8000 john@localhost
         );
         let instance_store = InstanceStoreMock::new(Vec::new());
         let image_store = ImageStoreMock::default();
-        let context = commands::Context::new(env, Box::new(image_store), Box::new(instance_store));
+        let context = commands::Context::new(
+            Rc::new(SystemMock::new()),
+            env,
+            Box::new(image_store),
+            Box::new(instance_store),
+        );
 
         assert!(matches!(
             ShowInstanceCommand {

--- a/src/commands/ssh_command.rs
+++ b/src/commands/ssh_command.rs
@@ -49,8 +49,8 @@ impl Command for SshCommand {
         console.debug(&format!(
             "Connecting to '{name}' as '{user}' on port {ssh_port} using key '{client_key}'"
         ));
-        let mut ssh = Russh::new();
-        ssh.set_private_keys(env.get_home_ssh_private_key_paths(&FS::new()));
+        let mut ssh = Russh::new(context);
+        ssh.set_private_keys(env.get_home_ssh_private_key_paths(context.get_system(), &FS::new()));
         ssh.set_env_vars(self.env_args.env_vars.clone());
         ssh.shell(console, name.as_str(), &client_key, &user, ssh_port);
         Ok(())

--- a/src/commands/stop_command.rs
+++ b/src/commands/stop_command.rs
@@ -83,7 +83,9 @@ mod tests {
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
     use crate::models::Environment;
+    use crate::platform::SystemMock;
     use crate::view::ConsoleMock;
+    use std::rc::Rc;
 
     #[test]
     fn test_reject_path_traversal() {
@@ -100,6 +102,7 @@ mod tests {
             String::new(),
         );
         let context = commands::Context::new(
+            Rc::new(SystemMock::new()),
             env,
             Box::new(ImageStoreMock::default()),
             Box::new(InstanceStoreMock::new(Vec::new())),
@@ -127,6 +130,7 @@ mod tests {
             String::new(),
         );
         let context = commands::Context::new(
+            Rc::new(SystemMock::new()),
             env,
             Box::new(ImageStoreMock::default()),
             Box::new(InstanceStoreMock::new(Vec::new())),

--- a/src/env/environment_factory.rs
+++ b/src/env/environment_factory.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use crate::models::Environment;
-use std::env;
+use crate::platform::System;
 
 const ROOT_USERNAME: &str = "root";
 pub const DEFAULT_USERNAME: &str = "cubic";
@@ -9,17 +9,21 @@ const USERNAME_ENV_VARS: [&str; 3] = ["USER", "LOGNAME", "USERNAME"];
 pub struct EnvironmentFactory;
 
 impl EnvironmentFactory {
-    fn read_env(var: &str) -> Result<String> {
-        env::var(var).map_err(|_| Error::UnsetEnvVar(var.to_string()))
+    fn read_env(system: &dyn System, var: &str) -> Result<String> {
+        system
+            .read_env_var(var)
+            .ok_or_else(|| Error::UnsetEnvVar(var.to_string()))
     }
 
-    fn read_current_username() -> Option<String> {
-        USERNAME_ENV_VARS.iter().find_map(|var| env::var(var).ok())
+    fn read_current_username(system: &dyn System) -> Option<String> {
+        USERNAME_ENV_VARS
+            .iter()
+            .find_map(|var| system.read_env_var(var))
     }
 
-    pub fn get_username() -> String {
+    pub fn get_username(system: &dyn System) -> String {
         let username =
-            Self::read_current_username().unwrap_or_else(|| DEFAULT_USERNAME.to_string());
+            Self::read_current_username(system).unwrap_or_else(|| DEFAULT_USERNAME.to_string());
         if username == ROOT_USERNAME {
             DEFAULT_USERNAME.to_string()
         } else {
@@ -28,17 +32,19 @@ impl EnvironmentFactory {
     }
 
     #[cfg(target_os = "linux")]
-    pub fn create_env() -> Result<Environment> {
-        let data_dir = Self::read_env("SNAP_USER_COMMON")
-            .or_else(|_| Self::read_env("XDG_DATA_HOME"))
-            .or_else(|_| Self::read_env("HOME").map(|home| format!("{home}/.local/share")))?;
-        let cache_dir = Self::read_env("XDG_CACHE_HOME")
-            .or_else(|_| Self::read_env("HOME").map(|home| format!("{home}/.cache")))?;
-        let runtime_dir = Self::read_env("XDG_RUNTIME_DIR")
-            .or_else(|_| Self::read_env("UID").map(|uid| format!("/run/user/{uid}")))?;
+    pub fn create_env(system: &dyn System) -> Result<Environment> {
+        let data_dir = Self::read_env(system, "SNAP_USER_COMMON")
+            .or_else(|_| Self::read_env(system, "XDG_DATA_HOME"))
+            .or_else(|_| {
+                Self::read_env(system, "HOME").map(|home| format!("{home}/.local/share"))
+            })?;
+        let cache_dir = Self::read_env(system, "XDG_CACHE_HOME")
+            .or_else(|_| Self::read_env(system, "HOME").map(|home| format!("{home}/.cache")))?;
+        let runtime_dir = Self::read_env(system, "XDG_RUNTIME_DIR")
+            .or_else(|_| Self::read_env(system, "UID").map(|uid| format!("/run/user/{uid}")))?;
 
         Ok(Environment::new(
-            Self::get_username(),
+            Self::get_username(system),
             format!("{data_dir}/cubic"),
             format!("{cache_dir}/cubic"),
             format!("{runtime_dir}/cubic"),
@@ -46,11 +52,11 @@ impl EnvironmentFactory {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn create_env() -> Result<Environment> {
-        let home_dir = Self::read_env("HOME")?;
+    pub fn create_env(system: &dyn System) -> Result<Environment> {
+        let home_dir = Self::read_env(system, "HOME")?;
 
         Ok(Environment::new(
-            Self::get_username(),
+            Self::get_username(system),
             format!("{home_dir}/Library/cubic"),
             format!("{home_dir}/Library/Caches/cubic"),
             format!("{home_dir}/Library/Caches/cubic"),
@@ -58,15 +64,100 @@ impl EnvironmentFactory {
     }
 
     #[cfg(target_os = "windows")]
-    pub fn create_env() -> Result<Environment> {
-        let local_app_data_dir = Self::read_env("LOCALAPPDATA")?;
-        let temp_dir = Self::read_env("TEMP")?;
+    pub fn create_env(system: &dyn System) -> Result<Environment> {
+        let local_app_data_dir = Self::read_env(system, "LOCALAPPDATA")?;
+        let temp_dir = Self::read_env(system, "TEMP")?;
 
         Ok(Environment::new(
-            Self::get_username(),
+            Self::get_username(system),
             format!("{local_app_data_dir}\\cubic"),
             format!("{temp_dir}\\cubic"),
             format!("{temp_dir}\\cubic"),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::SystemMock;
+
+    #[test]
+    fn test_read_current_username_prefers_user_over_logname_and_username() {
+        let system = SystemMock::new()
+            .add_env_var("USER", "alice")
+            .add_env_var("LOGNAME", "bob")
+            .add_env_var("USERNAME", "carol");
+
+        assert_eq!(
+            EnvironmentFactory::read_current_username(&system),
+            Some("alice".to_string())
+        );
+    }
+
+    #[test]
+    fn test_read_current_username_falls_back_to_logname_then_username() {
+        let system = SystemMock::new().add_env_var("USERNAME", "carol");
+
+        assert_eq!(
+            EnvironmentFactory::read_current_username(&system),
+            Some("carol".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_username_falls_back_to_default_when_unset() {
+        let system = SystemMock::new();
+
+        assert_eq!(EnvironmentFactory::get_username(&system), DEFAULT_USERNAME);
+    }
+
+    #[test]
+    fn test_get_username_maps_root_to_default() {
+        let system = SystemMock::new().add_env_var("USER", ROOT_USERNAME);
+
+        assert_eq!(EnvironmentFactory::get_username(&system), DEFAULT_USERNAME);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_create_env_falls_back_through_xdg_and_home() {
+        let system = SystemMock::new()
+            .add_env_var("USER", "alice")
+            .add_env_var("HOME", "/home/alice")
+            .add_env_var("XDG_RUNTIME_DIR", "/run/user/1000");
+
+        let env = EnvironmentFactory::create_env(&system).unwrap();
+
+        assert_eq!(
+            env.get_instance_dir(),
+            "/home/alice/.local/share/cubic/machines"
+        );
+        assert_eq!(env.get_cache_dir(), "/home/alice/.cache/cubic");
+        assert_eq!(env.get_runtime_dir(), "/run/user/1000/cubic");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_create_env_prefers_snap_and_xdg_vars_over_home() {
+        let system = SystemMock::new()
+            .add_env_var("USER", "alice")
+            .add_env_var("SNAP_USER_COMMON", "/snap/cubic/common")
+            .add_env_var("XDG_CACHE_HOME", "/cache")
+            .add_env_var("XDG_RUNTIME_DIR", "/run/user/1000")
+            .add_env_var("HOME", "/home/alice");
+
+        let env = EnvironmentFactory::create_env(&system).unwrap();
+
+        assert_eq!(env.get_instance_dir(), "/snap/cubic/common/cubic/machines");
+        assert_eq!(env.get_cache_dir(), "/cache/cubic");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_create_env_errors_when_no_dir_vars_are_set() {
+        let system = SystemMock::new().add_env_var("USER", "alice");
+
+        assert!(EnvironmentFactory::create_env(&system).is_err());
     }
 }

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -5,20 +5,23 @@ use crate::instance::{
     YamlInstanceDeserializer,
 };
 use crate::models::{DataSize, Environment, Instance, InstanceName};
+use crate::platform::System;
 use crate::qemu::Monitor;
 use crate::qemu::QemuImg;
 use crate::ssh_cmd::PortChecker;
 use std::path::Path;
+use std::rc::Rc;
 use std::str;
 use std::str::FromStr;
 
 pub struct InstanceDao {
     fs: FS,
     pub env: Environment,
+    system: Rc<dyn System>,
 }
 
 impl InstanceDao {
-    pub fn new(env: &Environment) -> Result<Self> {
+    pub fn new(system: Rc<dyn System>, env: &Environment) -> Result<Self> {
         let fs = FS::new();
         fs.setup_directory_access(&env.get_instance_dir())?;
         fs.setup_directory_access(env.get_cache_dir())?;
@@ -27,6 +30,7 @@ impl InstanceDao {
         Ok(InstanceDao {
             fs,
             env: env.clone(),
+            system,
         })
     }
 
@@ -106,7 +110,9 @@ impl InstanceStore for InstanceDao {
                     self.store(&instance).ok();
                 }
 
-                if let Some(info) = QemuImg::new().get_image_info(&self.env, &instance) {
+                if let Some(info) =
+                    QemuImg::new(self.system.as_ref()).get_image_info(&self.env, &instance)
+                {
                     instance.disk_used = Some(DataSize::new(info.actual_size as usize));
                     instance.disk_capacity = DataSize::new(info.virtual_size as usize);
                 }
@@ -164,7 +170,8 @@ impl InstanceStore for InstanceDao {
         } else if instance.disk_capacity.get_bytes() >= size as usize {
             Err(Error::CannotShrinkDisk(instance.name.to_string()))
         } else {
-            QemuImg::new().resize(&self.env.get_instance_image_file(&instance.name), size)?;
+            QemuImg::new(self.system.as_ref())
+                .resize(&self.env.get_instance_image_file(&instance.name), size)?;
             instance.disk_capacity = DataSize::new(size as usize);
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod image;
 mod instance;
 mod iso9660;
 mod models;
+mod platform;
 mod qemu;
 mod ssh_cmd;
 mod util;
@@ -15,9 +16,11 @@ mod view;
 mod web;
 
 use crate::commands::CommandDispatcher;
+use crate::platform::{OsSystem, System};
 use crate::view::Console;
 use clap::Parser;
 use std::process::ExitCode;
+use std::rc::Rc;
 
 fn main() -> ExitCode {
     // Disable raw mode before the default panic hook runs, so a panic during
@@ -30,8 +33,9 @@ fn main() -> ExitCode {
         default_hook(info);
     }));
 
-    let console = &mut view::Stdio::new();
-    match CommandDispatcher::parse().dispatch(console) {
+    let system: Rc<dyn System> = Rc::new(OsSystem::new());
+    let console = &mut view::Stdio::new(system.as_ref());
+    match CommandDispatcher::parse().dispatch(Rc::clone(&system), console) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             console.error(&e.to_string());

--- a/src/models/environment.rs
+++ b/src/models/environment.rs
@@ -1,5 +1,5 @@
 use crate::fs::FS;
-use std::env;
+use crate::platform::System;
 use std::path::PathBuf;
 
 #[derive(Default, Clone)]
@@ -125,12 +125,12 @@ impl Environment {
             .into_owned()
     }
 
-    pub fn get_home_ssh_private_key_paths(&self, fs: &FS) -> Vec<String> {
+    pub fn get_home_ssh_private_key_paths(&self, system: &dyn System, fs: &FS) -> Vec<String> {
         let mut private_keys = Vec::new();
 
         let search_dirs: Vec<String> = ["SNAP_REAL_HOME", "HOME"]
             .iter()
-            .filter_map(|var| env::var(var).ok())
+            .filter_map(|var| system.read_env_var(var))
             .map(|dir| {
                 PathBuf::from(dir)
                     .join(".ssh")

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,6 @@
+mod system;
+mod system_mock;
+
+pub use system::*;
+#[cfg(test)]
+pub use system_mock::tests::SystemMock;

--- a/src/platform/system.rs
+++ b/src/platform/system.rs
@@ -1,0 +1,18 @@
+pub trait System {
+    fn read_env_var(&self, key: &str) -> Option<String>;
+}
+
+#[derive(Default)]
+pub struct OsSystem;
+
+impl OsSystem {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl System for OsSystem {
+    fn read_env_var(&self, key: &str) -> Option<String> {
+        std::env::var(key).ok()
+    }
+}

--- a/src/platform/system_mock.rs
+++ b/src/platform/system_mock.rs
@@ -1,0 +1,42 @@
+#[cfg(test)]
+pub mod tests {
+    use crate::platform::System;
+    use std::collections::HashMap;
+
+    pub struct SystemMock {
+        env_vars: HashMap<String, String>,
+    }
+
+    impl SystemMock {
+        pub fn new() -> Self {
+            Self {
+                env_vars: HashMap::new(),
+            }
+        }
+
+        pub fn add_env_var(mut self, key: &str, value: &str) -> Self {
+            self.env_vars.insert(key.to_string(), value.to_string());
+            self
+        }
+    }
+
+    impl System for SystemMock {
+        fn read_env_var(&self, key: &str) -> Option<String> {
+            self.env_vars.get(key).cloned()
+        }
+    }
+
+    #[test]
+    fn read_env_var_returns_configured_value() {
+        let system = SystemMock::new().add_env_var("FOO", "bar");
+
+        assert_eq!(system.read_env_var("FOO"), Some("bar".to_string()));
+    }
+
+    #[test]
+    fn read_env_var_returns_none_when_not_set() {
+        let system = SystemMock::new();
+
+        assert_eq!(system.read_env_var("FOO"), None);
+    }
+}

--- a/src/qemu/qemu_firmware.rs
+++ b/src/qemu/qemu_firmware.rs
@@ -2,18 +2,19 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::models::Arch;
+use crate::platform::System;
 use crate::qemu::qemu_firmware_descriptor::QemuFirmwareDescriptor;
 use crate::qemu::qemu_path_builder::find_in_dir;
 
 pub struct QemuFirmware;
 
 impl QemuFirmware {
-    pub fn locate(dirs: &[PathBuf], arch: Arch) -> Option<PathBuf> {
+    pub fn locate(system: &dyn System, dirs: &[PathBuf], arch: Arch) -> Option<PathBuf> {
         let var = format!("CUBIC_QEMU_FW_{}", arch.as_vendor_str().to_uppercase());
-        if let Some(fw) = std::env::var_os(&var) {
+        if let Some(fw) = system.read_env_var(&var) {
             return Some(PathBuf::from(fw)); // trust the override as-is
         }
-        QemuInstall::find(dirs)?.find_firmware(arch)
+        QemuInstall::find(dirs)?.find_firmware(system, arch)
     }
 }
 
@@ -78,17 +79,17 @@ impl QemuInstall {
             .any(|entry| entry.path().extension().is_some_and(|ext| ext == "so"))
     }
 
-    fn find_firmware(&self, arch: Arch) -> Option<PathBuf> {
-        self.collect_descriptors()
+    fn find_firmware(&self, system: &dyn System, arch: Arch) -> Option<PathBuf> {
+        self.collect_descriptors(system)
             .into_iter()
             .filter(|descriptor| descriptor.matches(arch))
             .map(|descriptor| descriptor.build_code_path(&self.prefix))
             .find(|code| code.exists())
     }
 
-    fn collect_descriptors(&self) -> Vec<QemuFirmwareDescriptor> {
+    fn collect_descriptors(&self, system: &dyn System) -> Vec<QemuFirmwareDescriptor> {
         let mut by_name: BTreeMap<String, PathBuf> = BTreeMap::new();
-        for dir in self.build_descriptor_dirs() {
+        for dir in self.build_descriptor_dirs(system) {
             for path in Self::find_json_files(&dir) {
                 if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                     by_name.entry(name.to_owned()).or_insert(path);
@@ -101,11 +102,11 @@ impl QemuInstall {
             .collect()
     }
 
-    fn build_descriptor_dirs(&self) -> Vec<PathBuf> {
+    fn build_descriptor_dirs(&self, system: &dyn System) -> Vec<PathBuf> {
         let mut dirs = Vec::new();
-        if let Some(config) = std::env::var_os("XDG_CONFIG_HOME") {
+        if let Some(config) = system.read_env_var("XDG_CONFIG_HOME") {
             dirs.push(PathBuf::from(config).join("qemu/firmware"));
-        } else if let Some(home) = std::env::var_os("HOME") {
+        } else if let Some(home) = system.read_env_var("HOME") {
             dirs.push(PathBuf::from(home).join(".config/qemu/firmware"));
         }
         dirs.push(PathBuf::from("/etc/qemu/firmware"));
@@ -130,6 +131,7 @@ impl QemuInstall {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::SystemMock;
 
     #[test]
     fn test_module_dir_candidates_cover_lib_layouts() {
@@ -143,6 +145,53 @@ mod tests {
                 PathBuf::from("/snap/cubic/current/usr/lib/qemu"),
                 PathBuf::from("/snap/cubic/current/usr/lib64/qemu"),
             ]
+        );
+    }
+
+    #[test]
+    fn test_locate_trusts_override_env_var_without_scanning_dirs() {
+        let system = SystemMock::new().add_env_var("CUBIC_QEMU_FW_AMD64", "/custom/fw.bin");
+
+        let firmware = QemuFirmware::locate(&system, &[], Arch::AMD64);
+
+        assert_eq!(firmware, Some(PathBuf::from("/custom/fw.bin")));
+    }
+
+    #[test]
+    fn test_locate_returns_none_when_no_override_and_no_install_found() {
+        let system = SystemMock::new();
+
+        let firmware = QemuFirmware::locate(&system, &[], Arch::AMD64);
+
+        assert_eq!(firmware, None);
+    }
+
+    #[test]
+    fn test_build_descriptor_dirs_prefers_xdg_config_home_over_home() {
+        let system = SystemMock::new()
+            .add_env_var("XDG_CONFIG_HOME", "/xdg")
+            .add_env_var("HOME", "/home/user");
+        let install = QemuInstall {
+            prefix: PathBuf::from("/prefix"),
+        };
+
+        let dirs = install.build_descriptor_dirs(&system);
+
+        assert_eq!(dirs.first(), Some(&PathBuf::from("/xdg/qemu/firmware")));
+    }
+
+    #[test]
+    fn test_build_descriptor_dirs_falls_back_to_home() {
+        let system = SystemMock::new().add_env_var("HOME", "/home/user");
+        let install = QemuInstall {
+            prefix: PathBuf::from("/prefix"),
+        };
+
+        let dirs = install.build_descriptor_dirs(&system);
+
+        assert_eq!(
+            dirs.first(),
+            Some(&PathBuf::from("/home/user/.config/qemu/firmware"))
         );
     }
 }

--- a/src/qemu/qemu_img.rs
+++ b/src/qemu/qemu_img.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, Result};
 use crate::models::{Environment, Instance};
+use crate::platform::System;
 use crate::qemu::QemuPathBuilder;
 use crate::util::SystemCommand;
 use serde::{Deserialize, Serialize};
@@ -12,16 +13,18 @@ pub struct ImageInfo {
     pub virtual_size: u64,
 }
 
-pub struct QemuImg;
+pub struct QemuImg<'a> {
+    system: &'a dyn System,
+}
 
-impl QemuImg {
-    pub fn new() -> Self {
-        Self {}
+impl<'a> QemuImg<'a> {
+    pub fn new(system: &'a dyn System) -> Self {
+        Self { system }
     }
 
-    fn command() -> SystemCommand {
+    fn command(&self) -> SystemCommand {
         let mut cmd = SystemCommand::new("qemu-img");
-        cmd.set_env("PATH", QemuPathBuilder::new().build());
+        cmd.set_env("PATH", QemuPathBuilder::new(self.system).build());
         cmd
     }
 
@@ -33,7 +36,7 @@ impl QemuImg {
     }
 
     pub fn get_image_info(&self, env: &Environment, instance: &Instance) -> Option<ImageInfo> {
-        Self::command()
+        self.command()
             .arg("info")
             .arg("--force-share")
             .arg("--output")
@@ -46,7 +49,7 @@ impl QemuImg {
     }
 
     pub fn convert(&self, src: &str, dst: &str) -> Result<()> {
-        Self::command()
+        self.command()
             .arg("convert")
             .arg("-f")
             .arg("qcow2")
@@ -59,7 +62,7 @@ impl QemuImg {
     }
 
     pub fn resize(&self, image: &str, size: u64) -> Result<()> {
-        Self::command()
+        self.command()
             .arg("resize")
             .arg(image)
             .arg(size.to_string())

--- a/src/qemu/qemu_path_builder.rs
+++ b/src/qemu/qemu_path_builder.rs
@@ -1,3 +1,4 @@
+use crate::platform::System;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
@@ -19,16 +20,16 @@ pub struct QemuPathBuilder {
 }
 
 impl QemuPathBuilder {
-    pub fn new() -> Self {
+    pub fn new(system: &dyn System) -> Self {
         let mut dirs: Vec<PathBuf> = Vec::new();
 
         // Add QEMU directory override
-        if let Some(dir) = std::env::var_os("CUBIC_QEMU_DIR") {
+        if let Some(dir) = system.read_env_var("CUBIC_QEMU_DIR") {
             dirs.push(PathBuf::from(dir));
         }
 
         // Add system PATH variable
-        if let Some(path) = std::env::var_os("PATH") {
+        if let Some(path) = system.read_env_var("PATH") {
             dirs.extend(std::env::split_paths(&path));
         }
 
@@ -62,12 +63,6 @@ impl QemuPathBuilder {
     }
 }
 
-impl Default for QemuPathBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 pub fn find_in_dir(dir: &Path, name: &str) -> Option<PathBuf> {
     let candidate = dir.join(name);
     if candidate.exists() {
@@ -86,6 +81,45 @@ pub fn find_in_dir(dir: &Path, name: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::SystemMock;
+
+    #[test]
+    fn test_new_puts_cubic_qemu_dir_override_first() {
+        let system = SystemMock::new().add_env_var("CUBIC_QEMU_DIR", "/override/bin");
+
+        let builder = QemuPathBuilder::new(&system);
+
+        assert_eq!(
+            builder.get_dirs().first(),
+            Some(&PathBuf::from("/override/bin"))
+        );
+    }
+
+    #[test]
+    fn test_new_splits_path_variable() {
+        let joined = std::env::join_paths(["/a", "/b"].map(PathBuf::from))
+            .unwrap()
+            .into_string()
+            .unwrap();
+        let system = SystemMock::new().add_env_var("PATH", &joined);
+
+        let builder = QemuPathBuilder::new(&system);
+
+        assert!(builder.get_dirs().contains(&PathBuf::from("/a")));
+        assert!(builder.get_dirs().contains(&PathBuf::from("/b")));
+    }
+
+    #[test]
+    fn test_new_falls_back_to_default_dirs_when_unset() {
+        let system = SystemMock::new();
+
+        let builder = QemuPathBuilder::new(&system);
+
+        assert_eq!(
+            builder.get_dirs(),
+            DEFAULT_DIRS.iter().map(PathBuf::from).collect::<Vec<_>>()
+        );
+    }
 
     #[test]
     fn test_new_from_dirs_keeps_order_and_drops_duplicates() {

--- a/src/qemu/qemu_system.rs
+++ b/src/qemu/qemu_system.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use crate::error::{Error, Result};
 use crate::models::{Arch, PortForward};
+use crate::platform::System;
 use crate::qemu::QemuPathBuilder;
 use crate::util::SystemCommand;
 use crate::view::Console;
@@ -30,7 +31,7 @@ impl QemuSystem {
         }
     }
 
-    pub fn from(arch: Arch) -> Result<QemuSystem> {
+    pub fn from(system: &dyn System, arch: Arch) -> Result<QemuSystem> {
         let binary = format!("qemu-system-{}", arch.as_canonical_str());
         let mut command = match arch {
             Arch::AMD64 => {
@@ -47,7 +48,7 @@ impl QemuSystem {
         };
 
         // Resolve the QEMU binary by name from the extended PATH.
-        command.set_env("PATH", QemuPathBuilder::new().build());
+        command.set_env("PATH", QemuPathBuilder::new(system).build());
 
         // Set CPU type
         command.arg("-cpu").arg("max");
@@ -185,6 +186,7 @@ impl QemuSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::SystemMock;
 
     #[test]
     fn test_map_error_translates_not_found() {
@@ -198,7 +200,7 @@ mod tests {
 
     #[test]
     fn test_add_datadir_appends_dash_l() {
-        let mut qemu = QemuSystem::from(Arch::AMD64).unwrap();
+        let mut qemu = QemuSystem::from(&SystemMock::new(), Arch::AMD64).unwrap();
         qemu.add_datadir(Path::new("/snap/cubic/current/usr/share/qemu"));
         assert!(
             qemu.command
@@ -209,7 +211,7 @@ mod tests {
 
     #[test]
     fn test_from_suppresses_emulated_default_devices() {
-        let qemu = QemuSystem::from(Arch::AMD64).unwrap();
+        let qemu = QemuSystem::from(&SystemMock::new(), Arch::AMD64).unwrap();
         let command = qemu.command.get_command();
         assert!(command.contains("-nodefaults"));
         assert!(!command.contains("-vga none"));
@@ -217,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_from_adds_virtio_rng_with_builtin_backend() {
-        let qemu = QemuSystem::from(Arch::AMD64).unwrap();
+        let qemu = QemuSystem::from(&SystemMock::new(), Arch::AMD64).unwrap();
         let command = qemu.command.get_command();
         assert!(command.contains("rng-builtin,id=rng0"));
         assert!(command.contains("virtio-rng-pci,rng=rng0"));
@@ -225,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_from_adds_virtio_balloon() {
-        let qemu = QemuSystem::from(Arch::ARM64).unwrap();
+        let qemu = QemuSystem::from(&SystemMock::new(), Arch::ARM64).unwrap();
         assert!(qemu.command.get_command().contains("virtio-balloon-pci"));
     }
 

--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -1,3 +1,4 @@
+use crate::commands::Context;
 use crate::error::Error;
 use crate::models::{Instance, TargetInstancePath};
 use crate::ssh_cmd::{SftpPath, SshKeyGenerator};
@@ -6,7 +7,6 @@ use crate::view::{Console, Spinner};
 use russh::keys::*;
 use russh::*;
 use russh_sftp::client::SftpSession;
-use std::env;
 use std::io::Cursor;
 use std::path::Path;
 use std::rc::Rc;
@@ -63,11 +63,11 @@ async fn ssh_output(output: Arc<Mutex<ChannelWriteHalf<client::Msg>>>) -> Result
     }
 }
 
-#[derive(Default)]
-pub struct Russh {
+pub struct Russh<'a> {
     private_keys: Vec<String>,
     cmd: Option<String>,
     env_vars: Vec<String>,
+    context: &'a Context,
 }
 
 struct Client {}
@@ -83,9 +83,14 @@ impl client::Handler for Client {
     }
 }
 
-impl Russh {
-    pub fn new() -> Self {
-        Self::default()
+impl<'a> Russh<'a> {
+    pub fn new(context: &'a Context) -> Self {
+        Self {
+            private_keys: Vec::new(),
+            cmd: None,
+            env_vars: Vec::new(),
+            context,
+        }
     }
 
     async fn authenticate_with_default_password(
@@ -297,7 +302,11 @@ impl Russh {
         channel
             .request_pty(
                 false,
-                &env::var("TERM").unwrap_or_else(|_| "xterm".into()),
+                &self
+                    .context
+                    .get_system()
+                    .read_env_var("TERM")
+                    .unwrap_or_else(|| "xterm".into()),
                 w,
                 h,
                 0,
@@ -311,7 +320,13 @@ impl Russh {
             let (name, value) = if let Some((k, v)) = var.split_once('=') {
                 (k.to_string(), v.to_string())
             } else {
-                (var.clone(), env::var(var).unwrap_or_default())
+                (
+                    var.clone(),
+                    self.context
+                        .get_system()
+                        .read_env_var(var)
+                        .unwrap_or_default(),
+                )
             };
             channel.set_env(false, name, value).await.map_err(|_| ())?;
         }

--- a/src/view/stdio.rs
+++ b/src/view/stdio.rs
@@ -1,4 +1,5 @@
 use crate::commands::Verbosity;
+use crate::platform::System;
 use crate::view::{Animation, Console};
 use crossterm::QueueableCommand;
 use crossterm::cursor::MoveToColumn;
@@ -10,10 +11,6 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 const ANIMATION_TICK_MS: u64 = 100;
-
-fn is_no_color() -> bool {
-    std::env::var_os("NO_COLOR").is_some()
-}
 
 // On Windows, ANSI escape codes are only interpreted once virtual terminal
 // processing is turned on for the console; this call is a no-op elsewhere.
@@ -62,8 +59,8 @@ impl Stream {
         }
     }
 
-    fn print(self, msg: &str, style: Option<(&str, Color)>) {
-        let enabled = style.is_some() && self.is_terminal() && !is_no_color();
+    fn print(self, msg: &str, style: Option<(&str, Color)>, no_color: bool) {
+        let enabled = style.is_some() && self.is_terminal() && !no_color;
         let text = match style {
             Some((label, color)) => format!("{} {msg}", colorize(label, color, enabled)),
             None => msg.to_string(),
@@ -75,15 +72,16 @@ impl Stream {
     }
 }
 
-pub struct Stdio {
+pub struct Stdio<'a> {
     verbosity: Verbosity,
     is_tty: bool,
     state: Arc<AnimationState>,
     thread: Option<JoinHandle<()>>,
+    system: &'a dyn System,
 }
 
-impl Stdio {
-    pub fn new() -> Self {
+impl<'a> Stdio<'a> {
+    pub fn new(system: &'a dyn System) -> Self {
         enable_ansi_support();
         Self {
             verbosity: Verbosity::new(false, false),
@@ -97,7 +95,12 @@ impl Stdio {
                 signal: Condvar::new(),
             }),
             thread: None,
+            system,
         }
+    }
+
+    fn is_no_color(&self) -> bool {
+        self.system.read_env_var("NO_COLOR").is_some()
     }
 
     // Print a message that coexists with a running animation. While an
@@ -105,13 +108,14 @@ impl Stdio {
     // holding the state lock): clear its line, print the message, then redraw a
     // fresh frame immediately so the live line stays just below the output.
     fn emit(&self, stream: Stream, msg: &str, style: Option<(&str, Color)>) {
+        let no_color = self.is_no_color();
         let inner = self.state.inner.lock().unwrap();
         let animation = inner.animation.clone();
         let mut stdout = stdout();
         if animation.is_some() {
             AnimationState::clear_line(&mut stdout);
         }
-        stream.print(msg, style);
+        stream.print(msg, style, no_color);
         if let Some(animation) = animation {
             AnimationState::draw_frame(&mut stdout, &animation);
         }
@@ -184,7 +188,7 @@ impl AnimationState {
     }
 }
 
-impl Console for Stdio {
+impl Console for Stdio<'_> {
     fn set_verbosity(&mut self, verbosity: Verbosity) {
         self.verbosity = verbosity;
     }
@@ -335,7 +339,7 @@ impl Console for Stdio {
     }
 }
 
-impl Drop for Stdio {
+impl Drop for Stdio<'_> {
     fn drop(&mut self) {
         self.stop();
         self.state.inner.lock().unwrap().shutdown = true;


### PR DESCRIPTION
## Summary

Route environment variable reads through a platform::System trait instead of calling std::env directly, so the logic is mockable in tests. Migrate every std::env call site to it and share one OsSystem instance for the process via Context.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Run `make check`.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed
