### PR TITLE
fix: parse data sizes without panics or overflows

### DIFF
--- a/src/models/data_size.rs
+++ b/src/models/data_size.rs
@@ -38,8 +38,8 @@ impl FromStr for DataSize {
             return Err(error);
         }
 
-        let suffix: char = value.bytes().last().unwrap() as char;
-        let size = &value[..value.len() - 1];
+        let suffix = value.chars().next_back().unwrap();
+        let size = &value[..value.len() - suffix.len_utf8()];
         let power = match suffix {
             'B' => 0,
             'K' => 1,
@@ -49,11 +49,11 @@ impl FromStr for DataSize {
             _ => return Err(error),
         };
 
-        size.parse()
-            .map(|size: usize| Self {
-                bytes: size * 1024_usize.pow(power),
-            })
-            .map_err(|_| error)
+        size.parse::<usize>()
+            .ok()
+            .and_then(|size| size.checked_mul(1024_usize.pow(power)))
+            .map(|bytes| Self { bytes })
+            .ok_or(error)
     }
 }
 
@@ -138,5 +138,30 @@ mod tests {
             DataSize::from_str("1T").unwrap().get_bytes(),
             1024_usize.pow(4)
         )
+    }
+
+    #[test]
+    fn test_from_multibyte_suffix() {
+        assert!(DataSize::from_str("10€").is_err())
+    }
+
+    #[test]
+    fn test_from_only_multibyte_char() {
+        assert!(DataSize::from_str("€").is_err())
+    }
+
+    #[test]
+    fn test_from_overflow() {
+        assert!(DataSize::from_str("99999999999999999T").is_err())
+    }
+
+    #[test]
+    fn test_from_missing_suffix() {
+        assert!(DataSize::from_str("10").is_err())
+    }
+
+    #[test]
+    fn test_from_empty() {
+        assert!(DataSize::from_str("").is_err())
     }
 }


### PR DESCRIPTION
Summary

The data size parser read the unit from the last byte of the input and then sliced everything before that byte. A size ending in a multibyte character put the slice inside the character and the program panicked, so a typo like --disk 10€ crashed the tool instead of printing the parse error. The parser also multiplied the number by the unit without a check, so a very large value wrapped to a much smaller size in a release build and was accepted.

This takes the unit from the last character and sizes the slice by the length of that character, so the split always lands on a character boundary. The multiply is now checked and reports the same parse error on overflow. The set of accepted inputs and the error text are unchanged.

Related Issue(s)

Closes #449

Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

Test Plan

Five unit tests were added next to the existing ones in src/models/data_size.rs. They cover a trailing multibyte character, an input that is only a multibyte character, an overflowing terabyte value, a bare number with no unit, and an empty string. The two regression tests both fail against the old code, one by panicking on the slice and one by panicking on the overflow in a debug build.

make test passes with 431 tests. make format and make lint are clean.

Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed