### PR TITLE
docs: fix the getting started examples and add a QEMU troubleshooting page

### DIFF
--- a/docs/howto/getting_started.rst
+++ b/docs/howto/getting_started.rst
@@ -14,38 +14,20 @@ You can list all supported distributions with:
 
     $ cubic images
     Name                       Arch         Size   Cached
-    archlinux:latest           amd64   516.7 MiB       no
-    debian:{12, bookworm}      amd64   426.0 MiB       no
-    debian:{11, bullseye}      amd64   343.5 MiB       no
-    debian:{10, buster}        amd64   301.7 MiB       no
-    debian:{13, trixie}        amd64   411.2 MiB       no
-    fedora:41                  amd64   468.9 MiB       no
-    fedora:42                  amd64   507.6 MiB       no
+    almalinux:9                amd64   554.8 MiB       no
+    archlinux:latest           amd64   530.6 MiB       no
+    debian:{12, bookworm}      amd64   426.8 MiB       no
     fedora:43                  amd64   556.3 MiB       no
-    opensuse:15.2              amd64   544.1 MiB       no
-    opensuse:15.3              amd64   560.4 MiB       no
-    opensuse:15.4              amd64   683.7 MiB       no
-    opensuse:15.5              amd64   643.1 MiB       no
-    opensuse:15.6              amd64   683.6 MiB       no
-    rockylinux:10              amd64   548.8 MiB       no
-    rockylinux:8               amd64     1.9 GiB       no
-    rockylinux:9               amd64   618.8 MiB       no
-    ubuntu:{18.04, bionic}     amd64   206.0 MiB       no
-    ubuntu:{18.10, cosmic}     amd64   289.7 MiB       no
-    ubuntu:{19.04, disco}      amd64   153.3 MiB       no
-    ubuntu:{19.10, eoan}       amd64   193.1 MiB       no
-    ubuntu:{20.04, focal}      amd64   251.9 MiB       no
-    ubuntu:{20.10, groovy}     amd64   250.6 MiB       no
-    ubuntu:{21.04, hirsute}    amd64   258.3 MiB       no
-    ubuntu:{21.10, impish}     amd64   254.4 MiB       no
-    ubuntu:{22.04, jammy}      amd64   293.9 MiB       no
-    ubuntu:{22.10, kinetic}    amd64   294.5 MiB       no
-    ubuntu:{23.04, lunar}      amd64   335.9 MiB       no
-    ubuntu:{23.10, mantic}     amd64   228.1 MiB       no
-    ubuntu:{24.04, noble}      amd64   251.5 MiB       no
-    ubuntu:{24.10, oracular}   amd64   249.6 MiB       no
-    ubuntu:{25.04, plucky}     amd64   261.1 MiB       no
-    ubuntu:{25.10, questing}   amd64   394.4 MiB       no
+    gentoo:latest              amd64     1.7 GiB       no
+    opensuse:15.6              amd64   690.1 MiB       no
+    rockylinux:10              amd64   519.8 MiB       no
+    ubuntu:{22.04, jammy}      amd64   295.6 MiB       no
+    [...]
+
+The list above is shortened to one release per distribution.
+Run the command to see every image.
+By default Cubic only lists images for the architecture of your host.
+Add ``--all`` to see the other architectures too.
 
 Create the Virtual Machine
 --------------------------
@@ -64,8 +46,13 @@ You can list all your virtual machines with the following command:
 .. code-block::
 
     $ cubic instances
-    PID    Name         Arch    CPUs     Memory       Disk   Running
-           example      amd64      1    1.0 GiB    1.0 GiB       yes
+    PID   Name      Arch    CPUs    Memory   Disk Used   Disk Total   Running
+          example   amd64      4   4.0 GiB   941.2 MiB    100.0 GiB        no
+
+The machine is created but not started yet, so it has no process id and
+``Running`` is ``no``.
+Cubic picks the number of CPUs and the memory size from the resources of your
+host, so your values can differ.
 
 Additional Settings
 -------------------
@@ -75,7 +62,7 @@ For example to create a virtual machine with 4 CPU cores, 4 GiB of memory and 10
 
 .. code-block::
 
-    $ cubic create example --image debian:bookworm --cpus 4 --mem 4G  --disk 10G
+    $ cubic create example --image debian:bookworm --cpus 4 --memory 4G --disk 10G
 
 
 Start the virtual machine

--- a/docs/troubleshooting/qemu_not_found.rst
+++ b/docs/troubleshooting/qemu_not_found.rst
@@ -1,0 +1,109 @@
+.. _qemu not found:
+
+QEMU or Firmware Not Found
+==========================
+
+Cubic stops with the following error when it cannot start a virtual machine:
+
+.. code-block::
+
+    QEMU or its UEFI firmware was not found.
+
+The error lists the install command for your platform, so follow that first.
+This guide helps when the packages are installed and the error still appears.
+
+The same error covers two different causes. Cubic needs the QEMU binaries and
+it needs the UEFI firmware that boots the guest. Either one can be missing.
+
+Find Out Which Part Is Missing
+------------------------------
+
+Start the machine again with ``--verbose``:
+
+.. code-block::
+
+    $ cubic start <instance> --verbose
+
+Cubic reports where it found the QEMU install:
+
+.. code-block::
+
+    debug: Found QEMU install at '/usr'
+
+When you see this line, QEMU is fine and the firmware is the problem.
+When you see ``debug: No QEMU install found`` instead, Cubic never located the
+binaries and the firmware search never ran.
+
+QEMU Was Not Found
+------------------
+
+Cubic looks for ``qemu-system-x86_64``, ``qemu-system-aarch64`` and
+``qemu-img`` in the directories described in :ref:`qemu detection`.
+Check that the binaries exist and that their directory is on your ``PATH``:
+
+.. code-block::
+
+    $ qemu-system-x86_64 --version
+    $ qemu-img --version
+
+When QEMU lives somewhere else, point Cubic at the directory that contains the
+binaries:
+
+.. code-block::
+
+    $ CUBIC_QEMU_DIR=/opt/qemu/bin cubic start <instance>
+
+Cubic puts this directory at the front of its search list, so it wins over
+your ``PATH`` and the built-in fallbacks.
+Only the QEMU process gets this search path, your own shell stays untouched.
+
+The Firmware Was Not Found
+--------------------------
+
+Cubic reads the QEMU firmware descriptors, which are JSON files that describe
+the available UEFI images. It collects them from these directories, in order:
+
+* ``$XDG_CONFIG_HOME/qemu/firmware``, or ``$HOME/.config/qemu/firmware`` when
+  ``XDG_CONFIG_HOME`` is not set
+* ``/etc/qemu/firmware``
+* ``<prefix>/share/qemu/firmware``
+* ``<prefix>/share/firmware``
+* ``<prefix>/firmware``
+
+The prefix is the parent of the directory that holds the QEMU binaries, so
+``/usr/bin`` gives the prefix ``/usr``. On Windows the prefix is the directory
+itself.
+
+Descriptors are matched by file name and the first directory wins. A leftover
+file in your home directory therefore hides the one shipped by your
+distribution. List the descriptors and remove the stale copies:
+
+.. code-block::
+
+    $ ls ~/.config/qemu/firmware /etc/qemu/firmware /usr/share/qemu/firmware
+
+A descriptor is only useful when the firmware image it points at is present on
+disk. Cubic skips every descriptor whose image is missing, which is what
+happens when the QEMU package is installed without the matching firmware
+package.
+
+Point Cubic at a Firmware Image
+-------------------------------
+
+When the descriptors are unusable you can name the firmware image directly:
+
+.. code-block::
+
+    $ CUBIC_QEMU_FW_AMD64=/usr/share/OVMF/OVMF_CODE.fd cubic start <instance>
+
+Use ``CUBIC_QEMU_FW_ARM64`` for arm64 machines.
+Cubic uses these paths as they are and never checks that the file exists.
+A typo therefore replaces this error with a QEMU startup failure later on.
+Verify the path before you set the variable:
+
+.. code-block::
+
+    $ ls -l /usr/share/OVMF/OVMF_CODE.fd
+
+The variables are described with the rest of the settings in
+:ref:`qemu detection`.

--- a/docs/troubleshooting/recover_disk.rst
+++ b/docs/troubleshooting/recover_disk.rst
@@ -50,7 +50,10 @@ Mount the Image with ``qemu-nbd``
 ---------------------------------
 
 When ``libguestfs-tools`` is not available, expose the disk as a block device
-on Linux with the Network Block Device kernel module:
+on Linux with the Network Block Device kernel module.
+
+The Snap package does not ship ``qemu-nbd``, so install the ``qemu-utils``
+package of your distribution to get it:
 
 .. code-block::
 

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -66,6 +66,7 @@ Cubic
    :caption: Troubleshooting
    :hidden:
 
+   troubleshooting/qemu_not_found
    troubleshooting/recover_disk
 
 .. toctree::


### PR DESCRIPTION
## Summary

Two documentation fixes that both correct output samples users cannot reproduce.

The Getting Started page showed an instance listing with a `Disk` column that does not exist and marked the machine as running before the guide starts it. The real table has `Disk Used` and `Disk Total`, and a created machine reports an empty process id with `Running` set to `no`. The create example also used the `--mem` alias with a double space instead of the canonical `--memory` flag. The image list was a fixed snapshot of every release, which already drifted. It was missing Alma Linux and Gentoo and still listed Fedora 41 and 42, which are gone. It is now one release per distribution with a `[...]` marker, matching the sample style in `src/commands/list_image_command.rs`.

The second change adds a troubleshooting page for a missing QEMU or UEFI firmware. The error already prints the install command for each platform, so the page does not repeat it. It covers what the error cannot say. The same message appears for a missing binary and for a missing firmware, and `--verbose` tells the two apart. It also documents the firmware descriptor search order, the rule that the first directory wins for a given file name, and the fact that a `CUBIC_QEMU_FW_*` override is used without any existence check, so a typo fails later at QEMU startup.

The recovery guide gained a note that the Snap package does not ship `qemu-nbd`.

## Related Issue(s)

Closes #457
Closes #462

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Test Plan

Every sample in the Getting Started page was generated from a real run instead of written by hand.

make build
./target/debug/cubic images
./target/debug/cubic create example --image debian:bookworm
./target/debug/cubic instances
./target/debug/cubic delete example

The claims in the troubleshooting page were checked against the code that produces them. The error text comes from `format_qemu_not_found_help` in `src/error.rs`. The verbose lines come from `src/actions/start_instance_action.rs` and carry the `debug:` label added by `Console::debug`. The search order and the shadowing rule come from `build_descriptor_dirs` and `collect_descriptors` in `src/qemu/qemu_firmware.rs`. The search list behaviour of `CUBIC_QEMU_DIR` comes from `QemuPathBuilder` in `src/qemu/qemu_path_builder.rs`.

The site was built with `sphinx-build docs target/page/docs`. The new page renders, both `:ref:` links resolve and no warning points at any changed file. The remaining warnings come from `docs/index.rst` and `docs/reference/`, which are ignored build artifacts that CI regenerates.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed