### PR TITLE
Fix documentation issues

### DIFF
--- a/docs/howto/environment_variables.rst
+++ b/docs/howto/environment_variables.rst
@@ -1,4 +1,4 @@
-.. _environment variables:
+.. _github token:
 
 Build with a Private GitHub Token Inside a VM
 =============================================
@@ -6,6 +6,11 @@ Build with a Private GitHub Token Inside a VM
 This guide shows how to forward a ``GITHUB_TOKEN`` from the host into a Cubic
 virtual machine so a build script can fetch private dependencies without storing
 the token inside the VM.
+
+This page is about passing host environment variables into a guest with
+``--env``. Cubic's own ``CUBIC_QEMU_DIR``, ``CUBIC_QEMU_FW_AMD64`` and
+``CUBIC_QEMU_FW_ARM64`` settings configure where Cubic looks for QEMU and UEFI
+firmware on the host instead. See :ref:`qemu detection` for those.
 
 Create the Virtual Machine
 --------------------------

--- a/docs/howto/http_server.rst
+++ b/docs/howto/http_server.rst
@@ -60,8 +60,8 @@ active port forwarding rules:
 .. code-block::
 
     $ cubic show --all webserver
-    Status:       stopped
-    PID:          n/a
+    Running:      yes
+    PID:          12345
     Arch:         amd64
     CPUs:         4
     Memory:       4.0 GiB
@@ -72,11 +72,11 @@ active port forwarding rules:
     SSH Port:     10022
     Monitor Port: 10023
     Console Port: 10024
+    Forward:      127.0.0.1:8080:80/tcp
     Disk Image:   ~/.local/share/cubic/machines/webserver/machine.img
     Config:       ~/.local/share/cubic/machines/webserver/instance.toml
     SSH Key:      ~/.local/share/cubic/machines/webserver/ssh_client_key
     SSH:          ssh -i .../webserver/ssh_client_key -p 10022 alice@localhost
-    Forward:      127.0.0.1:8080:80/tcp
 
 Modify VM Settings
 ------------------

--- a/docs/howto/install.rst
+++ b/docs/howto/install.rst
@@ -73,7 +73,7 @@ Install with Cargo
 ------------------
 
 1. Install Dependencies
-^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Cubic needs QEMU and its UEFI firmware on the host. Install them with your
 package manager:
@@ -115,7 +115,7 @@ For Windows:
     winget install SoftwareFreedomConservancy.QEMU
 
 2. Install Rust toolchain
-^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Install the `Rust toolchain`_:
 
@@ -126,14 +126,14 @@ Install the `Rust toolchain`_:
 .. _Rust toolchain: https://rustup.rs
 
 3. Install Cubic
-^^^^^
+^^^^^^^^^^^^^^^^
 
 .. code-block::
 
     cargo install cubic
 
 4. Update PATH Environment Variable
-^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Add Cargo bin directory to PATH environment variable.
 
@@ -145,7 +145,7 @@ For Linux distributions:
     source ~/.profile
 
 5. Allow KVM Acceleration (Linux only, Optional)
-^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It is recommended to add Kernel-based Virtual Machine (KVM) permission to your user for optimal VM performance:
 
@@ -156,7 +156,7 @@ It is recommended to add Kernel-based Virtual Machine (KVM) permission to your u
 This requires to exit the current user session and to relogin to make the change active.
 
 Test Cubic
-^^^^
+^^^^^^^^^^
 
 Check if Cubic is installed correctly:
 

--- a/docs/internals/how_it_works.rst
+++ b/docs/internals/how_it_works.rst
@@ -14,10 +14,10 @@ What Happens When You Run Cubic
    subsequent instances reuse it without re-downloading.
 
 2. **Provision** — Cubic generates a unique Ed25519 SSH key for the instance
-   and packages a cloud-init configuration into an ISO 9660 image. QEMU mounts
-   the ISO as a virtual CD-ROM drive on first boot.
+   and packages a cloud-init configuration into an ISO 9660 image. QEMU
+   attaches the image as a small virtio disk.
 
-3. **First boot** — cloud-init reads the ISO, creates the default user,
+3. **First boot** — cloud-init reads the seed disk, creates the default user,
    installs the instance's SSH key, and runs any configured tasks. On all
    subsequent boots cloud-init detects that provisioning is complete and does
    not run again.
@@ -42,10 +42,11 @@ initialising cloud VMs on first boot. Cubic uses it to configure each instance
 automatically without user interaction.
 
 For each new instance Cubic assembles a cloud-init configuration and packs it
-into a small ISO 9660 image. QEMU presents the ISO as a virtual CD-ROM;
-cloud-init finds it on first boot, applies the configuration — including
-creating the default user and installing the instance's SSH public key — and
-marks provisioning as done. The ISO is no longer consulted on subsequent boots.
+into a small ISO 9660 image. QEMU attaches that image as a virtio disk, and
+cloud-init finds it on first boot. It then applies the configuration —
+including creating the default user and installing the instance's SSH public
+key — and marks provisioning as done. The seed disk is no longer consulted on
+subsequent boots.
 
 QEMU and Hardware Acceleration
 -------------------------------

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -11,8 +11,9 @@ function generate_cmd_doc() {
     cmd="$2"
     ref="$3"
     file="$4"
+    underline="${name//?/=}"
 
-    echo -e ".. $ref:\n\n$name\n=====\n\n.. code-block::\n\n    \$ $name --help" > "$file"
+    echo -e ".. $ref:\n\n$name\n$underline\n\n.. code-block::\n\n    \$ $name --help" > "$file"
     cargo run -- $cmd --help | sed "s/^/    /" >> "$file"
 }
 


### PR DESCRIPTION
## Summary

Four documentation fixes from the low hanging fruits triage, one commit each, each touching its own files.

- **#455** The How Cubic Works page said QEMU mounts the cloud-init seed as a virtual CD-ROM. Cubic attaches it with `add_drive` as `if=virtio,format=raw` and starts QEMU with `-nodefaults`, so the machine only carries virtio drives. Both passages now say virtio disk, and the first boot wording moved to cloud-init, which reads the seed once.
- **#456** The `cubic show --all` sample named the first field Status and put the forward row last. The command prints Running with a yes or no value, and it prints the forward rows ahead of the extra fields that `--all` adds. The sample also showed a stopped VM inside a guide that has nginx serving by that point, so it now shows a running VM.
- **#460** The reference generator wrote a fixed five character underline under every command title, so all twenty generated pages warned on each Sphinx build. Six headings on the install page were short in the same way. The generator now derives the underline from the title length. Git ignores every generated page, so the generator alone needed the fix.
- **#461** A reader who wanted to point Cubic at a QEMU install landed on the environment variables page and found a guide about forwarding host variables into a guest. The page now says which kind of variable it covers and links to the QEMU detection page, which already lists the CUBIC settings. The anchor still read like a reference, so it now matches the title.

## Related Issue(s)

Closes #455
Closes #456
Closes #460
Closes #461

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Test Plan

Check generated documentation locally.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed