### PR TITLE
fix: disable whpx acceleration on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Cubic fits a lot of everyday workflows:
   - **Ubuntu**
 - Supports the following host OS: **Linux**, **macOS**, **Windows**
 - Supports **amd64** and **arm64** CPU architectures
-- Supports hardware acceleration with **KVM** (Linux), **Hypervisor** (macOS), and **Hyper-V** (Windows)
+- Supports hardware acceleration with **KVM** (Linux) and **Hypervisor** (macOS), Windows runs on **TCG** software emulation for now
 - Daemonless design which does not require root privileges
 - Written in Rust
 

--- a/docs/internals/how_it_works.rst
+++ b/docs/internals/how_it_works.rst
@@ -57,8 +57,14 @@ on the host platform:
 
 * **KVM** on Linux
 * **HVF** (Hypervisor Framework) on macOS
-* **Hyper-V** on Windows
+* **NVMM** on the BSDs
 * **TCG** (software emulation) as a fallback
+
+On Windows the **WHPX** accelerator is currently disabled and instances run on
+TCG software emulation. WHPX requires the ``host`` CPU model, while the CPU
+model Cubic passes is shared with the TCG path, and the mismatch makes the
+guest hang at the OVMF firmware screen. See `issue #500
+<https://github.com/cubic-vm/cubic/issues/500>`_.
 
 Each instance stores its own disk image under
 ``~/.local/share/cubic/machines/<name>/``, keeping instances fully isolated

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -97,7 +97,7 @@ Features
 * Supports Alma Linux, Arch Linux, Debian, Fedora, Gentoo, OpenSUSE, Rocky Linux and Ubuntu guest images
 * Uses official, checksum-verified cloud images downloaded straight from each distribution
 * Supports Linux, macOS and Windows hosts with amd64 and arm64 architecture
-* Supports hardware acceleration with KVM (Linux), Hypervisor (macOS) and Hyper-V (Windows)
+* Supports hardware acceleration with KVM (Linux) and Hypervisor (macOS), Windows runs on TCG software emulation for now
 * Boots each VM with EDK2 UEFI firmware, discovered automatically per architecture
 * No background privileged service and runs with standard user rights, no admin or root needed
 * Written in Rust

--- a/src/qemu/qemu_system.rs
+++ b/src/qemu/qemu_system.rs
@@ -23,9 +23,9 @@ impl QemuSystem {
             Some("nvmm")
         } else if cfg!(any(target_os = "macos", target_os = "ios")) {
             Some("hvf")
-        } else if cfg!(target_os = "windows") {
-            Some("whpx")
         } else {
+            // WHPX is disabled on Windows because it needs `-cpu host` while
+            // the shared `-cpu max` makes the guest hang at OVMF, see #500
             None
         }
     }


### PR DESCRIPTION
## Summary

WHPX only works with the host CPU model, but the CPU model is shared
with the TCG path where host breaks emulation. With the current max
model QEMU initialises WHPX and then hangs at the OVMF firmware
screen, so the -accel tcg fallback never triggers.

Windows now runs on TCG software emulation until the CPU model can be
chosen per accelerator.

## Related Issue(s)

Closes #500

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Manuel tests.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed
