### PR TITLE
refactor: move command execution into the System trait

### DIFF
--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -106,7 +106,12 @@ impl StartInstanceAction {
         qemu_system.set_pid_file(&env.get_qemu_pid_file(&self.instance.name));
 
         qemu_system.set_monitor(self.instance.monitor_port.unwrap(), &instance_dir);
-        qemu_system.run(console)
+
+        let command = qemu_system.build_command();
+        console.debug(&command.get_command());
+        system
+            .spawn_command(&command)
+            .map_err(QemuSystem::map_error)
     }
 
     pub fn is_done(&self) -> bool {

--- a/src/platform/os_system.rs
+++ b/src/platform/os_system.rs
@@ -1,8 +1,11 @@
 use crate::error::{Error, Result};
 use crate::platform::{Stream, System};
+use crate::util::SystemCommand;
 use std::fs;
-use std::io::{IsTerminal, Read, Write, stderr, stdin, stdout};
+use std::io::{ErrorKind, IsTerminal, Read, Write, stderr, stdin, stdout};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::str::from_utf8;
 
 #[derive(Default)]
 pub struct OsSystem;
@@ -21,6 +24,38 @@ impl OsSystem {
         system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[sys_pid]), true);
         (system, sys_pid)
     }
+
+    fn build_process(command: &SystemCommand) -> Command {
+        let mut process = Command::new(command.get_program());
+        process.args(command.get_args());
+        for (key, value) in command.get_envs() {
+            process.env(key, value);
+        }
+        process
+    }
+
+    // A missing binary is worth telling apart from a binary that refused to
+    // start, since only the first one means the host lacks the tool.
+    fn map_spawn_error(command: &SystemCommand, error: std::io::Error) -> Error {
+        if error.kind() == ErrorKind::NotFound {
+            return Error::SystemCommandNotFound(command.get_program().to_string());
+        }
+
+        Error::SystemCommandFailed(command.get_command(), error.to_string())
+    }
+}
+
+// Detaches the child from the session of the parent, so it survives the shell
+// that started cubic.
+#[cfg(unix)]
+fn detach_from_session() -> std::io::Result<()> {
+    unsafe extern "C" {
+        fn setsid() -> i32;
+    }
+    if unsafe { setsid() } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 impl System for OsSystem {
@@ -273,6 +308,74 @@ impl System for OsSystem {
         let process = system.process(sys_pid).ok_or(Error::ProcessNotFound(pid))?;
 
         process.kill().then_some(()).ok_or(Error::KillFailed(pid))
+    }
+
+    fn run_command(&self, command: &SystemCommand) -> Result<Vec<u8>> {
+        Self::build_process(command)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| Self::map_spawn_error(command, e))
+            .and_then(|out| {
+                if out.status.success() {
+                    Ok(out.stdout)
+                } else {
+                    Err(Error::SystemCommandFailed(
+                        command.get_command(),
+                        from_utf8(&out.stderr).unwrap_or_default().to_string(),
+                    ))
+                }
+            })
+    }
+
+    fn spawn_command(&self, command: &SystemCommand) -> Result<()> {
+        let mut process = Self::build_process(command);
+
+        #[cfg(unix)]
+        unsafe {
+            use std::os::unix::process::CommandExt;
+            process.pre_exec(detach_from_session);
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            const DETACHED_PROCESS: u32 = 0x0000_0008;
+            process.creation_flags(DETACHED_PROCESS);
+        }
+
+        let mut child = process
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| Self::map_spawn_error(command, e))?;
+
+        // Check immediately for instant failures, then again after a brief window
+        // to catch startup errors (KVM permission denied, bad firmware, port conflicts).
+        for ms in [0, 100] {
+            std::thread::sleep(std::time::Duration::from_millis(ms));
+            if let Ok(Some(_)) = child.try_wait() {
+                let stderr = child
+                    .stderr
+                    .take()
+                    .map(|mut s| {
+                        let mut buf = Vec::new();
+                        s.read_to_end(&mut buf).unwrap_or(0);
+                        from_utf8(&buf).unwrap_or_default().to_owned()
+                    })
+                    .unwrap_or_default();
+                return Err(Error::SystemCommandFailed(command.get_command(), stderr));
+            }
+        }
+
+        // Reap the child when it eventually exits to avoid a zombie process.
+        std::thread::spawn(move || {
+            let _ = child.wait();
+        });
+
+        Ok(())
     }
 
     fn get_total_memory(&self) -> u64 {

--- a/src/platform/system.rs
+++ b/src/platform/system.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
 use crate::platform::Stream;
+use crate::util::SystemCommand;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
@@ -34,6 +35,9 @@ pub trait System {
 
     fn exists_process(&self, pid: u64) -> bool;
     fn kill_process(&self, pid: u64) -> Result<()>;
+
+    fn run_command(&self, command: &SystemCommand) -> Result<Vec<u8>>;
+    fn spawn_command(&self, command: &SystemCommand) -> Result<()>;
 
     fn get_total_memory(&self) -> u64;
     fn get_available_memory(&self) -> u64;

--- a/src/platform/system_mock.rs
+++ b/src/platform/system_mock.rs
@@ -2,6 +2,7 @@
 pub mod tests {
     use crate::error::{Error, Result};
     use crate::platform::{Stream, System};
+    use crate::util::SystemCommand;
     use std::cell::RefCell;
     use std::collections::{HashMap, HashSet, VecDeque};
     use std::io::{Cursor, Read, Write};
@@ -233,6 +234,44 @@ pub mod tests {
         }
     }
 
+    // How a seeded command answers a run.
+    enum CommandResult {
+        // Exits successfully with this on stdout.
+        Output(Vec<u8>),
+        // Exits with a failure carrying this on stderr.
+        Failure(String),
+    }
+
+    // The commands the host knows how to answer, alongside the record of what
+    // was attempted. A command that is not seeded is one the host cannot run,
+    // so it reports a missing binary rather than quietly succeeding.
+    #[derive(Default)]
+    struct CommandTable {
+        results: HashMap<String, CommandResult>,
+        executed: Vec<String>,
+    }
+
+    impl CommandTable {
+        fn add(&mut self, command: &str, result: CommandResult) {
+            self.results.insert(command.to_string(), result);
+        }
+
+        fn run(&mut self, command: &SystemCommand) -> Result<Vec<u8>> {
+            let line = command.get_command();
+            self.executed.push(line.clone());
+
+            match self.results.get(line.as_str()) {
+                None => Err(Error::SystemCommandNotFound(
+                    command.get_program().to_string(),
+                )),
+                Some(CommandResult::Failure(stderr)) => {
+                    Err(Error::SystemCommandFailed(line, stderr.clone()))
+                }
+                Some(CommandResult::Output(stdout)) => Ok(stdout.clone()),
+            }
+        }
+    }
+
     pub struct SystemMock {
         env_vars: HashMap<String, String>,
         terminal: bool,
@@ -240,6 +279,7 @@ pub mod tests {
         console: RefCell<ConsoleState>,
         file_system: Rc<RefCell<FileSystemState>>,
         processes: RefCell<ProcessTable>,
+        commands: RefCell<CommandTable>,
     }
 
     impl SystemMock {
@@ -257,6 +297,7 @@ pub mod tests {
                 console: RefCell::new(ConsoleState::default()),
                 file_system: Rc::new(RefCell::new(FileSystemState::default())),
                 processes: RefCell::new(ProcessTable::default()),
+                commands: RefCell::new(CommandTable::default()),
             }
         }
 
@@ -327,6 +368,25 @@ pub mod tests {
 
         pub fn get_killed_processes(&self) -> Vec<u64> {
             self.processes.borrow().killed.clone()
+        }
+
+        pub fn add_command_output(self, command: &str, stdout: &[u8]) -> Self {
+            self.commands
+                .borrow_mut()
+                .add(command, CommandResult::Output(stdout.to_vec()));
+            self
+        }
+
+        pub fn add_failing_command(self, command: &str, stderr: &str) -> Self {
+            self.commands
+                .borrow_mut()
+                .add(command, CommandResult::Failure(stderr.to_string()));
+            self
+        }
+
+        // Every command the host was asked to run, seeded or not, in order.
+        pub fn get_executed_commands(&self) -> Vec<String> {
+            self.commands.borrow().executed.clone()
         }
     }
 
@@ -486,6 +546,16 @@ pub mod tests {
 
         fn kill_process(&self, pid: u64) -> Result<()> {
             self.processes.borrow_mut().kill(pid)
+        }
+
+        fn run_command(&self, command: &SystemCommand) -> Result<Vec<u8>> {
+            self.commands.borrow_mut().run(command)
+        }
+
+        // A detached start has nothing to wait for, so it only reports whether
+        // the host could launch the command at all.
+        fn spawn_command(&self, command: &SystemCommand) -> Result<()> {
+            self.commands.borrow_mut().run(command).map(|_| ())
         }
 
         fn get_total_memory(&self) -> u64 {
@@ -885,5 +955,85 @@ pub mod tests {
         assert_eq!(system.get_total_memory(), 8_000);
         assert_eq!(system.get_available_memory(), 2_000);
         assert_eq!(system.get_cpu_count(), 4);
+    }
+
+    #[test]
+    fn run_command_returns_the_seeded_output() {
+        let system = SystemMock::new().add_command_output("echo hello", b"hello\n");
+
+        let mut command = SystemCommand::new("echo");
+        command.arg("hello");
+
+        assert_eq!(system.run_command(&command).unwrap(), b"hello\n");
+    }
+
+    #[test]
+    fn run_command_fails_for_an_unseeded_command() {
+        let system = SystemMock::new();
+
+        assert!(matches!(
+            system.run_command(&SystemCommand::new("qemu-img")),
+            Err(Error::SystemCommandNotFound(program)) if program == "qemu-img"
+        ));
+    }
+
+    #[test]
+    fn run_command_reports_a_seeded_failure_with_its_stderr() {
+        let system = SystemMock::new().add_failing_command("qemu-img resize", "no such file");
+
+        let mut command = SystemCommand::new("qemu-img");
+        command.arg("resize");
+
+        assert!(matches!(
+            system.run_command(&command),
+            Err(Error::SystemCommandFailed(line, stderr))
+                if line == "qemu-img resize" && stderr == "no such file"
+        ));
+    }
+
+    #[test]
+    fn run_command_matches_on_the_arguments() {
+        let system = SystemMock::new().add_command_output("qemu-img info a", b"a");
+
+        let mut other = SystemCommand::new("qemu-img");
+        other.arg("info").arg("b");
+
+        assert!(system.run_command(&other).is_err());
+    }
+
+    #[test]
+    fn spawn_command_succeeds_without_returning_output() {
+        let system = SystemMock::new().add_command_output("qemu-system-x86_64", b"ignored");
+
+        system
+            .spawn_command(&SystemCommand::new("qemu-system-x86_64"))
+            .unwrap();
+    }
+
+    #[test]
+    fn spawn_command_fails_for_an_unseeded_command() {
+        let system = SystemMock::new();
+
+        assert!(matches!(
+            system.spawn_command(&SystemCommand::new("qemu-system-x86_64")),
+            Err(Error::SystemCommandNotFound(program)) if program == "qemu-system-x86_64"
+        ));
+    }
+
+    #[test]
+    fn get_executed_commands_records_every_attempt_in_order() {
+        let system = SystemMock::new().add_command_output("echo one", b"");
+
+        let mut first = SystemCommand::new("echo");
+        first.arg("one");
+        system.run_command(&first).unwrap();
+
+        let mut second = SystemCommand::new("echo");
+        second.arg("two");
+        system.run_command(&second).ok();
+
+        // The failed attempt is recorded too, since the host was still asked
+        // to run it.
+        assert_eq!(system.get_executed_commands(), vec!["echo one", "echo two"]);
     }
 }

--- a/src/qemu/qemu_img.rs
+++ b/src/qemu/qemu_img.rs
@@ -35,38 +35,49 @@ impl<'a> QemuImg<'a> {
         }
     }
 
+    // Anything that keeps the info from arriving, from a host without qemu to
+    // an image the tool cannot read, leaves the caller with what it already
+    // knows about the disk.
     pub fn get_image_info(&self, env: &Environment, instance: &Instance) -> Option<ImageInfo> {
-        self.command()
+        let mut command = self.command();
+        command
             .arg("info")
             .arg("--force-share")
             .arg("--output")
             .arg("json")
-            .arg(env.get_instance_image_file(&instance.name))
-            .output()
+            .arg(env.get_instance_image_file(&instance.name));
+
+        self.system
+            .run_command(&command)
             .ok()
-            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .and_then(|stdout| String::from_utf8(stdout).ok())
             .and_then(|stdout| serde_json::from_str(&stdout).ok())
     }
 
     pub fn convert(&self, src: &str, dst: &str) -> Result<()> {
-        self.command()
+        let mut command = self.command();
+        command
             .arg("convert")
             .arg("-f")
             .arg("qcow2")
             .arg("-O")
             .arg("qcow2")
             .arg(src)
-            .arg(dst)
-            .run()
+            .arg(dst);
+
+        self.system
+            .run_command(&command)
+            .map(|_| ())
             .map_err(Self::map_error)
     }
 
     pub fn resize(&self, image: &str, size: u64) -> Result<()> {
-        self.command()
-            .arg("resize")
-            .arg(image)
-            .arg(size.to_string())
-            .run()
+        let mut command = self.command();
+        command.arg("resize").arg(image).arg(size.to_string());
+
+        self.system
+            .run_command(&command)
+            .map(|_| ())
             .map_err(Self::map_error)
     }
 }
@@ -74,6 +85,110 @@ impl<'a> QemuImg<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::UserName;
+    use crate::platform::SystemMock;
+    use std::str::FromStr;
+
+    fn build_env() -> Environment {
+        Environment::new(
+            UserName::from_str("cubic").unwrap(),
+            "/data".to_string(),
+            "/cache".to_string(),
+            "/run".to_string(),
+        )
+    }
+
+    fn build_instance() -> Instance {
+        Instance {
+            name: "test".to_string(),
+            ..Instance::default()
+        }
+    }
+
+    fn build_info_command(env: &Environment) -> String {
+        format!(
+            "qemu-img info --force-share --output json {}",
+            env.get_instance_image_file("test")
+        )
+    }
+
+    #[test]
+    fn test_get_image_info_reads_the_reported_sizes() {
+        let env = build_env();
+        let system = SystemMock::new().add_command_output(
+            &build_info_command(&env),
+            br#"{"virtual-size": 1073741824, "actual-size": 200704}"#,
+        );
+
+        let info = QemuImg::new(&system)
+            .get_image_info(&env, &build_instance())
+            .unwrap();
+
+        assert_eq!(info.virtual_size, 1073741824);
+        assert_eq!(info.actual_size, 200704);
+    }
+
+    #[test]
+    fn test_get_image_info_is_none_without_qemu() {
+        let env = build_env();
+        let system = SystemMock::new();
+
+        assert!(
+            QemuImg::new(&system)
+                .get_image_info(&env, &build_instance())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_get_image_info_is_none_when_the_output_is_not_readable() {
+        let env = build_env();
+        let system = SystemMock::new().add_command_output(&build_info_command(&env), b"not json");
+
+        assert!(
+            QemuImg::new(&system)
+                .get_image_info(&env, &build_instance())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_resize_reports_a_missing_qemu() {
+        let system = SystemMock::new();
+
+        assert!(matches!(
+            QemuImg::new(&system).resize("/data/machines/test/image", 2048),
+            Err(Error::QemuNotFound)
+        ));
+    }
+
+    #[test]
+    fn test_resize_passes_the_size_to_qemu_img() {
+        let system = SystemMock::new()
+            .add_command_output("qemu-img resize /data/machines/test/image 2048", b"");
+
+        QemuImg::new(&system)
+            .resize("/data/machines/test/image", 2048)
+            .unwrap();
+
+        assert_eq!(
+            system.get_executed_commands(),
+            vec!["qemu-img resize /data/machines/test/image 2048"]
+        );
+    }
+
+    #[test]
+    fn test_convert_reports_the_failure_of_qemu_img() {
+        let system = SystemMock::new().add_failing_command(
+            "qemu-img convert -f qcow2 -O qcow2 /cache/image /data/machines/test/image",
+            "boom",
+        );
+
+        assert!(matches!(
+            QemuImg::new(&system).convert("/cache/image", "/data/machines/test/image"),
+            Err(Error::SystemCommandFailed(_, stderr)) if stderr == "boom"
+        ));
+    }
 
     #[test]
     fn test_image_info() {

--- a/src/qemu/qemu_system.rs
+++ b/src/qemu/qemu_system.rs
@@ -5,7 +5,6 @@ use crate::models::{Arch, PortForward};
 use crate::platform::System;
 use crate::qemu::QemuPathBuilder;
 use crate::util::SystemCommand;
-use crate::view::Console;
 
 pub const NETDEV_ID: &str = "net0";
 
@@ -167,17 +166,18 @@ impl QemuSystem {
         self.command.arg("-pidfile").arg(path);
     }
 
-    fn map_error(error: Error) -> Error {
+    // A host that cannot find the binary lacks qemu, which is worth saying
+    // plainly rather than reporting a command that would not start. The caller
+    // runs the command, so it maps the failure through here.
+    pub fn map_error(error: Error) -> Error {
         match error {
             Error::SystemCommandNotFound(_) => Error::QemuNotFound,
             other => other,
         }
     }
 
-    pub fn run(&mut self, console: &mut Console<'_>) -> Result<()> {
-        console.debug(&self.command.get_command());
-
-        self.command.run_daemonized().map_err(Self::map_error)
+    pub fn build_command(self) -> SystemCommand {
+        self.command
     }
 }
 
@@ -227,6 +227,15 @@ mod tests {
     fn test_from_adds_virtio_balloon() {
         let qemu = QemuSystem::from(&SystemMock::new(), Arch::ARM64).unwrap();
         assert!(qemu.command.get_command().contains("virtio-balloon-pci"));
+    }
+
+    #[test]
+    fn test_build_command_names_the_binary_of_the_arch() {
+        let command = QemuSystem::from(&SystemMock::new(), Arch::AMD64)
+            .unwrap()
+            .build_command();
+
+        assert!(command.get_command().starts_with("qemu-system-x86_64"));
     }
 
     #[test]

--- a/src/util/system_command.rs
+++ b/src/util/system_command.rs
@@ -1,29 +1,30 @@
-use crate::error::{Error, Result};
-use std::ffi::OsStr;
-use std::io::{ErrorKind, Read};
-use std::process::{Command, Output, Stdio};
-use std::str::from_utf8;
+use std::ffi::{OsStr, OsString};
 
+// A command to run, described but not started. Turning one into a child
+// process is the job of the `System` implementation, which keeps every spawn
+// on the host behind the same seam as every file access.
 pub struct SystemCommand {
-    cmd: Command,
-    stdout: bool,
+    program: String,
+    args: Vec<OsString>,
+    envs: Vec<(OsString, OsString)>,
 }
 
 impl SystemCommand {
     pub fn new(program: &str) -> Self {
         Self {
-            cmd: Command::new(program),
-            stdout: false,
+            program: program.to_string(),
+            args: Vec::new(),
+            envs: Vec::new(),
         }
     }
 
     pub fn get_command(&self) -> String {
         format!(
             "{} {}",
-            self.cmd.get_program().to_str().unwrap(),
-            self.cmd
-                .get_args()
-                .map(|a| a.to_str().unwrap())
+            self.program,
+            self.args
+                .iter()
+                .map(|a| a.to_string_lossy())
                 .collect::<Vec<_>>()
                 .join(" ")
         )
@@ -31,25 +32,26 @@ impl SystemCommand {
         .to_string()
     }
 
-    fn get_program(&self) -> String {
-        self.cmd.get_program().to_string_lossy().into_owned()
+    pub fn get_program(&self) -> &str {
+        &self.program
     }
 
-    fn map_spawn_error(&self, error: std::io::Error) -> Error {
-        if error.kind() == ErrorKind::NotFound {
-            return Error::SystemCommandNotFound(self.get_program());
-        }
+    pub fn get_args(&self) -> &[OsString] {
+        &self.args
+    }
 
-        Error::SystemCommandFailed(self.get_command(), error.to_string())
+    pub fn get_envs(&self) -> &[(OsString, OsString)] {
+        &self.envs
     }
 
     pub fn set_env<K: AsRef<OsStr>, V: AsRef<OsStr>>(&mut self, key: K, value: V) -> &mut Self {
-        self.cmd.env(key, value);
+        self.envs
+            .push((key.as_ref().to_os_string(), value.as_ref().to_os_string()));
         self
     }
 
     pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
-        self.cmd.arg(arg);
+        self.args.push(arg.as_ref().to_os_string());
         self
     }
 
@@ -58,99 +60,11 @@ impl SystemCommand {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        self.cmd.args(args);
+        for arg in args {
+            self.arg(arg);
+        }
         self
     }
-
-    pub fn run(&mut self) -> Result<()> {
-        self.cmd
-            .stdin(Stdio::null())
-            .stdout(if self.stdout {
-                Stdio::inherit()
-            } else {
-                Stdio::null()
-            })
-            .stderr(Stdio::piped())
-            .output()
-            .map_err(|e| self.map_spawn_error(e))
-            .and_then(|out| {
-                if out.status.success() {
-                    Ok(())
-                } else {
-                    Err(Error::SystemCommandFailed(
-                        self.get_command(),
-                        from_utf8(&out.stderr).unwrap_or_default().to_string(),
-                    ))
-                }
-            })
-    }
-
-    pub fn run_daemonized(&mut self) -> Result<()> {
-        #[cfg(unix)]
-        unsafe {
-            use std::os::unix::process::CommandExt;
-            self.cmd.pre_exec(detach_from_session);
-        }
-
-        #[cfg(target_os = "windows")]
-        {
-            use std::os::windows::process::CommandExt;
-            const DETACHED_PROCESS: u32 = 0x0000_0008;
-            self.cmd.creation_flags(DETACHED_PROCESS);
-        }
-
-        let mut child = self
-            .cmd
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| self.map_spawn_error(e))?;
-
-        // Check immediately for instant failures, then again after a brief window
-        // to catch startup errors (KVM permission denied, bad firmware, port conflicts).
-        for ms in [0, 100] {
-            std::thread::sleep(std::time::Duration::from_millis(ms));
-            if let Ok(Some(_)) = child.try_wait() {
-                let stderr = child
-                    .stderr
-                    .take()
-                    .map(|mut s| {
-                        let mut buf = Vec::new();
-                        s.read_to_end(&mut buf).unwrap_or(0);
-                        from_utf8(&buf).unwrap_or_default().to_owned()
-                    })
-                    .unwrap_or_default();
-                return Err(Error::SystemCommandFailed(self.get_command(), stderr));
-            }
-        }
-
-        // Reap the child when it eventually exits to avoid a zombie process.
-        std::thread::spawn(move || {
-            let _ = child.wait();
-        });
-
-        Ok(())
-    }
-
-    pub fn output(&mut self) -> Result<Output> {
-        self.cmd
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .map_err(|e| self.map_spawn_error(e))
-    }
-}
-
-#[cfg(unix)]
-fn detach_from_session() -> std::io::Result<()> {
-    unsafe extern "C" {
-        fn setsid() -> i32;
-    }
-    if unsafe { setsid() } == -1 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

SystemCommand wrapped std::process::Command and spawned on its own, so every path that shelled out stayed beyond the reach of the tests. Loading an instance forked a real qemu-img, which made the result depend on whether qemu was installed on the machine.

SystemCommand now only describes a command and the System trait runs it. All process code sits in OsSystem next to the file system code. The system mock answers from a seeded table and reports an unknown command as a missing binary, the way a host without qemu does.

QemuImg runs its commands through the trait, so reading image info, resizing and converting are covered now. QemuSystem stays a pure builder and hands its command to the caller.

## Related Issue(s)

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Run automatic and manual tests.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed
