### PR TITLE
refactor: run AsyncCaller on a single-threaded tokio runtime

### DIFF
--- a/src/util/async_caller.rs
+++ b/src/util/async_caller.rs
@@ -5,7 +5,7 @@ pub struct AsyncCaller {
 impl AsyncCaller {
     pub fn new() -> Self {
         Self {
-            runtime: tokio::runtime::Builder::new_multi_thread()
+            runtime: tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .unwrap(),


### PR DESCRIPTION
## Summary

The multi-thread runtime spawned unused worker threads since AsyncCaller's only caller never spawns cross-thread tasks. Switch to a current-thread runtime to drop the overhead.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Test Plan

Run `make check` and manual tests.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed
