### PR TITLE
docs: redesign landing page layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cubic - Linux VMs in one command</title>
   <meta name="description" content="Cubic spins up Linux virtual machines on Linux, macOS and Windows with a single command. Prebuilt cloud images, no root required, built on QEMU.">
+  <link rel="icon" href="logo-mark.svg" type="image/svg+xml">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Cubic - Linux VMs in one command">
+  <meta property="og:description" content="Cubic spins up Linux virtual machines on Linux, macOS and Windows with a single command. Prebuilt cloud images, no root required, built on QEMU.">
+  <meta property="og:url" content="https://cubic-vm.github.io/cubic/">
+  <meta property="og:image" content="https://cubic-vm.github.io/cubic/cubic.gif">
+  <meta name="twitter:card" content="summary_large_image">
   <style>
     :root {
       --bg: #ffffff;
@@ -12,8 +19,6 @@
       --border: #e3e3e6;
       --fg: #18181b;
       --muted: #5c5c66;
-      --accent: #18181b;
-      --accent-dark: #000000;
       --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
       --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     }
@@ -30,99 +35,127 @@
     }
 
     .page {
-      max-width: 1280px;
+      max-width: 115rem;
       margin: 0 auto;
-      min-height: 100vh;
-      padding: 18px 28px 22px;
-      display: flex;
-      flex-direction: column;
+      padding: 48px 48px 56px;
     }
 
-    /* Top bar */
-    .bar {
+    /* Brand */
+    .brand {
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      gap: 16px;
+      gap: 12px;
+      text-decoration: none;
+      color: var(--fg);
     }
-    .brand { display: flex; align-items: center; gap: 12px; text-decoration: none; color: var(--fg); }
     .brand .logo { width: 84px; height: 84px; display: block; }
-    .brand b { font-size: 3.2rem; letter-spacing: -0.03em; line-height: 1; color: var(--accent); }
 
     /* Hero: text left, demo right */
     .hero {
-      flex: 1;
       display: grid;
-      grid-template-columns: 0.82fr 1.5fr;
-      align-content: center;
-      align-items: start;
-      gap: 48px;
+      grid-template-columns: 40fr 60fr;
+      align-items: center;
+      gap: 28px 48px;
       padding: 24px 0;
     }
+    .brand b,
     .hero h1 {
       font-size: clamp(2.8rem, 5.2vw, 4.4rem);
-      margin: 0 0 16px;
       letter-spacing: -0.045em;
       line-height: 1;
-      color: var(--accent);
+      color: var(--fg);
     }
+    .hero h1 { margin: 0; }
     .badges { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 18px; }
     .badges img { display: block; height: 20px; }
     .intro {
       color: var(--muted);
-      font-size: clamp(1rem, 1.3vw, 1.12rem);
+      font-size: clamp(1.1rem, 1.35vw, 1.25rem);
       margin: 0 0 16px;
+      text-align: justify;
+      -webkit-hyphens: auto;
+      hyphens: auto;
     }
     .intro:last-of-type { margin-bottom: 26px; }
-    .cta { display: flex; gap: 10px; flex-wrap: nowrap; }
+    .cta { display: flex; gap: 10px; flex-wrap: wrap; }
     .btn {
       display: inline-block;
       padding: 10px 18px;
       border-radius: 9px;
       font-weight: 600;
-      font-size: 0.92rem;
+      font-size: 0.95rem;
       white-space: nowrap;
       text-decoration: none;
       border: 1px solid var(--fg);
-      transition: opacity 0.15s ease, background 0.15s ease;
+      transition: background 0.15s ease, border-color 0.15s ease;
     }
-    .btn-primary { background: var(--accent); color: #ffffff; border-color: var(--accent); }
-    .btn-primary:hover { background: var(--accent-dark); border-color: var(--accent-dark); }
-    .btn-secondary { background: transparent; color: var(--accent); border-color: var(--accent); }
+    .btn-primary { background: var(--fg); color: #ffffff; border-color: var(--fg); }
+    .btn-primary:hover { background: #000000; border-color: #000000; }
+    .btn-secondary { background: transparent; color: var(--fg); border-color: var(--fg); }
     .btn-secondary:hover { background: var(--surface); }
 
-    .demo img {
+    .intro-col, .demo { align-self: start; }
+
+    .demo > img {
       width: 100%;
       height: auto;
       border: 1px solid var(--border);
-      border-radius: 14px;
+      border-radius: 8px;
       display: block;
       box-shadow: 0 18px 60px rgba(0, 0, 0, 0.14);
     }
 
     /* Install */
-    .install-grid {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      gap: 16px;
+    .install {
+      margin-top: 24px;
     }
-    .install-block h3 {
-      margin: 0 0 8px;
-      font-size: 0.78rem;
+    .install h2 {
+      margin: 0 0 10px;
+      font-size: 1.5rem;
+      letter-spacing: -0.03em;
+      line-height: 1.1;
+      color: var(--fg);
+    }
+    .tabs {
+      display: flex;
+      gap: 6px;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 14px;
+    }
+    .tab {
+      border: none;
+      background: transparent;
       color: var(--muted);
+      font: inherit;
       font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
+      font-size: clamp(1.1rem, 1.35vw, 1.25rem);
+      padding: 6px 12px;
+      margin-bottom: -1px;
+      border-bottom: 2px solid transparent;
+      cursor: pointer;
+      transition: color 0.15s ease, border-color 0.15s ease;
+    }
+    .tab:hover { color: var(--fg); }
+    .tab[aria-selected="true"] {
+      color: var(--fg);
+      border-bottom-color: var(--fg);
+    }
+    .store-link {
+      display: inline-block;
+      margin-top: 10px;
+      font-size: clamp(1.1rem, 1.35vw, 1.25rem);
+      font-weight: 600;
+      color: var(--fg);
     }
     .cmd { position: relative; }
     pre {
       margin: 0;
       overflow-x: auto;
-      background: var(--accent);
+      background: var(--fg);
       color: #ffffff;
       border-radius: 10px;
-      padding: 14px 52px 14px 16px;
-      font-size: 0.85rem;
+      padding: 12px 52px 12px 14px;
+      font-size: clamp(1.1rem, 1.35vw, 1.25rem);
       line-height: 1.55;
     }
     code { font-family: var(--mono); }
@@ -143,47 +176,32 @@
     .copy:hover { background: rgba(255, 255, 255, 0.14); }
     .copy.copied { background: #ffffff; color: var(--fg); border-color: #ffffff; }
 
-    /* Footer */
-    footer {
-      display: flex;
-      justify-content: space-between;
-      flex-wrap: wrap;
-      gap: 10px;
-      color: var(--muted);
-      font-size: 0.82rem;
-      border-top: 1px solid var(--border);
-      padding-top: 14px;
-      margin-top: 20px;
-    }
-    footer a { color: var(--muted); }
-
-    @media (max-width: 820px) {
-      .page { min-height: 0; }
+    @media (max-width: 1100px) {
+      .page { padding: 24px 24px 28px; }
       .hero { grid-template-columns: 1fr; gap: 32px; text-align: center; }
-      .hero .demo { order: -1; }
+      .hero .intro-col { order: 1; }
+      .brand { justify-content: center; }
       .badges { justify-content: center; }
-      .cta { justify-content: center; flex-wrap: wrap; }
-      .install-grid { grid-template-columns: 1fr; }
+      .cta { justify-content: center; }
+      .tabs { flex-wrap: wrap; justify-content: center; }
+      .install pre { text-align: left; }
     }
   </style>
 </head>
 <body>
   <div class="page">
 
-    <header class="bar">
-      <a class="brand" href="https://github.com/cubic-vm/cubic">
+    <main class="hero">
+      <a class="brand" href="https://github.com/cubic-vm/cubic" target="_blank" rel="noopener">
         <img class="logo" src="logo-mark.svg" alt="Cubic logo" width="84" height="84">
         <b>Cubic</b>
       </a>
-    </header>
-
-    <main class="hero">
+      <h1>Linux VMs with one command</h1>
       <div class="intro-col">
-        <h1>Linux VMs with a single command</h1>
         <div class="badges">
-          <a href="https://github.com/cubic-vm/cubic"><img src="https://img.shields.io/github/stars/cubic-vm/cubic?style=flat&label=stars" alt="GitHub stars"></a>
-          <a href="https://crates.io/crates/cubic"><img src="https://img.shields.io/crates/v/cubic.svg?label=crates.io" alt="Latest version on crates.io"></a>
-          <a href="https://snapcraft.io/cubic"><img src="https://snapcraft.io/cubic/badge.svg" alt="Snap Store"></a>
+          <a href="https://github.com/cubic-vm/cubic" target="_blank" rel="noopener"><img src="https://img.shields.io/github/stars/cubic-vm/cubic?style=flat&amp;label=stars" alt="GitHub stars"></a>
+          <a href="https://crates.io/crates/cubic" target="_blank" rel="noopener"><img src="https://img.shields.io/crates/v/cubic.svg?label=crates.io" alt="Latest version on crates.io"></a>
+          <a href="https://snapcraft.io/cubic" target="_blank" rel="noopener"><img src="https://snapcraft.io/cubic/badge.svg" alt="Snap Store"></a>
         </div>
         <p class="intro">
           Cubic spins up Linux virtual machines on Linux, macOS and Windows with
@@ -198,67 +216,106 @@
           QEMU, EDK2, official cloud images and cloud-init.
         </p>
         <div class="cta">
-          <a class="btn btn-primary" href="https://github.com/cubic-vm/cubic">GitHub</a>
+          <a class="btn btn-primary" href="https://github.com/cubic-vm/cubic" target="_blank" rel="noopener">GitHub</a>
           <a class="btn btn-secondary" href="docs/">Documentation</a>
-          <a class="btn btn-secondary" href="https://crates.io/crates/cubic">crates.io</a>
-          <a class="btn btn-secondary" href="https://snapcraft.io/cubic">Snap Store</a>
         </div>
+
+        <section class="install">
+          <h2>Try Cubic</h2>
+          <div class="tabs" role="tablist" aria-label="Installation instructions">
+            <button class="tab" id="tab-ubuntu" role="tab" aria-selected="true" aria-controls="panel-ubuntu" type="button">Ubuntu</button>
+            <button class="tab" id="tab-macos" role="tab" aria-selected="false" aria-controls="panel-macos" type="button">macOS</button>
+            <button class="tab" id="tab-windows" role="tab" aria-selected="false" aria-controls="panel-windows" type="button">Windows</button>
+            <button class="tab" id="tab-cargo" role="tab" aria-selected="false" aria-controls="panel-cargo" type="button">Cargo</button>
+          </div>
+          <div class="panel" id="panel-ubuntu" role="tabpanel" aria-labelledby="tab-ubuntu">
+            <div class="cmd">
+              <pre><code>sudo snap install cubic &amp;&amp; \
+sudo snap connect cubic:kvm</code></pre>
+              <button class="copy" type="button" aria-label="Copy command">Copy</button>
+            </div>
+            <a class="store-link" href="https://snapcraft.io/cubic" target="_blank" rel="noopener">View on the Snap Store</a>
+          </div>
+          <div class="panel" id="panel-macos" role="tabpanel" aria-labelledby="tab-macos" hidden>
+            <div class="cmd">
+              <pre><code>brew install cubic-vm/cubic/cubic</code></pre>
+              <button class="copy" type="button" aria-label="Copy command">Copy</button>
+            </div>
+            <a class="store-link" href="https://github.com/cubic-vm/homebrew-cubic" target="_blank" rel="noopener">View the Homebrew tap</a>
+          </div>
+          <div class="panel" id="panel-windows" role="tabpanel" aria-labelledby="tab-windows" hidden>
+            <div class="cmd">
+              <pre><code>winget install cubic-vm.cubic</code></pre>
+              <button class="copy" type="button" aria-label="Copy command">Copy</button>
+            </div>
+            <a class="store-link" href="https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/cubic-vm/cubic" target="_blank" rel="noopener">View the winget manifest</a>
+          </div>
+          <div class="panel" id="panel-cargo" role="tabpanel" aria-labelledby="tab-cargo" hidden>
+            <div class="cmd">
+              <pre><code>cargo install cubic</code></pre>
+              <button class="copy" type="button" aria-label="Copy command">Copy</button>
+            </div>
+            <a class="store-link" href="https://crates.io/crates/cubic" target="_blank" rel="noopener">View on crates.io</a>
+          </div>
+        </section>
       </div>
       <div class="demo">
-        <img src="cubic.gif" alt="Cubic demo: creating and entering a Linux VM" loading="lazy">
+        <img src="cubic.gif" alt="Cubic demo: creating and entering a Linux VM" width="2009" height="1389" fetchpriority="high">
       </div>
     </main>
-
-    <section class="install-grid">
-      <div class="install-block">
-        <h3>Ubuntu (Snap)</h3>
-        <div class="cmd">
-          <pre><code>sudo snap install cubic && \
-sudo snap connect cubic:kvm</code></pre>
-          <button class="copy" type="button" aria-label="Copy command">Copy</button>
-        </div>
-      </div>
-      <div class="install-block">
-        <h3>macOS (Homebrew)</h3>
-        <div class="cmd">
-          <pre><code>brew install cubic-vm/cubic/cubic</code></pre>
-          <button class="copy" type="button" aria-label="Copy command">Copy</button>
-        </div>
-      </div>
-      <div class="install-block">
-        <h3>Windows (winget)</h3>
-        <div class="cmd">
-          <pre><code>winget install cubic-vm.cubic</code></pre>
-          <button class="copy" type="button" aria-label="Copy command">Copy</button>
-        </div>
-      </div>
-      <div class="install-block">
-        <h3>Others (Cargo)</h3>
-        <div class="cmd">
-          <pre><code>cargo install cubic</code></pre>
-          <button class="copy" type="button" aria-label="Copy command">Copy</button>
-        </div>
-      </div>
-    </section>
-
-    <footer>
-      <span>Dual-licensed under Apache 2.0 and MIT.</span>
-      <span>Built on QEMU, EDK2, official cloud images and cloud-init.</span>
-    </footer>
 
   </div>
 
   <script>
+    var tabs = document.querySelectorAll(".tab");
+
+    function selectTab(selectedTab) {
+      tabs.forEach(function (tab) {
+        var selected = tab === selectedTab;
+        tab.setAttribute("aria-selected", selected ? "true" : "false");
+        document.getElementById(tab.getAttribute("aria-controls")).hidden = !selected;
+      });
+    }
+
+    tabs.forEach(function (tab) {
+      tab.addEventListener("click", function () {
+        selectTab(tab);
+      });
+    });
+
+    function detectOs() {
+      var platform = "";
+      if (navigator.userAgentData && navigator.userAgentData.platform) {
+        platform = navigator.userAgentData.platform;
+      } else if (navigator.userAgent) {
+        platform = navigator.userAgent;
+      }
+      platform = platform.toLowerCase();
+      if (platform.indexOf("mac") !== -1) return "macos";
+      if (platform.indexOf("win") !== -1) return "windows";
+      if (platform.indexOf("linux") !== -1 || platform.indexOf("android") !== -1) return "ubuntu";
+      return "cargo";
+    }
+
+    selectTab(document.getElementById("tab-" + detectOs()));
+
     document.querySelectorAll(".copy").forEach(function (btn) {
       btn.addEventListener("click", function () {
         var text = btn.previousElementSibling.innerText.trim();
-        navigator.clipboard.writeText(text).then(function () {
-          btn.textContent = "Copied";
-          btn.classList.add("copied");
+
+        function showResult(label, copied) {
+          btn.textContent = label;
+          btn.classList.toggle("copied", copied);
           setTimeout(function () {
             btn.textContent = "Copy";
             btn.classList.remove("copied");
           }, 1500);
+        }
+
+        navigator.clipboard.writeText(text).then(function () {
+          showResult("Copied", true);
+        }, function () {
+          showResult("Failed", false);
         });
       });
     });

--- a/docs/logo-mark.svg
+++ b/docs/logo-mark.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 85.099281 85.099281" width="85" height="85">
-  <rect width="85.099281" height="85.099281" rx="16" fill="#000000" />
+  <rect width="85.099281" height="85.099281" rx="10" fill="#000000" />
   <g transform="translate(-50.703999,-98.159405)" fill="#ffffff">
     <rect width="48.539997" height="5.6222234" x="-56.126945" y="140.98662" transform="rotate(-45)" />
     <rect width="48.539997" height="5.6222234" x="141.00244" y="50.510292" transform="rotate(45)" />


### PR DESCRIPTION
## Summary

Restructure the hero section into a two column grid with the brand and headline on top. Replace the install grid with a tabbed section per platform (Ubuntu, macOS, Windows, Cargo) that preselects from the user agent. Add favicon and social preview metadata, and drop the footer.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Test Plan

Tested locally.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed
