### PR TITLE
fix: remove the shared default password from new machines

### DIFF
--- a/docs/howto/console_login.rst
+++ b/docs/howto/console_login.rst
@@ -1,0 +1,61 @@
+.. _console login:
+
+Log In on the Serial Console
+============================
+
+Set a console password now, while SSH still works. The console is what you
+reach for when SSH is broken, and at that point it is too late to set one.
+
+Why the Console Needs a Password
+--------------------------------
+
+A new virtual machine has no account password at all. Cubic installs a unique
+SSH key during first boot, so ``cubic ssh`` works right away without one.
+
+The serial console is different. It shows the login prompt of the guest, and
+that prompt only accepts a password. SSH keys do not apply there. So the
+account stays locked on the console until you set a password from inside the
+guest.
+
+Set a Password
+--------------
+
+Connect over SSH and set a password for your own account:
+
+.. code-block::
+
+    $ cubic ssh <instance>
+    $ sudo passwd $USER
+
+The command asks for the new password twice. Nothing else is needed, because
+the account already has passwordless sudo.
+
+Look Up the User Name
+---------------------
+
+The login prompt wants the guest user name. Use ``cubic show`` if you are not
+sure which one the machine uses:
+
+.. code-block::
+
+    $ cubic show <instance>
+    ...
+    User:        <username>
+    ...
+
+Open the Console
+----------------
+
+.. code-block::
+
+    $ cubic console <instance>
+
+Log in with the user name and the password you just set. To leave the console
+press Enter, then ``~``, then ``.``. The virtual machine keeps running.
+
+When the Console Helps
+----------------------
+
+The console is useful when you want to watch a machine boot, or when you need
+to reach a guest whose network or SSH server stopped working. Both cases are
+easier to handle if the password is already in place.

--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -101,11 +101,13 @@ The intended way to reach a guest is SSH key authentication, which depends on
 holding the private key that Cubic stores alongside the virtual machine rather
 than on a password that could be guessed or shared.
 
-For convenience while a machine is still being provisioned, new instances also
-have a default account password enabled for the moment. The SSH port is bound to
-loopback, so this is only reachable from the same host and never from the
-network, but moving to key-only authentication and dropping the default password
-is a planned improvement.
+A new machine has no account password at all. The user account is created with a
+locked password, so the SSH key is the only way in.
+
+This shapes how you use the serial console. The console shows the login prompt
+of the guest, and that prompt accepts only a password, so it stays closed until
+you set one from an SSH session. Set a password while SSH works if you want the
+console available as a way in later. See :ref:`console login` for the steps.
 
 One area that can still be improved is host key verification. Today the host key
 that the guest presents is accepted as it is, which is reasonable while

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -59,6 +59,7 @@ Cubic
    howto/getting_started
    howto/http_server
    howto/ssh_connect
+   howto/console_login
    howto/environment_variables
 
 .. toctree::

--- a/src/cloudinit/user_data_factory.rs
+++ b/src/cloudinit/user_data_factory.rs
@@ -24,8 +24,7 @@ impl UserDataFactory {
             #cloud-config\n\
             users:\n\
             \u{20}\u{20}- name: {user}\n\
-            \u{20}\u{20}\u{20}\u{20}lock_passwd: false\n\
-            \u{20}\u{20}\u{20}\u{20}hashed_passwd: $y$j9T$wifmOLBedd7NSaH2IqG4L.$2J.8E.qE57lxapsWosOFod37djHePHg7Go03iDNsRe4\n\
+            \u{20}\u{20}\u{20}\u{20}lock_passwd: true\n\
             \u{20}\u{20}\u{20}\u{20}ssh_authorized_keys: [{pubkey}]\n\
             \u{20}\u{20}\u{20}\u{20}shell: /bin/bash\n\
             \u{20}\u{20}\u{20}\u{20}sudo: ALL=(ALL) NOPASSWD:ALL\n\
@@ -49,8 +48,7 @@ mod tests {
         let expected = r#"#cloud-config
 users:
   - name: tux
-    lock_passwd: false
-    hashed_passwd: $y$j9T$wifmOLBedd7NSaH2IqG4L.$2J.8E.qE57lxapsWosOFod37djHePHg7Go03iDNsRe4
+    lock_passwd: true
     ssh_authorized_keys: [pubkey]
     shell: /bin/bash
     sudo: ALL=(ALL) NOPASSWD:ALL
@@ -74,8 +72,7 @@ write_files:
         let expected = r#"#cloud-config
 users:
   - name: tux
-    lock_passwd: false
-    hashed_passwd: $y$j9T$wifmOLBedd7NSaH2IqG4L.$2J.8E.qE57lxapsWosOFod37djHePHg7Go03iDNsRe4
+    lock_passwd: true
     ssh_authorized_keys: [pubkey]
     shell: /bin/bash
     sudo: ALL=(ALL) NOPASSWD:ALL

--- a/src/commands/console_command.rs
+++ b/src/commands/console_command.rs
@@ -19,7 +19,7 @@ use tokio_util::io::StreamReader;
 ///
 ///   Connect to the console of 'my-instance'
 ///   $ cubic console my-instance
-///   Default credentials: cubic / cubic
+///   Login requires a password. Set one with 'sudo passwd' over cubic ssh.
 ///   Press Enter, ~, . to exit the console.
 ///
 ///   [...]
@@ -45,7 +45,7 @@ impl Command for ConsoleCommand {
             .get_instance_store()
             .load(self.instance.value.as_str())?;
 
-        console.info(&format!("Default credentials: {} / cubic", instance.user));
+        console.info("Login requires a password. Set one with 'sudo passwd' over cubic ssh.");
         console.info("Press Enter, ~, . to exit the console.");
 
         let port = instance

--- a/src/ssh/ssh_client.rs
+++ b/src/ssh/ssh_client.rs
@@ -72,19 +72,6 @@ impl<'a> SshClient<'a> {
         }
     }
 
-    async fn authenticate_with_default_password(
-        &self,
-        session: &mut russh::client::Handle<ServerKeyHandler>,
-        user: &str,
-    ) -> Result<(), ()> {
-        let auth = session
-            .authenticate_password(user, "cubic")
-            .await
-            .map(|auth| auth.success());
-
-        if let Ok(true) = auth { Ok(()) } else { Err(()) }
-    }
-
     async fn authenticate_with_keys(
         &self,
         session: &mut russh::client::Handle<ServerKeyHandler>,
@@ -170,17 +157,7 @@ impl<'a> SshClient<'a> {
             return Ok(AuthMethod::Deprecated);
         }
 
-        console.debug("Deprecated keys failed, trying the default password");
-        if self
-            .authenticate_with_default_password(session, user)
-            .await
-            .is_ok()
-        {
-            console.debug("Authenticated with the default password");
-            return Ok(AuthMethod::Deprecated);
-        }
-
-        console.debug("Default password failed, prompting for a password");
+        console.debug("Deprecated keys failed, prompting for a password");
         self.authenticate_with_password(console, session, user, machine)
             .await
             .map(|_| AuthMethod::Deprecated)


### PR DESCRIPTION
## Summary

Every machine got the same password hash in its cloud-init user data, and the plaintext lives in the repository. Cloud-init installs a unique SSH key on first boot, so the password adds nothing.

New machines now lock the account password. The serial console still needs one, so a new how-to shows how to set it over SSH.

## Related Issue(s)

None. This comes from a code review, not a filed issue.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Test Plan

Run unit and manual tests.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed