### PR TITLE
feat: apply port forwarding changes live via QEMU monitor

### DIFF
--- a/src/commands/modify_command.rs
+++ b/src/commands/modify_command.rs
@@ -7,8 +7,9 @@ use clap::{ArgAction, Parser};
 /// Modify VM instances
 ///
 /// Use this command to change the settings of an existing VM instance (CPU, memory,
-/// disk, etc.). The changes will be applied on the next (re-)start of the VM
-/// instance.
+/// disk, etc.). Port forwarding rules (--port/--rm-port) take effect immediately if
+/// the instance is running. All other changes are applied on the next (re-)start of
+/// the VM instance.
 ///
 /// Examples:
 ///
@@ -69,8 +70,21 @@ impl Command for ModifyCommand {
         let instance_store = context.get_instance_store();
         let mut instance = instance_store.load(self.instance.value.as_str())?;
 
-        if instance_store.is_running(&instance) {
-            console.info("Note: changes will be applied after the next restart.");
+        let is_running = instance_store.is_running(&instance);
+        let hostfwd_changed = !self.port.is_empty() || !self.rm_port.is_empty();
+
+        if is_running && hostfwd_changed {
+            let mut monitor = instance_store.get_monitor(&instance)?;
+            for fwd in &self.rm_port {
+                monitor.remove_hostfwd(fwd)?;
+            }
+            for fwd in &self.port {
+                monitor.add_hostfwd(fwd)?;
+            }
+        }
+
+        if is_running {
+            console.info("Note: changes may require a restart to take effect.");
         }
 
         if let Some(cpus) = &self.cpus {
@@ -165,7 +179,31 @@ mod tests {
 
         assert_eq!(
             system.get_output(),
-            "info: Note: changes will be applied after the next restart.\n"
+            "info: Note: changes may require a restart to take effect.\n"
         );
+    }
+
+    #[test]
+    fn test_modify_running_instance_port_attempts_live_apply() {
+        let system = SystemMock::new();
+        let console = &mut Console::new(&system);
+        let context = build_context(InstanceStoreMock::new_with_running(
+            vec![Instance {
+                name: "test".to_string(),
+                ..Instance::default()
+            }],
+            &["test"],
+        ));
+
+        // InstanceStoreMock has no real monitor, so a live hostfwd change on
+        // a running instance surfaces the mock's InstanceNotRunning error
+        // instead of silently deferring to a restart, and the restart note
+        // is never printed.
+        let result = ModifyCommand::try_parse_from(["modify", "test", "--port", "8080:80"])
+            .unwrap()
+            .run(console, &context);
+
+        assert!(result.is_err());
+        assert_eq!(system.get_output(), "");
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -126,6 +126,9 @@ Troubleshoot:
         "Invalid username '{0}'.\n\nUsernames must start with a lowercase letter or underscore, followed by lowercase letters, numbers, underlines or dashes"
     )]
     InvalidUsername(String),
+
+    #[error("Failed to apply port forwarding rule on the running instance: {0}")]
+    HostfwdCommandFailed(String),
 }
 
 fn format_qemu_not_found_help() -> String {

--- a/src/qemu/monitor.rs
+++ b/src/qemu/monitor.rs
@@ -1,7 +1,8 @@
 use crate::commands::Verbosity;
 use crate::error::{Error, Result};
-use crate::models::{Environment, Instance, InstanceCertPaths};
-use crate::qemu::{Qmp, TlsClient};
+use crate::models::{Environment, Instance, InstanceCertPaths, PortForward};
+use crate::qemu::{NETDEV_ID, Qmp, QmpMessage, TlsClient};
+use serde_json::json;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -41,5 +42,48 @@ impl Monitor {
 
     pub fn shutdown(&mut self) -> Result<()> {
         self.qmp.execute("system_powerdown")
+    }
+
+    pub fn add_hostfwd(&mut self, fwd: &PortForward) -> Result<()> {
+        let output = self.run_hmp_command(&format!("hostfwd_add {NETDEV_ID} {}", fwd.to_qemu()))?;
+        if output.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::HostfwdCommandFailed(output))
+        }
+    }
+
+    pub fn remove_hostfwd(&mut self, fwd: &PortForward) -> Result<()> {
+        let rule = format!(
+            "{}:{}:{}",
+            fwd.get_protocol(),
+            fwd.get_host_ip(),
+            fwd.get_host_port(),
+        );
+        let output = self.run_hmp_command(&format!("hostfwd_remove {NETDEV_ID} {rule}"))?;
+        if output.contains("not found") {
+            Err(Error::HostfwdCommandFailed(output))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Runs an HMP (human monitor protocol) command line over QMP via the
+    /// `human-monitor-command` passthrough verb, for HMP commands that have
+    /// no native QMP equivalent. Returns the raw (trimmed) text QEMU printed,
+    /// since success/failure text conventions differ per HMP command and
+    /// must be interpreted by the caller.
+    fn run_hmp_command(&mut self, command_line: &str) -> Result<String> {
+        let response = self.qmp.execute_with_args(
+            "human-monitor-command",
+            json!({ "command-line": command_line }),
+        )?;
+        match response {
+            QmpMessage::Success { ret, .. } => {
+                Ok(ret.as_str().unwrap_or_default().trim().to_string())
+            }
+            QmpMessage::Error { error, .. } => Err(Error::HostfwdCommandFailed(error.desc)),
+            _ => Ok(String::new()),
+        }
     }
 }

--- a/src/qemu/qemu_system.rs
+++ b/src/qemu/qemu_system.rs
@@ -7,6 +7,8 @@ use crate::qemu::QemuPathBuilder;
 use crate::util::SystemCommand;
 use crate::view::Console;
 
+pub const NETDEV_ID: &str = "net0";
+
 pub struct QemuSystem {
     command: SystemCommand,
 }
@@ -128,10 +130,10 @@ impl QemuSystem {
         let restrict = if isolate { "on" } else { "off" };
         self.command
             .arg("-device")
-            .arg("virtio-net-pci,netdev=net0,romfile=")
+            .arg(format!("virtio-net-pci,netdev={NETDEV_ID},romfile="))
             .arg("-netdev")
             .arg(format!(
-                "user,id=net0,restrict={restrict},hostfwd=tcp:127.0.0.1:{ssh_port}-:22{hostfwd_options}"
+                "user,id={NETDEV_ID},restrict={restrict},hostfwd=tcp:127.0.0.1:{ssh_port}-:22{hostfwd_options}"
             ));
     }
 

--- a/src/qemu/qmp_message.rs
+++ b/src/qemu/qmp_message.rs
@@ -9,8 +9,8 @@ pub struct QmpTimestamp {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct QmpError {
-    class: String,
-    desc: String,
+    pub class: String,
+    pub desc: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

cubic modify used to require a restart for --port and --rm-port changes. Now it applies them live on running instances using QEMU's HMP hostfwd_add and hostfwd_remove commands, reached over QMP through human-monitor-command. Other fields like cpus, memory, disk and isolate still need a restart.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Unit and manual tests.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed
