### PR TITLE
fix: validate usernames before cloud-init and SSH (#447)

### DIFF
--- a/src/cloudinit/user_data_factory.rs
+++ b/src/cloudinit/user_data_factory.rs
@@ -1,8 +1,10 @@
+use crate::models::UserName;
+
 #[derive(Default)]
 pub struct UserDataFactory;
 
 impl UserDataFactory {
-    pub fn create(&self, user: &str, pubkey: &str, execute: Option<&str>) -> String {
+    pub fn create(&self, user: &UserName, pubkey: &str, execute: Option<&str>) -> String {
         let execute = execute
             .map(|execute| {
                 format!(
@@ -38,10 +40,12 @@ impl UserDataFactory {
 #[cfg(test)]
 mod tests {
     pub use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn test_write_user_data_without_execute() {
-        let actual = UserDataFactory::default().create("tux", "pubkey", None);
+        let actual =
+            UserDataFactory::default().create(&UserName::from_str("tux").unwrap(), "pubkey", None);
         let expected = r#"#cloud-config
 users:
   - name: tux
@@ -62,8 +66,11 @@ write_files:
 
     #[test]
     fn test_write_user_data_with_execute() {
-        let actual =
-            UserDataFactory::default().create("tux", "pubkey", Some("\"sudo apt install vim\""));
+        let actual = UserDataFactory::default().create(
+            &UserName::from_str("tux").unwrap(),
+            "pubkey",
+            Some("\"sudo apt install vim\""),
+        );
         let expected = r#"#cloud-config
 users:
   - name: tux
@@ -86,7 +93,11 @@ bootcmd:
 
     #[test]
     fn test_write_user_data_escapes_execute() {
-        let actual = UserDataFactory::default().create("tux", "pubkey", Some("a\\b\t\"c\"\nd\re"));
+        let actual = UserDataFactory::default().create(
+            &UserName::from_str("tux").unwrap(),
+            "pubkey",
+            Some("a\\b\t\"c\"\nd\re"),
+        );
 
         let expected_bootcmd = r#"bootcmd:
   - "a\\b\t\"c\"\nd\re"

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -71,13 +71,14 @@ mod tests {
     use crate::instance::InstanceStoreMock;
     use crate::models::Environment;
     use crate::models::Instance;
+    use crate::models::UserName;
     use crate::platform::SystemMock;
     use std::rc::Rc;
     use std::str::FromStr;
 
     fn build_context(instances: Vec<Instance>) -> Context {
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),
@@ -122,7 +123,7 @@ mod tests {
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -5,7 +5,7 @@ use crate::commands::{
 };
 use crate::error::{Error, Result};
 use crate::fs::FS;
-use crate::models::{DataSize, ImageName, Instance, PortForward, ResourceAllocator};
+use crate::models::{DataSize, ImageName, Instance, PortForward, ResourceAllocator, UserName};
 use crate::ssh_cmd::PortChecker;
 use crate::view::Console;
 use crate::view::Spinner;
@@ -49,7 +49,7 @@ pub struct CreateCommand {
     image: ImageName,
     /// Username (default: 'cubic')
     #[clap(short, long)]
-    user: Option<String>,
+    user: Option<UserName>,
     /// Number of vCPUs for the VM instance (default: derived from host resources)
     #[clap(short, long)]
     cpus: Option<u16>,
@@ -99,9 +99,8 @@ impl Command for CreateCommand {
             arch: image.arch,
             user: self
                 .user
-                .as_deref()
-                .unwrap_or(context.get_env().get_username())
-                .to_string(),
+                .clone()
+                .unwrap_or_else(|| context.get_env().get_username().clone()),
             cpus: self.cpus.unwrap_or(default_cpus),
             mem: self.memory.clone().unwrap_or(default_mem),
             disk_capacity: self.disk.clone(),
@@ -137,13 +136,14 @@ mod tests {
     use crate::models::Environment;
     use crate::platform::SystemMock;
     use std::rc::Rc;
+    use std::str::FromStr;
 
     #[test]
     fn test_create_rejects_existing_instance_name() {
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -74,9 +74,10 @@ mod tests {
     use super::*;
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
-    use crate::models::Environment;
+    use crate::models::{Environment, UserName};
     use crate::platform::SystemMock;
     use std::rc::Rc;
+    use std::str::FromStr;
 
     #[test]
     fn test_reject_path_traversal() {
@@ -88,7 +89,7 @@ mod tests {
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let env = Environment::new(
-            "myuser".to_string(),
+            UserName::from_str("myuser").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -52,15 +52,16 @@ pub fn fetch_image(
 mod tests {
     use super::*;
     use crate::image::ImageStoreMock;
-    use crate::models::{Arch, HashAlg};
+    use crate::models::{Arch, HashAlg, UserName};
     use crate::platform::SystemMock;
+    use std::str::FromStr;
 
     #[test]
     fn test_fetch_image_skips_cached_image() {
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -67,9 +67,10 @@ mod tests {
     use super::*;
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
-    use crate::models::{Arch, DataSize, Environment, Instance};
+    use crate::models::{Arch, DataSize, Environment, Instance, UserName};
     use crate::platform::SystemMock;
     use std::rc::Rc;
+    use std::str::FromStr;
 
     #[test]
     fn test_list_instance_command() {
@@ -77,7 +78,7 @@ mod tests {
         let console = &mut Console::new(&system);
         let image_store = ImageStoreMock::default();
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),
@@ -86,7 +87,7 @@ mod tests {
             Instance {
                 name: "test".to_string(),
                 arch: Arch::AMD64,
-                user: "cubic".to_string(),
+                user: UserName::from_str("cubic").unwrap(),
                 cpus: 1,
                 mem: DataSize::new(1024),
                 disk_capacity: DataSize::new(1048576),
@@ -97,7 +98,7 @@ mod tests {
             Instance {
                 name: "test2".to_string(),
                 arch: Arch::AMD64,
-                user: "cubic".to_string(),
+                user: UserName::from_str("cubic").unwrap(),
                 cpus: 5,
                 mem: DataSize::new(0),
                 disk_capacity: DataSize::new(5000),
@@ -132,7 +133,7 @@ PID   Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
         let instance_store = InstanceStoreMock::new(Vec::new());
         let image_store = ImageStoreMock::default();
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/commands/list_port_command.rs
+++ b/src/commands/list_port_command.rs
@@ -69,13 +69,14 @@ mod tests {
     use super::*;
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
-    use crate::models::{Environment, Instance};
+    use crate::models::{Environment, Instance, UserName};
     use crate::platform::SystemMock;
     use std::rc::Rc;
+    use std::str::FromStr;
 
     fn build_context(instances: Vec<Instance>) -> commands::Context {
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/commands/modify_command.rs
+++ b/src/commands/modify_command.rs
@@ -104,13 +104,14 @@ mod tests {
     use super::*;
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
-    use crate::models::{Environment, Instance};
+    use crate::models::{Environment, Instance, UserName};
     use crate::platform::SystemMock;
     use std::rc::Rc;
+    use std::str::FromStr;
 
     fn build_context(instance_store: InstanceStoreMock) -> commands::Context {
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/commands/rename_command.rs
+++ b/src/commands/rename_command.rs
@@ -37,14 +37,14 @@ mod tests {
     use crate::error::Error;
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
-    use crate::models::{Environment, Instance};
+    use crate::models::{Environment, Instance, UserName};
     use crate::platform::SystemMock;
     use std::rc::Rc;
     use std::str::FromStr;
 
     fn build_context(instances: Vec<Instance>) -> commands::Context {
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -84,14 +84,14 @@ mod tests {
     use crate::error::Error;
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
-    use crate::models::{Environment, Instance};
+    use crate::models::{Environment, Instance, UserName};
     use crate::platform::SystemMock;
     use std::rc::Rc;
     use std::str::FromStr;
 
     fn build_context(instances: Vec<Instance>) -> commands::Context {
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -44,7 +44,7 @@ impl Command for ShowInstanceCommand {
             &util::format_or_na(instance.disk_used.map(|size| size.to_size())),
         );
         view.add("Disk Total", &instance.disk_capacity.to_size());
-        view.add("User", &instance.user);
+        view.add("User", instance.user.as_str());
         view.add("Isolated", util::to_yes_no(instance.isolate));
         view.add("SSH Port", &instance.ssh_port.to_string());
         view.add("Monitor Port", &util::format_or_na(instance.monitor_port));
@@ -80,7 +80,7 @@ mod tests {
     use super::*;
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
-    use crate::models::{Arch, DataSize, Environment, Instance, InstanceName};
+    use crate::models::{Arch, DataSize, Environment, Instance, InstanceName, UserName};
     use crate::platform::SystemMock;
     use std::path::PathBuf;
     use std::rc::Rc;
@@ -91,7 +91,7 @@ mod tests {
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let env = Environment::new(
-            "myuser".to_string(),
+            UserName::from_str("myuser").unwrap(),
             String::new(),
             String::new(),
             String::new(),
@@ -100,7 +100,7 @@ mod tests {
         let instance_store = InstanceStoreMock::new(vec![Instance {
             name: "test".to_string(),
             arch: Arch::AMD64,
-            user: "myuser".to_string(),
+            user: UserName::from_str("myuser").unwrap(),
             cpus: 1,
             mem: DataSize::new(1024),
             disk_capacity: DataSize::new(1048576),
@@ -147,7 +147,7 @@ Forward:      127.0.0.1:4000:40/tcp
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let env = Environment::new(
-            "cubic".to_string(),
+            UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),
@@ -156,7 +156,7 @@ Forward:      127.0.0.1:4000:40/tcp
         let instance_store = InstanceStoreMock::new(vec![Instance {
             name: "test".to_string(),
             arch: Arch::ARM64,
-            user: "john".to_string(),
+            user: UserName::from_str("john").unwrap(),
             cpus: 2,
             mem: DataSize::new(1),
             disk_capacity: DataSize::new(1),
@@ -230,7 +230,7 @@ SSH:          ssh -i {ssh_key} -p 8000 john@localhost
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let env = Environment::new(
-            "testuser".to_string(),
+            UserName::from_str("testuser").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/commands/stop_command.rs
+++ b/src/commands/stop_command.rs
@@ -82,9 +82,10 @@ mod tests {
     use crate::error::Error;
     use crate::image::ImageStoreMock;
     use crate::instance::InstanceStoreMock;
-    use crate::models::Environment;
+    use crate::models::{Environment, UserName};
     use crate::platform::SystemMock;
     use std::rc::Rc;
+    use std::str::FromStr;
 
     #[test]
     fn test_reject_path_traversal() {
@@ -96,7 +97,7 @@ mod tests {
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let env = Environment::new(
-            "myuser".to_string(),
+            UserName::from_str("myuser").unwrap(),
             String::new(),
             String::new(),
             String::new(),
@@ -125,7 +126,7 @@ mod tests {
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let env = Environment::new(
-            "myuser".to_string(),
+            UserName::from_str("myuser").unwrap(),
             String::new(),
             String::new(),
             String::new(),

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,3 +1,3 @@
 mod environment_factory;
 
-pub use environment_factory::{DEFAULT_USERNAME, EnvironmentFactory};
+pub use environment_factory::EnvironmentFactory;

--- a/src/env/environment_factory.rs
+++ b/src/env/environment_factory.rs
@@ -1,9 +1,9 @@
 use crate::error::{Error, Result};
-use crate::models::Environment;
+use crate::models::{DEFAULT_USERNAME, Environment, UserName};
 use crate::platform::System;
+use std::str::FromStr;
 
 const ROOT_USERNAME: &str = "root";
-pub const DEFAULT_USERNAME: &str = "cubic";
 const USERNAME_ENV_VARS: [&str; 3] = ["USER", "LOGNAME", "USERNAME"];
 
 pub struct EnvironmentFactory;
@@ -21,14 +21,13 @@ impl EnvironmentFactory {
             .find_map(|var| system.read_env_var(var))
     }
 
-    pub fn get_username(system: &dyn System) -> String {
+    pub fn get_username(system: &dyn System) -> UserName {
         let username =
             Self::read_current_username(system).unwrap_or_else(|| DEFAULT_USERNAME.to_string());
         if username == ROOT_USERNAME {
-            DEFAULT_USERNAME.to_string()
-        } else {
-            username
+            return UserName::default();
         }
+        UserName::from_str(&username).unwrap_or_default()
     }
 
     #[cfg(target_os = "linux")]
@@ -109,14 +108,30 @@ mod tests {
     fn test_get_username_falls_back_to_default_when_unset() {
         let system = SystemMock::new();
 
-        assert_eq!(EnvironmentFactory::get_username(&system), DEFAULT_USERNAME);
+        assert_eq!(
+            EnvironmentFactory::get_username(&system).as_str(),
+            DEFAULT_USERNAME
+        );
     }
 
     #[test]
     fn test_get_username_maps_root_to_default() {
         let system = SystemMock::new().add_env_var("USER", ROOT_USERNAME);
 
-        assert_eq!(EnvironmentFactory::get_username(&system), DEFAULT_USERNAME);
+        assert_eq!(
+            EnvironmentFactory::get_username(&system).as_str(),
+            DEFAULT_USERNAME
+        );
+    }
+
+    #[test]
+    fn test_get_username_falls_back_to_default_when_invalid() {
+        let system = SystemMock::new().add_env_var("USER", "Bad Name");
+
+        assert_eq!(
+            EnvironmentFactory::get_username(&system).as_str(),
+            DEFAULT_USERNAME
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -121,6 +121,11 @@ Troubleshoot:
 
     #[error("SFTP Error: {0}")]
     Sftp(String),
+
+    #[error(
+        "Invalid username '{0}'.\n\nUsernames must start with a lowercase letter or underscore, followed by lowercase letters, numbers, underlines or dashes"
+    )]
+    InvalidUsername(String),
 }
 
 fn format_qemu_not_found_help() -> String {

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -123,7 +123,7 @@ impl InstanceStore for InstanceDao {
             Some(i) => i,
             None => Instance {
                 name: name.to_string(),
-                user: self.env.get_username().to_string(),
+                user: self.env.get_username().clone(),
                 cpus: 1,
                 mem: DataSize::from_str("1G").unwrap(),
                 disk_capacity: DataSize::from_str("1G").unwrap(),

--- a/src/instance/instance_serializer.rs
+++ b/src/instance/instance_serializer.rs
@@ -21,7 +21,8 @@ impl InstanceSerializer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{Arch, DataSize};
+    use crate::models::{Arch, DataSize, UserName};
+    use std::str::FromStr;
 
     #[test]
     fn test_serialize_minimal_config() {
@@ -32,7 +33,7 @@ mod tests {
                 &Instance {
                     name: "test".to_string(),
                     arch: Arch::AMD64,
-                    user: "tux".to_string(),
+                    user: UserName::from_str("tux").unwrap(),
                     cpus: 1,
                     mem: DataSize::new(1000),
                     disk_capacity: DataSize::new(1000),
@@ -69,7 +70,7 @@ isolate = false
                 &Instance {
                     name: "test".to_string(),
                     arch: Arch::AMD64,
-                    user: "tux".to_string(),
+                    user: UserName::from_str("tux").unwrap(),
                     cpus: 1,
                     mem: DataSize::new(1000),
                     disk_capacity: DataSize::new(1000),

--- a/src/instance/target_path.rs
+++ b/src/instance/target_path.rs
@@ -9,7 +9,7 @@ pub fn resolve_target_path(
     if let Some(target) = tp.get_target() {
         let instance = instance_store.load(target.get_instance().as_str())?;
         Ok(TargetInstancePath {
-            user: target.get_user().cloned(),
+            user: target.get_user().map(|user| user.to_string()),
             instance: Some(instance),
             path: tp.path.clone(),
         })

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -56,7 +56,7 @@ ssh_port = 14357
             .deserialize("test", reader)
             .expect("Cannot parse config");
         assert_eq!(instance.name, "test");
-        assert_eq!(instance.user, "cubic");
+        assert_eq!(instance.user.as_str(), "cubic");
         assert_eq!(instance.cpus, 1);
         assert_eq!(instance.mem.get_bytes(), 1073741824);
         assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
@@ -86,7 +86,7 @@ isolate = true
             .deserialize("test", reader)
             .expect("Cannot parse config");
         assert_eq!(instance.name, "test");
-        assert_eq!(instance.user, "tux");
+        assert_eq!(instance.user.as_str(), "tux");
         assert_eq!(instance.cpus, 1);
         assert_eq!(instance.mem.get_bytes(), 1073741824);
         assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
@@ -101,5 +101,27 @@ isolate = true
         );
         assert_eq!(instance.execute, Some("sudo apt update".to_string()));
         assert!(instance.isolate);
+    }
+
+    #[test]
+    fn test_deserialize_falls_back_to_default_user_instead_of_discarding_config() {
+        let reader = &mut BufReader::new(
+            r#"
+user = "Bad Name"
+cpus = 4
+mem = 1073741824
+disk_capacity = 2361393152
+ssh_port = 14357
+"#
+            .as_bytes(),
+        );
+
+        let instance = TomlInstanceDeserializer::new()
+            .deserialize("test", reader)
+            .expect("Cannot parse config");
+        assert_eq!(instance.name, "test");
+        assert_eq!(instance.user.as_str(), "cubic");
+        assert_eq!(instance.cpus, 4);
+        assert_eq!(instance.ssh_port, 14357);
     }
 }

--- a/src/instance/yaml_instance_deserializer.rs
+++ b/src/instance/yaml_instance_deserializer.rs
@@ -53,7 +53,7 @@ machine:
             .deserialize("test", reader)
             .expect("Cannot parse config");
         assert_eq!(instance.name, "test");
-        assert_eq!(instance.user, "cubic");
+        assert_eq!(instance.user.as_str(), "cubic");
         assert_eq!(instance.cpus, 1);
         assert_eq!(instance.mem.get_bytes(), 1073741824);
         assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);
@@ -80,7 +80,7 @@ machine:
             .deserialize("test", reader)
             .expect("Cannot parse config");
         assert_eq!(instance.name, "test");
-        assert_eq!(instance.user, "tux");
+        assert_eq!(instance.user.as_str(), "tux");
         assert_eq!(instance.cpus, 1);
         assert_eq!(instance.mem.get_bytes(), 1073741824);
         assert_eq!(instance.disk_capacity.get_bytes(), 2361393152);

--- a/src/models.rs
+++ b/src/models.rs
@@ -14,6 +14,7 @@ mod resource_allocator;
 mod target;
 mod target_instance_path;
 mod target_path;
+mod user_name;
 
 pub use arch::*;
 pub use checksum::*;
@@ -31,3 +32,4 @@ pub use resource_allocator::*;
 pub use target::*;
 pub use target_instance_path::*;
 pub use target_path::*;
+pub use user_name::*;

--- a/src/models/environment.rs
+++ b/src/models/environment.rs
@@ -1,17 +1,23 @@
 use crate::fs::FS;
+use crate::models::UserName;
 use crate::platform::System;
 use std::path::PathBuf;
 
 #[derive(Default, Clone)]
 pub struct Environment {
-    username: String,
+    username: UserName,
     data_dir: String,
     cache_dir: String,
     runtime_dir: String,
 }
 
 impl Environment {
-    pub fn new(username: String, data_dir: String, cache_dir: String, runtime_dir: String) -> Self {
+    pub fn new(
+        username: UserName,
+        data_dir: String,
+        cache_dir: String,
+        runtime_dir: String,
+    ) -> Self {
         Self {
             username,
             data_dir,
@@ -20,7 +26,7 @@ impl Environment {
         }
     }
 
-    pub fn get_username(&self) -> &str {
+    pub fn get_username(&self) -> &UserName {
         &self.username
     }
 
@@ -163,6 +169,7 @@ impl Environment {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     fn join_all(base: &str, segments: &[&str]) -> PathBuf {
         segments
@@ -173,13 +180,13 @@ mod tests {
     #[test]
     fn test_paths() {
         let env = Environment::new(
-            "testuser".to_string(),
+            UserName::from_str("testuser").unwrap(),
             "/data/cubic".to_string(),
             "/cache/cubic".to_string(),
             "/runtime/cubic".to_string(),
         );
 
-        assert_eq!(env.get_username(), "testuser");
+        assert_eq!(env.get_username().as_str(), "testuser");
         assert_eq!(env.get_cache_dir(), "/cache/cubic");
         assert_eq!(
             PathBuf::from(env.get_ssh_private_key_file("mymachine")),

--- a/src/models/instance.rs
+++ b/src/models/instance.rs
@@ -1,10 +1,5 @@
-use crate::env::DEFAULT_USERNAME;
-use crate::models::{Arch, DataSize, PortForward};
+use crate::models::{Arch, DataSize, PortForward, UserName};
 use serde::{Deserialize, Serialize};
-
-fn default_user() -> String {
-    DEFAULT_USERNAME.to_string()
-}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Instance {
@@ -12,8 +7,8 @@ pub struct Instance {
     pub name: String,
     #[serde(default)]
     pub arch: Arch,
-    #[serde(default = "default_user")]
-    pub user: String,
+    #[serde(default)]
+    pub user: UserName,
     pub cpus: u16,
     pub mem: DataSize,
     #[serde(skip)]

--- a/src/models/target.rs
+++ b/src/models/target.rs
@@ -1,10 +1,10 @@
-use crate::models::InstanceName;
+use crate::models::{InstanceName, UserName};
 use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone)]
 pub struct Target {
-    user: Option<String>,
+    user: Option<UserName>,
     instance: InstanceName,
 }
 
@@ -16,7 +16,7 @@ impl Target {
         }
     }
 
-    pub fn get_user(&self) -> Option<&String> {
+    pub fn get_user(&self) -> Option<&UserName> {
         self.user.as_ref()
     }
 
@@ -36,7 +36,7 @@ impl FromStr for Target {
             }),
 
             [user, instance] => Ok(Self {
-                user: Some(user.to_string()),
+                user: Some(UserName::from_str(user).map_err(|error| error.to_string())?),
                 instance: InstanceName::from_str(instance)?,
             }),
             _ => Err("Target name must have format 'user@instance' or 'instance'".to_string()),
@@ -79,6 +79,11 @@ mod tests {
     #[test]
     fn test_invalid_target() {
         assert!(Target::from_str("cubic@my@machine").is_err());
+    }
+
+    #[test]
+    fn test_invalid_user_name() {
+        assert!(Target::from_str("bad user@mymachine").is_err());
     }
 
     #[test]

--- a/src/models/target_instance_path.rs
+++ b/src/models/target_instance_path.rs
@@ -25,6 +25,8 @@ impl TargetInstancePath {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::UserName;
+    use std::str::FromStr;
 
     #[test]
     fn test_to_pathbuf() {
@@ -89,7 +91,7 @@ mod tests {
     #[test]
     fn test_to_pathbuf_tilde_with_user_and_instance() {
         let mut instance = Instance::default();
-        instance.user = "root".to_string();
+        instance.user = UserName::from_str("root").unwrap();
         assert_eq!(
             TargetInstancePath {
                 user: Some("tux".to_string()),
@@ -106,7 +108,7 @@ mod tests {
     #[test]
     fn test_to_pathbuf_tilde_with_instance_without_user() {
         let mut instance = Instance::default();
-        instance.user = "root".to_string();
+        instance.user = UserName::from_str("root").unwrap();
         assert_eq!(
             TargetInstancePath {
                 user: None,

--- a/src/models/user_name.rs
+++ b/src/models/user_name.rs
@@ -1,0 +1,142 @@
+use crate::error::Error;
+use regex::Regex;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+use std::sync::LazyLock;
+
+pub const DEFAULT_USERNAME: &str = "cubic";
+
+static USER_NAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new("^[a-z_][a-z0-9_-]*$").unwrap());
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct UserName {
+    name: String,
+}
+
+impl UserName {
+    pub fn as_str(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+impl Default for UserName {
+    fn default() -> Self {
+        Self {
+            name: DEFAULT_USERNAME.to_string(),
+        }
+    }
+}
+
+impl FromStr for UserName {
+    type Err = Error;
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        if USER_NAME_REGEX.is_match(name) {
+            Ok(Self {
+                name: name.to_string(),
+            })
+        } else {
+            Err(Error::InvalidUsername(name.to_string()))
+        }
+    }
+}
+
+impl fmt::Display for UserName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl Serialize for UserName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.name)
+    }
+}
+
+impl<'de> Deserialize<'de> for UserName {
+    // Falls back to the default username instead of failing so that a persisted
+    // instance config with a username predating this validation (or edited by
+    // hand) does not take down the rest of the instance's settings with it.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let name = String::deserialize(deserializer)?;
+        Ok(UserName::from_str(&name).unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_letters() {
+        UserName::from_str("tux").unwrap();
+    }
+
+    #[test]
+    fn test_leading_underscore() {
+        UserName::from_str("_tux").unwrap();
+    }
+
+    #[test]
+    fn test_numbers_underscore_dash_after_first_char() {
+        UserName::from_str("tux-01_x").unwrap();
+    }
+
+    #[test]
+    fn test_reject_leading_digit() {
+        assert!(UserName::from_str("1tux").is_err());
+    }
+
+    #[test]
+    fn test_reject_leading_dash() {
+        assert!(UserName::from_str("-tux").is_err());
+    }
+
+    #[test]
+    fn test_reject_empty_name() {
+        assert!(UserName::from_str("").is_err());
+    }
+
+    #[test]
+    fn test_reject_space() {
+        assert!(UserName::from_str("bad name").is_err());
+    }
+
+    #[test]
+    fn test_reject_newline() {
+        assert!(UserName::from_str("tux\nroot").is_err());
+    }
+
+    #[test]
+    fn test_reject_yaml_injection() {
+        assert!(UserName::from_str("tux\n  - name: root").is_err());
+    }
+
+    #[test]
+    fn test_reject_uppercase() {
+        assert!(UserName::from_str("Tux").is_err());
+    }
+
+    #[test]
+    fn test_serialize_round_trip() {
+        let user = UserName::from_str("tux").unwrap();
+        let json = serde_json::to_string(&user).unwrap();
+        assert_eq!(json, "\"tux\"");
+        let back: UserName = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, user);
+    }
+
+    #[test]
+    fn test_deserialize_falls_back_to_default_for_invalid_value() {
+        let result: UserName = serde_json::from_str("\"bad name\"").unwrap();
+        assert_eq!(result, UserName::default());
+    }
+}

--- a/src/ssh_cmd/russh.rs
+++ b/src/ssh_cmd/russh.rs
@@ -360,7 +360,7 @@ impl<'a> Russh<'a> {
         user: &Option<String>,
         client_key: &str,
     ) -> Rc<SftpSession> {
-        let user = user.as_ref().unwrap_or(&instance.user);
+        let user = user.as_deref().unwrap_or(instance.user.as_str());
         let channel = self
             .open_channel(console, &instance.name, client_key, user, instance.ssh_port)
             .await


### PR DESCRIPTION
## Summary

Usernames from --user and ssh/scp targets went unvalidated straight into cloud-init YAML and the SSH client, so bad input could break provisioning or inject YAML.

Add a UserName type that enforces a safe charset, and use it for Instance.user, Target.user, Environment.username, and the --user flag. UserDataFactory now requires a UserName, so the compiler guarantees only validated input reaches the generated config.

Persisted config still loads without failing, falling back to the default username instead of discarding the whole instance on invalid data.

## Related Issue(s)

Closes #447

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Run unit tests and manual checks.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed
