### PR TITLE
fix: bound the console wait so it cannot hang forever

### DIFF
--- a/src/commands/console_command.rs
+++ b/src/commands/console_command.rs
@@ -5,13 +5,15 @@ use crate::qemu::TlsClient;
 use crate::util;
 use crate::view::Console;
 use clap::Parser;
-use std::net::TcpStream;
 use std::path::PathBuf;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::io::AsyncWriteExt;
 use tokio_util::codec::FramedRead;
 use tokio_util::io::StreamReader;
+
+const CONSOLE_TIMEOUT: Duration = Duration::from_secs(60);
+const PROBE_IO_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Open VM instance console
 ///
@@ -58,7 +60,22 @@ impl Command for ConsoleCommand {
         );
         let certs = InstanceCertPaths::load(&instance_dir);
 
-        while TcpStream::connect(format!("127.0.0.1:{port}")).is_err() {
+        let system = context.get_system();
+        let instance_store = context.get_instance_store();
+        let deadline = Instant::now() + CONSOLE_TIMEOUT;
+        let mut was_running = false;
+        while system.connect_port(port, PROBE_IO_TIMEOUT).is_err() {
+            // QEMU writes its pid file after the spawn returns, so only a pid
+            // file that vanished again means it exited.
+            let running = instance_store.is_running(&instance);
+            if was_running && !running {
+                return Err(Error::InstanceNotRunning(instance.name.clone()));
+            }
+            was_running |= running;
+
+            if Instant::now() >= deadline {
+                return Err(Error::ConsoleTimeout(instance.name.clone()));
+            }
             thread::sleep(Duration::from_secs(1));
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,11 @@ pub enum Error {
     StartTimeout,
 
     #[error(
+        "Timed out waiting for the console of instance '{0}'.\n\nTroubleshoot:\n  - Check that the instance is running: `cubic list`\n  - Run with --verbose to see the QEMU command\n  - Try again; the system may be under load\n"
+    )]
+    ConsoleTimeout(String),
+
+    #[error(
         "Not enough free memory to start instance '{0}'.\n\nTroubleshoot:\n  - Free up memory by stopping other instances or processes\n  - Reduce the instance memory: `cubic modify {0} --memory <size>`\n  - Accept the proposed smaller size by running with --yes\n"
     )]
     NotEnoughMemory(String),


### PR DESCRIPTION
## Summary

`cubic console` looped on a blocking connect with no deadline, so a QEMU that never opened the console port left the command spinning until the user killed it.

The wait now gives up after 60 seconds with a new `Error::ConsoleTimeout`, and ends early once QEMU has been seen running and its pid file goes away. The probe goes through `System::connect_port` instead of `std::net::TcpStream`.

The liveness check only arms after QEMU has been seen with a pid file, since QEMU writes that file some time after the spawn returns and checking right away would fail a healthy cold start.

## Related Issue(s)

Closes #442

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

`make test`, `make lint` and `make format` pass locally. The new paths have no unit tests because the logic lives in `run()`, which starts QEMU. Manual verification against a real host is still open.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed