### PR TITLE
refactor: move process and host access into the System trait

### DIFF
--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -97,7 +97,7 @@ impl Command for CreateCommand {
         let ssh_port = PortChecker::new().get_new_port()?;
 
         let (default_cpus, default_mem) =
-            ResourceAllocator::read_from_host().get_default_resources();
+            ResourceAllocator::read_from_host(context.get_system()).get_default_resources();
 
         let instance = Instance {
             name: self.instance_name.value.to_string(),

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -3,6 +3,7 @@ use crate::commands::{self, Command};
 use crate::error::{Error, Result};
 use crate::instance::InstanceStore;
 use crate::models::{DataSize, HOST_MEMORY_RESERVE, Instance, ResourceAllocator};
+use crate::platform::System;
 use crate::ssh::PortChecker;
 use crate::view::Console;
 use crate::view::{ConfirmDialog, Spinner};
@@ -10,7 +11,6 @@ use clap::Parser;
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
-use sysinfo::System;
 
 /// Start VM instances
 ///
@@ -66,7 +66,12 @@ impl Command for StartCommand {
                     ));
                 }
 
-                self.fit_to_available_memory(console, instance_store, instance)?;
+                self.fit_to_available_memory(
+                    console,
+                    context.get_system(),
+                    instance_store,
+                    instance,
+                )?;
 
                 let mut action = StartInstanceAction::new(instance);
                 action.run(context, &self.qemu_args, console)?;
@@ -106,12 +111,11 @@ impl StartCommand {
     fn fit_to_available_memory(
         &self,
         console: &mut Console<'_>,
+        system: &dyn System,
         instance_store: &dyn InstanceStore,
         instance: &mut Instance,
     ) -> Result<()> {
-        let mut system = System::new();
-        system.refresh_memory();
-        let available = system.available_memory() as usize;
+        let available = system.get_available_memory() as usize;
 
         console.debug(&format!(
             "Instance '{}' requests {}, host has {} available with {} reserved",
@@ -153,9 +157,102 @@ impl StartCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::instance::InstanceStoreMock;
+    use crate::platform::SystemMock;
+
+    const GIB: usize = 1024 * 1024 * 1024;
+
+    fn build_instance() -> Instance {
+        Instance {
+            name: "test".to_string(),
+            cpus: 8,
+            mem: DataSize::new(8 * GIB),
+            ..Instance::default()
+        }
+    }
 
     #[test]
     fn test_reject_path_traversal() {
         assert!(StartCommand::try_parse_from(["start", "../../etc"]).is_err());
+    }
+
+    #[test]
+    fn test_keeps_size_when_memory_is_available() {
+        let system = SystemMock::new().set_host_resources((16 * GIB) as u64, (16 * GIB) as u64, 8);
+        let mut console = Console::new(&system);
+        let store = InstanceStoreMock::new(vec![build_instance()]);
+        let command = StartCommand::try_parse_from(["start", "--yes", "test"]).unwrap();
+        let mut instance = build_instance();
+
+        command
+            .fit_to_available_memory(&mut console, &system, &store, &mut instance)
+            .unwrap();
+
+        assert_eq!(instance.cpus, 8);
+        assert_eq!(instance.mem.get_bytes(), 8 * GIB);
+    }
+
+    #[test]
+    fn test_reduces_size_to_fit_available_memory() {
+        // 5 GiB available minus the 1 GiB reserve leaves a 4 GiB budget.
+        let system = SystemMock::new().set_host_resources((16 * GIB) as u64, (5 * GIB) as u64, 8);
+        let mut console = Console::new(&system);
+        let store = InstanceStoreMock::new(vec![build_instance()]);
+        let command = StartCommand::try_parse_from(["start", "--yes", "test"]).unwrap();
+        let mut instance = build_instance();
+
+        command
+            .fit_to_available_memory(&mut console, &system, &store, &mut instance)
+            .unwrap();
+
+        assert_eq!(instance.cpus, 8);
+        assert_eq!(instance.mem.get_bytes(), 4 * GIB);
+    }
+
+    #[test]
+    fn test_reduces_size_when_the_user_confirms() {
+        let system = SystemMock::new().set_host_resources((16 * GIB) as u64, (5 * GIB) as u64, 8);
+        system.push_input("y");
+        let mut console = Console::new(&system);
+        let store = InstanceStoreMock::new(vec![build_instance()]);
+        let command = StartCommand::try_parse_from(["start", "test"]).unwrap();
+        let mut instance = build_instance();
+
+        command
+            .fit_to_available_memory(&mut console, &system, &store, &mut instance)
+            .unwrap();
+
+        assert_eq!(instance.mem.get_bytes(), 4 * GIB);
+    }
+
+    #[test]
+    fn test_errors_when_the_user_declines() {
+        let system = SystemMock::new().set_host_resources((16 * GIB) as u64, (5 * GIB) as u64, 8);
+        system.push_input("n");
+        let mut console = Console::new(&system);
+        let store = InstanceStoreMock::new(vec![build_instance()]);
+        let command = StartCommand::try_parse_from(["start", "test"]).unwrap();
+        let mut instance = build_instance();
+
+        assert!(matches!(
+            command.fit_to_available_memory(&mut console, &system, &store, &mut instance),
+            Err(Error::NotEnoughMemory(name)) if name == "test"
+        ));
+        // The instance keeps its size, the reduction is only applied on accept.
+        assert_eq!(instance.mem.get_bytes(), 8 * GIB);
+    }
+
+    #[test]
+    fn test_errors_when_nothing_fits() {
+        let system = SystemMock::new().set_host_resources((16 * GIB) as u64, GIB as u64, 8);
+        let mut console = Console::new(&system);
+        let store = InstanceStoreMock::new(vec![build_instance()]);
+        let command = StartCommand::try_parse_from(["start", "--yes", "test"]).unwrap();
+        let mut instance = build_instance();
+
+        assert!(matches!(
+            command.fit_to_available_memory(&mut console, &system, &store, &mut instance),
+            Err(Error::NotEnoughMemory(name)) if name == "test"
+        ));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,14 @@ pub enum Error {
     #[error("Instance '{0}' is not running")]
     InstanceNotRunning(String),
 
+    #[error("Process {0} is not running")]
+    ProcessNotFound(u64),
+
+    #[error(
+        "Cannot kill process {0}.\n\nTroubleshoot:\n  - Check that the process belongs to you\n  - Kill it manually and try again\n"
+    )]
+    KillFailed(u64),
+
     #[error(
         "Timed out waiting for instance(s) to start.\n\nTroubleshoot:\n  - Run with --verbose to see the QEMU command\n  - Check that QEMU can open /dev/kvm and firmware files\n  - Try again; the system may be under load\n"
     )]

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -30,13 +30,6 @@ impl InstanceDao {
         })
     }
 
-    fn is_process_alive(&self, pid: u64) -> bool {
-        let sys_pid = sysinfo::Pid::from_u32(pid as u32);
-        let mut system = sysinfo::System::new();
-        system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[sys_pid]), true);
-        system.process(sys_pid).is_some()
-    }
-
     fn read_running_pid(&self, instance: &Instance) -> Option<u64> {
         let pid = self
             .system
@@ -46,7 +39,7 @@ impl InstanceDao {
             .parse::<u64>()
             .ok()?;
 
-        if self.is_process_alive(pid) {
+        if self.system.exists_process(pid) {
             Some(pid)
         } else {
             self.system
@@ -211,17 +204,22 @@ impl InstanceStore for InstanceDao {
             .get_pid(instance)
             .ok_or_else(|| Error::InstanceNotRunning(instance.name.clone()))?;
 
-        let sys_pid = sysinfo::Pid::from_u32(pid as u32);
-        let mut system = sysinfo::System::new();
-        system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[sys_pid]), true);
-        if let Some(process) = system.process(sys_pid) {
-            process.kill();
-        }
+        // A process that died between the check above and the signal already
+        // reached the goal of this call, so it counts as success. Only a live
+        // process that refused to die is an error, and it keeps its pid file,
+        // since dropping the file would orphan a QEMU process that no later
+        // command could reach.
+        let result = match self.system.kill_process(pid) {
+            Err(Error::ProcessNotFound(_)) => Ok(()),
+            result => result,
+        };
 
-        self.system
-            .remove_file(Path::new(&self.env.get_qemu_pid_file(&instance.name)))
-            .ok();
-        Ok(())
+        if result.is_ok() {
+            self.system
+                .remove_file(Path::new(&self.env.get_qemu_pid_file(&instance.name)))
+                .ok();
+        }
+        result
     }
 
     fn get_monitor(&self, instance: &Instance) -> Result<Monitor> {
@@ -242,6 +240,13 @@ mod tests {
             "/cache".to_string(),
             "/run".to_string(),
         )
+    }
+
+    fn build_instance() -> Instance {
+        Instance {
+            name: "test".to_string(),
+            ..Instance::default()
+        }
     }
 
     #[test]
@@ -266,6 +271,93 @@ mod tests {
         let loaded = dao.load("test").unwrap();
 
         assert_eq!(loaded.name, instance.name);
+    }
+
+    #[test]
+    fn test_is_running_true_when_pid_alive() {
+        let env = build_env();
+        let system = SystemMock::new()
+            .add_file(&env.get_qemu_pid_file("test"), b"1234\n")
+            .add_process(1234);
+        let dao = InstanceDao::new(Rc::new(system), &env).unwrap();
+
+        assert!(dao.is_running(&build_instance()));
+        assert_eq!(dao.get_pid(&build_instance()), Some(1234));
+    }
+
+    #[test]
+    fn test_is_running_false_and_removes_stale_pid_file() {
+        let env = build_env();
+        let system = Rc::new(SystemMock::new().add_file(&env.get_qemu_pid_file("test"), b"1234\n"));
+        let dao = InstanceDao::new(Rc::clone(&system) as Rc<dyn System>, &env).unwrap();
+
+        assert!(!dao.is_running(&build_instance()));
+        assert!(!system.exists_path(Path::new(&env.get_qemu_pid_file("test"))));
+    }
+
+    #[test]
+    fn test_kill_kills_pid_and_removes_pid_file() {
+        let env = build_env();
+        let system = Rc::new(
+            SystemMock::new()
+                .add_file(&env.get_qemu_pid_file("test"), b"1234\n")
+                .add_process(1234),
+        );
+        let dao = InstanceDao::new(Rc::clone(&system) as Rc<dyn System>, &env).unwrap();
+
+        dao.kill(&build_instance()).unwrap();
+
+        assert_eq!(system.get_killed_processes(), vec![1234]);
+        assert!(!system.exists_path(Path::new(&env.get_qemu_pid_file("test"))));
+    }
+
+    #[test]
+    fn test_kill_succeeds_when_the_process_died_first() {
+        let env = build_env();
+        let system = Rc::new(
+            SystemMock::new()
+                .add_file(&env.get_qemu_pid_file("test"), b"1234\n")
+                .add_vanishing_process(1234),
+        );
+        let dao = InstanceDao::new(Rc::clone(&system) as Rc<dyn System>, &env).unwrap();
+
+        // The process is gone, which is what the call asked for, so losing the
+        // race to whoever reaped it is not a failure.
+        dao.kill(&build_instance()).unwrap();
+
+        assert!(system.get_killed_processes().is_empty());
+        assert!(!system.exists_path(Path::new(&env.get_qemu_pid_file("test"))));
+    }
+
+    #[test]
+    fn test_kill_keeps_pid_file_when_the_kill_fails() {
+        let env = build_env();
+        let system = Rc::new(
+            SystemMock::new()
+                .add_file(&env.get_qemu_pid_file("test"), b"1234\n")
+                .add_unkillable_process(1234),
+        );
+        let dao = InstanceDao::new(Rc::clone(&system) as Rc<dyn System>, &env).unwrap();
+
+        assert!(matches!(
+            dao.kill(&build_instance()),
+            Err(Error::KillFailed(1234))
+        ));
+        // The pid file has to survive, otherwise the still running QEMU
+        // process would be unreachable for every later command.
+        assert!(system.exists_path(Path::new(&env.get_qemu_pid_file("test"))));
+        assert!(dao.is_running(&build_instance()));
+    }
+
+    #[test]
+    fn test_kill_errors_when_not_running() {
+        let system = SystemMock::new();
+        let dao = InstanceDao::new(Rc::new(system), &build_env()).unwrap();
+
+        assert!(matches!(
+            dao.kill(&build_instance()),
+            Err(Error::InstanceNotRunning(name)) if name == "test"
+        ));
     }
 
     #[test]

--- a/src/models/resource_allocator.rs
+++ b/src/models/resource_allocator.rs
@@ -1,5 +1,5 @@
 use crate::models::DataSize;
-use sysinfo::System;
+use crate::platform::System;
 
 const MIB: usize = 1024 * 1024;
 const GIB: usize = 1024 * MIB;
@@ -43,15 +43,12 @@ impl ResourceAllocator {
 
     /// Read the live host total memory and cpu count and build an allocator.
     ///
-    /// `cpus().len()` counts logical processors, so a host with simultaneous
-    /// multithreading reports its thread count rather than its physical cores.
-    /// This matches the vCPU count handed to a machine, which also maps to
-    /// threads.
-    pub fn read_from_host() -> Self {
-        let mut system = System::new();
-        system.refresh_memory();
-        system.refresh_cpu_all();
-        Self::new(system.total_memory() as usize, system.cpus().len() as u16)
+    /// The cpu count is the number of logical processors, so a host with
+    /// simultaneous multithreading reports its thread count rather than its
+    /// physical cores. This matches the vCPU count handed to a machine, which
+    /// also maps to threads.
+    pub fn read_from_host(system: &dyn System) -> Self {
+        Self::new(system.get_total_memory() as usize, system.get_cpu_count())
     }
 
     /// Return the default vCPU count and memory for a new machine by selecting
@@ -90,6 +87,7 @@ impl ResourceAllocator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::SystemMock;
 
     fn assert_resources(
         host_mem_gib: usize,
@@ -101,6 +99,18 @@ mod tests {
         let (cpus, mem) = allocator.get_default_resources();
         assert_eq!(cpus, expected_cpus);
         assert_eq!(mem.get_bytes(), expected_mem_bytes);
+    }
+
+    #[test]
+    fn test_read_from_host_uses_the_host_totals() {
+        // A 16 GiB, 16 thread host. Only the totals are read, the available
+        // memory plays no part in the default size.
+        let system = SystemMock::new().set_host_resources((16 * GIB) as u64, (16 * GIB) as u64, 16);
+
+        let (cpus, mem) = ResourceAllocator::read_from_host(&system).get_default_resources();
+
+        assert_eq!(cpus, 6);
+        assert_eq!(mem.get_bytes(), 3 * GIB);
     }
 
     #[test]

--- a/src/platform/os_system.rs
+++ b/src/platform/os_system.rs
@@ -11,6 +11,16 @@ impl OsSystem {
     pub fn new() -> Self {
         Self
     }
+
+    // Refreshes a single process so a lookup sees the current state of the
+    // host. `sysinfo::System` is spelled out because the name collides with
+    // the `System` trait implemented below.
+    fn read_process_table(pid: u64) -> (sysinfo::System, sysinfo::Pid) {
+        let sys_pid = sysinfo::Pid::from_u32(pid as u32);
+        let mut system = sysinfo::System::new();
+        system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[sys_pid]), true);
+        (system, sys_pid)
+    }
 }
 
 impl System for OsSystem {
@@ -251,5 +261,37 @@ impl System for OsSystem {
     fn remove_file(&self, path: &Path) -> Result<()> {
         fs::remove_file(path)
             .map_err(|e| Error::FS(format!("Cannot delete file '{}' ({e})", path.display())))
+    }
+
+    fn exists_process(&self, pid: u64) -> bool {
+        let (system, sys_pid) = Self::read_process_table(pid);
+        system.process(sys_pid).is_some()
+    }
+
+    fn kill_process(&self, pid: u64) -> Result<()> {
+        let (system, sys_pid) = Self::read_process_table(pid);
+        let process = system.process(sys_pid).ok_or(Error::ProcessNotFound(pid))?;
+
+        process.kill().then_some(()).ok_or(Error::KillFailed(pid))
+    }
+
+    fn get_total_memory(&self) -> u64 {
+        let mut system = sysinfo::System::new();
+        system.refresh_memory();
+        system.total_memory()
+    }
+
+    fn get_available_memory(&self) -> u64 {
+        let mut system = sysinfo::System::new();
+        system.refresh_memory();
+        system.available_memory()
+    }
+
+    // Counts logical processors, so a host with simultaneous multithreading
+    // reports its thread count rather than its physical cores.
+    fn get_cpu_count(&self) -> u16 {
+        let mut system = sysinfo::System::new();
+        system.refresh_cpu_all();
+        system.cpus().len() as u16
     }
 }

--- a/src/platform/system.rs
+++ b/src/platform/system.rs
@@ -31,4 +31,11 @@ pub trait System {
     fn write_secret_file(&self, path: &Path, contents: &[u8]) -> Result<()>;
     fn rename_file(&self, from: &Path, to: &Path) -> Result<()>;
     fn remove_file(&self, path: &Path) -> Result<()>;
+
+    fn exists_process(&self, pid: u64) -> bool;
+    fn kill_process(&self, pid: u64) -> Result<()>;
+
+    fn get_total_memory(&self) -> u64;
+    fn get_available_memory(&self) -> u64;
+    fn get_cpu_count(&self) -> u16;
 }

--- a/src/platform/system_mock.rs
+++ b/src/platform/system_mock.rs
@@ -8,6 +8,20 @@ pub mod tests {
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
 
+    // How a seeded pid answers a kill. Every state is visible to a liveness
+    // check, they differ only in what killing one does.
+    #[derive(Clone, Copy)]
+    enum ProcessState {
+        // Dies when killed.
+        Alive,
+        // Stays alive and reports a failure, standing in for a kill the host
+        // rejects, such as one aimed at another user's process.
+        Unkillable,
+        // Already gone once the kill lands, modelling the race between
+        // checking a pid and signalling it.
+        Vanished,
+    }
+
     pub struct SystemMock {
         env_vars: HashMap<String, String>,
         output: RefCell<String>,
@@ -15,6 +29,11 @@ pub mod tests {
         input: RefCell<VecDeque<String>>,
         files: Rc<RefCell<HashMap<PathBuf, Vec<u8>>>>,
         dirs: RefCell<HashSet<PathBuf>>,
+        processes: RefCell<HashMap<u64, ProcessState>>,
+        killed: RefCell<Vec<u64>>,
+        total_memory: u64,
+        available_memory: u64,
+        cpu_count: u16,
     }
 
     impl SystemMock {
@@ -26,6 +45,13 @@ pub mod tests {
                 input: RefCell::new(VecDeque::new()),
                 files: Rc::new(RefCell::new(HashMap::new())),
                 dirs: RefCell::new(HashSet::new()),
+                processes: RefCell::new(HashMap::new()),
+                killed: RefCell::new(Vec::new()),
+                // A roomy host by default, so a test that does not care about
+                // host size never hits a resource limit by accident.
+                total_memory: 16 * 1024 * 1024 * 1024,
+                available_memory: 16 * 1024 * 1024 * 1024,
+                cpu_count: 8,
             }
         }
 
@@ -63,6 +89,39 @@ pub mod tests {
 
         pub fn get_written_file(&self, path: &str) -> Option<Vec<u8>> {
             self.files.borrow().get(Path::new(path)).cloned()
+        }
+
+        pub fn add_process(self, pid: u64) -> Self {
+            self.add_process_state(pid, ProcessState::Alive)
+        }
+
+        pub fn add_unkillable_process(self, pid: u64) -> Self {
+            self.add_process_state(pid, ProcessState::Unkillable)
+        }
+
+        pub fn add_vanishing_process(self, pid: u64) -> Self {
+            self.add_process_state(pid, ProcessState::Vanished)
+        }
+
+        fn add_process_state(self, pid: u64, state: ProcessState) -> Self {
+            self.processes.borrow_mut().insert(pid, state);
+            self
+        }
+
+        pub fn set_host_resources(
+            mut self,
+            total_memory: u64,
+            available_memory: u64,
+            cpu_count: u16,
+        ) -> Self {
+            self.total_memory = total_memory;
+            self.available_memory = available_memory;
+            self.cpu_count = cpu_count;
+            self
+        }
+
+        pub fn get_killed_processes(&self) -> Vec<u64> {
+            self.killed.borrow().clone()
         }
 
         // Registers every ancestor as a directory, so a seeded path behaves
@@ -309,6 +368,39 @@ pub mod tests {
                         path.display()
                     ))
                 })
+        }
+
+        fn exists_process(&self, pid: u64) -> bool {
+            self.processes.borrow().contains_key(&pid)
+        }
+
+        fn kill_process(&self, pid: u64) -> Result<()> {
+            let state = self.processes.borrow().get(&pid).copied();
+            match state {
+                None => Err(Error::ProcessNotFound(pid)),
+                Some(ProcessState::Unkillable) => Err(Error::KillFailed(pid)),
+                Some(ProcessState::Vanished) => {
+                    self.processes.borrow_mut().remove(&pid);
+                    Err(Error::ProcessNotFound(pid))
+                }
+                Some(ProcessState::Alive) => {
+                    self.processes.borrow_mut().remove(&pid);
+                    self.killed.borrow_mut().push(pid);
+                    Ok(())
+                }
+            }
+        }
+
+        fn get_total_memory(&self) -> u64 {
+            self.total_memory
+        }
+
+        fn get_available_memory(&self) -> u64 {
+            self.available_memory
+        }
+
+        fn get_cpu_count(&self) -> u16 {
+            self.cpu_count
         }
     }
 
@@ -617,5 +709,84 @@ pub mod tests {
 
         assert!(!system.exists_path(Path::new("/data/sub")));
         assert!(!system.exists_path(Path::new("/data/sub/c.txt")));
+    }
+
+    #[test]
+    fn exists_process_only_finds_seeded_pids() {
+        let system = SystemMock::new().add_process(42);
+
+        assert!(system.exists_process(42));
+        assert!(!system.exists_process(43));
+    }
+
+    #[test]
+    fn kill_process_records_the_pid_and_ends_the_process() {
+        let system = SystemMock::new().add_process(42);
+
+        system.kill_process(42).unwrap();
+
+        assert_eq!(system.get_killed_processes(), vec![42]);
+        assert!(!system.exists_process(42));
+    }
+
+    #[test]
+    fn kill_process_fails_for_an_unkillable_pid_that_stays_alive() {
+        let system = SystemMock::new().add_unkillable_process(42);
+
+        assert!(matches!(
+            system.kill_process(42),
+            Err(Error::KillFailed(42))
+        ));
+        assert!(system.exists_process(42));
+        assert!(system.get_killed_processes().is_empty());
+    }
+
+    #[test]
+    fn kill_process_reports_a_vanishing_process_as_gone() {
+        let system = SystemMock::new().add_vanishing_process(42);
+
+        assert!(system.exists_process(42));
+        assert!(matches!(
+            system.kill_process(42),
+            Err(Error::ProcessNotFound(42))
+        ));
+        // Once the kill has reported it gone, every later look agrees.
+        assert!(!system.exists_process(42));
+        assert!(system.get_killed_processes().is_empty());
+    }
+
+    #[test]
+    fn seeding_a_pid_twice_keeps_the_last_state() {
+        let system = SystemMock::new().add_process(42).add_vanishing_process(42);
+
+        assert!(matches!(
+            system.kill_process(42),
+            Err(Error::ProcessNotFound(42))
+        ));
+
+        let system = SystemMock::new().add_vanishing_process(7).add_process(7);
+
+        system.kill_process(7).unwrap();
+        assert_eq!(system.get_killed_processes(), vec![7]);
+    }
+
+    #[test]
+    fn kill_process_fails_for_an_unknown_pid() {
+        let system = SystemMock::new();
+
+        assert!(matches!(
+            system.kill_process(42),
+            Err(Error::ProcessNotFound(42))
+        ));
+        assert!(system.get_killed_processes().is_empty());
+    }
+
+    #[test]
+    fn host_resources_return_the_configured_values() {
+        let system = SystemMock::new().set_host_resources(8_000, 2_000, 4);
+
+        assert_eq!(system.get_total_memory(), 8_000);
+        assert_eq!(system.get_available_memory(), 2_000);
+        assert_eq!(system.get_cpu_count(), 4);
     }
 }


### PR DESCRIPTION
## Summary

Process liveness, killing and the host memory and cpu totals read sysinfo directly from InstanceDao and the commands. That kept those paths out of reach of the tests.

The System trait now covers them and sysinfo stays inside OsSystem. The system mock can stand in for a live host. A kill that leaves the process running reports an error and keeps the pid file. A process that died first counts as success.

## Related Issue(s)

Closes #

## Type of Change

- [] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Run tests.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed
