### PR TITLE
refactor: hash downloads once and buffer the writes

### DIFF
--- a/src/image/image_fetcher.rs
+++ b/src/image/image_fetcher.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, Result};
-use crate::models::{HashAlg, Image};
+use crate::models::Image;
 use crate::platform::System;
 use crate::view::{Console, Spinner, TransferView};
 use crate::web::WebClient;
@@ -17,11 +17,7 @@ impl ImageFetcher {
         ImageFetcher
     }
 
-    pub fn fetch_checksum(
-        &self,
-        client: &mut WebClient,
-        image: &Image,
-    ) -> Result<Option<(HashAlg, String)>> {
+    pub fn fetch_checksum(&self, client: &mut WebClient, image: &Image) -> Result<Option<String>> {
         if let Some(pos) = image.image_url.rfind("/") {
             let file_name = &image.image_url[pos + 1..image.image_url.len()];
             let content = client.download_content(&image.checksum_url)?;
@@ -44,7 +40,7 @@ impl ImageFetcher {
                     .collect::<Vec<_>>();
 
                 if let (&[_], &[hashsum]) = (file_names.as_slice(), hashsums.as_slice()) {
-                    return Ok(Some((image.hash_alg, hashsum.to_string())));
+                    return Ok(Some(hashsum.to_string()));
                 }
             }
         }
@@ -66,7 +62,8 @@ impl ImageFetcher {
             &image.to_name()
         ))));
         console.play(view.clone());
-        let checksum = client.download_file(system, &image.image_url, target_file, view)?;
+        let checksum =
+            client.download_file(system, &image.image_url, target_file, view, image.hash_alg)?;
         console.stop();
 
         // Verify checksum
@@ -76,12 +73,8 @@ impl ImageFetcher {
         )))));
         let mut valid_checksum = false;
 
-        if let Ok(Some((hash_alg, hashsum))) = self.fetch_checksum(&mut client, image) {
-            let check = match hash_alg {
-                HashAlg::Sha512 => checksum.sha512,
-                HashAlg::Sha256 => checksum.sha256,
-            };
-            valid_checksum = check == hashsum;
+        if let Ok(Some(hashsum)) = self.fetch_checksum(&mut client, image) {
+            valid_checksum = checksum == hashsum;
         }
 
         console.stop();

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,4 @@
 mod arch;
-mod checksum;
 mod config;
 mod data_size;
 mod environment;
@@ -17,7 +16,6 @@ mod target_path;
 mod user_name;
 
 pub use arch::*;
-pub use checksum::*;
 pub use config::*;
 pub use data_size::*;
 pub use environment::*;

--- a/src/models/checksum.rs
+++ b/src/models/checksum.rs
@@ -1,5 +1,0 @@
-#[derive(Default)]
-pub struct Checksum {
-    pub sha512: String,
-    pub sha256: String,
-}

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,3 +1,5 @@
+mod hasher;
 mod web_client;
 
+pub use hasher::*;
 pub use web_client::*;

--- a/src/web/hasher.rs
+++ b/src/web/hasher.rs
@@ -1,0 +1,69 @@
+use crate::models::HashAlg;
+use crate::util::hex_encode;
+use sha2::{Digest, Sha256, Sha512};
+
+pub enum Hasher {
+    Sha256(Sha256),
+    Sha512(Sha512),
+}
+
+impl Hasher {
+    pub fn new(hash_alg: HashAlg) -> Self {
+        match hash_alg {
+            HashAlg::Sha256 => Hasher::Sha256(Sha256::new()),
+            HashAlg::Sha512 => Hasher::Sha512(Sha512::new()),
+        }
+    }
+
+    pub fn update(&mut self, buf: &[u8]) {
+        match self {
+            Hasher::Sha256(hasher) => hasher.update(buf),
+            Hasher::Sha512(hasher) => hasher.update(buf),
+        }
+    }
+
+    pub fn finalize(self) -> String {
+        match self {
+            Hasher::Sha256(hasher) => hex_encode(&hasher.finalize()),
+            Hasher::Sha512(hasher) => hex_encode(&hasher.finalize()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sha256_of_abc() {
+        let mut hasher = Hasher::new(HashAlg::Sha256);
+        hasher.update(b"abc");
+        assert_eq!(
+            hasher.finalize(),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn test_sha512_of_abc() {
+        let mut hasher = Hasher::new(HashAlg::Sha512);
+        hasher.update(b"abc");
+        assert_eq!(
+            hasher.finalize(),
+            "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a\
+             2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+        );
+    }
+
+    #[test]
+    fn test_update_in_chunks_matches_single_update() {
+        let mut chunked = Hasher::new(HashAlg::Sha256);
+        chunked.update(b"a");
+        chunked.update(b"bc");
+
+        let mut single = Hasher::new(HashAlg::Sha256);
+        single.update(b"abc");
+
+        assert_eq!(chunked.finalize(), single.finalize());
+    }
+}

--- a/src/web/web_client.rs
+++ b/src/web/web_client.rs
@@ -1,35 +1,38 @@
 use crate::error::{Error, Result};
-use crate::models::Checksum;
+use crate::models::HashAlg;
 use crate::platform::System;
-use crate::util;
 use crate::view::TransferView;
+use crate::web::Hasher;
 use reqwest::blocking::Client;
-use sha2::{Digest, Sha256, Sha512};
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 const REQUEST_TIMEOUT_SEC: u64 = 30;
+const WRITE_BUFFER_SIZE: usize = 1 << 20;
 
 struct ProgressWriter {
-    file: Box<dyn Write>,
+    file: BufWriter<Box<dyn Write>>,
     size: Option<u64>,
     written: u64,
     view: Arc<Mutex<TransferView>>,
-    sha512: Sha512,
-    sha256: Sha256,
+    hasher: Hasher,
 }
 
 impl ProgressWriter {
-    pub fn new(file: Box<dyn Write>, size: Option<u64>, view: Arc<Mutex<TransferView>>) -> Self {
+    pub fn new(
+        file: Box<dyn Write>,
+        size: Option<u64>,
+        view: Arc<Mutex<TransferView>>,
+        hash_alg: HashAlg,
+    ) -> Self {
         Self {
-            file,
+            file: BufWriter::with_capacity(WRITE_BUFFER_SIZE, file),
             size,
             written: 0,
             view,
-            sha512: Sha512::new(),
-            sha256: Sha256::new(),
+            hasher: Hasher::new(hash_alg),
         }
     }
 }
@@ -37,8 +40,7 @@ impl ProgressWriter {
 impl io::Write for ProgressWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.written += buf.len() as u64;
-        self.sha512.update(buf);
-        self.sha256.update(buf);
+        self.hasher.update(buf);
         self.view
             .lock()
             .unwrap()
@@ -84,7 +86,8 @@ impl WebClient {
         url: &str,
         file_path: &Path,
         view: Arc<Mutex<TransferView>>,
-    ) -> Result<Checksum> {
+        hash_alg: HashAlg,
+    ) -> Result<String> {
         // Appends rather than replacing the extension, so an image named
         // `foo.img` downloads through `foo.img.tmp`.
         let mut temp_file = file_path.as_os_str().to_owned();
@@ -95,21 +98,24 @@ impl WebClient {
         }
 
         if system.exists_path(file_path) {
-            return Ok(Checksum::default());
+            return Ok(String::new());
         }
 
         let mut resp = self.client.get(url).send().map_err(Error::from)?;
 
-        let mut writer =
-            ProgressWriter::new(system.create_file(&temp_file)?, resp.content_length(), view);
+        let mut writer = ProgressWriter::new(
+            system.create_file(&temp_file)?,
+            resp.content_length(),
+            view,
+            hash_alg,
+        );
         resp.copy_to(&mut writer).map_err(Error::from)?;
 
+        // The buffered writer drops its tail without this flush
+        writer.flush().map_err(Error::from)?;
         system.rename_file(&temp_file, file_path)?;
 
-        Ok(Checksum {
-            sha512: util::hex_encode(&writer.sha512.clone().finalize()),
-            sha256: util::hex_encode(&writer.sha256.clone().finalize()),
-        })
+        Ok(writer.hasher.finalize())
     }
 
     pub fn download_content(&mut self, url: &str) -> Result<String> {


### PR DESCRIPTION
## Summary

The image download path hashed every byte with both SHA-256 and SHA-512 even though only one digest is ever compared against the published checksum, and it wrote through an unbuffered file, so a 500 MB image cost about 61000 write calls. This removes the duplicate hashing and buffers the writes.

Hashing moves behind a new `Hasher` enum in the web module, and the algorithm comes from the image before the transfer starts. The output file is wrapped in a 1 MiB `BufWriter`, with an explicit flush before the rename so the buffer cannot drop its tail into a renamed image. The `Checksum` model and the redundant `HashAlg` that `fetch_checksum` returned both existed only to carry the second digest, so they are gone.

## Related Issue(s)

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Verified end to end by downloading a cloud image on a cold cache and confirming that checksum verification still passes, that the progress bar renders as before, and that the image lands in the image store at the full expected size. The flush is the one step that would corrupt an image if it were missed, so the downloaded file was compared against `Content-Length` and its digest against the published checksum.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed