### PR TITLE
refactor: drop qemu-sandbox cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ categories = ["command-line-utilities"]
 edition = "2024"
 rust-version = "1.92"
 
-[features]
-qemu-sandbox = []
-
 [dependencies]
 bytes = "1"
 clap = { version = "4", features = ["derive"] }

--- a/src/qemu/qemu_system.rs
+++ b/src/qemu/qemu_system.rs
@@ -76,10 +76,6 @@ impl QemuSystem {
         // Allow memory reclaim via virtio-balloon.
         command.arg("-device").arg("virtio-balloon-pci");
 
-        // Sandbox
-        #[cfg(feature = "qemu-sandbox")]
-        command.arg("-sandbox").arg("on");
-
         Ok(QemuSystem { command })
     }
 


### PR DESCRIPTION
## Summary

The QEMU sandbox feature relies on Linux-only seccomp support and was never enabled by any build path.
Sandboxing can be reintroduced later with proper runtime platform detection.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed
