### PR TITLE
fix: a batch of small fixes to the read commands

### DIFF
--- a/docs/howto/getting_started.rst
+++ b/docs/howto/getting_started.rst
@@ -46,11 +46,11 @@ You can list all your virtual machines with the following command:
 .. code-block::
 
     $ cubic instances
-    PID   Name      Arch    CPUs    Memory   Disk Used   Disk Total   Running
-          example   amd64      4   4.0 GiB   941.2 MiB    100.0 GiB        no
+    Name      Arch    CPUs    Memory   Disk Used   Disk Total   Running
+    example   amd64      4   4.0 GiB   941.2 MiB    100.0 GiB        no
 
-The machine is created but not started yet, so it has no process id and
-``Running`` is ``no``.
+The machine is created but not started yet, so ``Running`` is ``no``.
+Add ``--all`` to see the process id of each running machine.
 Cubic picks the number of CPUs and the memory size from the resources of your
 host, so your values can differ.
 

--- a/docs/howto/http_server.rst
+++ b/docs/howto/http_server.rst
@@ -61,7 +61,6 @@ active port forwarding rules:
 
     $ cubic show --all webserver
     Running:      yes
-    PID:          12345
     Arch:         amd64
     CPUs:         4
     Memory:       4.0 GiB
@@ -73,6 +72,7 @@ active port forwarding rules:
     Monitor Port: 10023
     Console Port: 10024
     Forward:      127.0.0.1:8080:80/tcp
+    PID:          12345
     Disk Image:   ~/.local/share/cubic/machines/webserver/machine.img
     Config:       ~/.local/share/cubic/machines/webserver/instance.toml
     SSH Key:      ~/.local/share/cubic/machines/webserver/ssh_client_key

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,3 +1,4 @@
+mod all_info_arg;
 mod clone_command;
 mod command_dispatcher;
 mod completions_command;
@@ -27,6 +28,7 @@ mod stop_command;
 mod verbosity;
 mod yes_arg;
 
+pub use all_info_arg::*;
 pub use clone_command::*;
 pub use command_dispatcher::*;
 pub use completions_command::*;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,6 @@
+mod all_images_arg;
 mod all_info_arg;
+mod all_instances_arg;
 mod clone_command;
 mod command_dispatcher;
 mod completions_command;
@@ -28,7 +30,9 @@ mod stop_command;
 mod verbosity;
 mod yes_arg;
 
+pub use all_images_arg::*;
 pub use all_info_arg::*;
+pub use all_instances_arg::*;
 pub use clone_command::*;
 pub use command_dispatcher::*;
 pub use completions_command::*;

--- a/src/commands/all_images_arg.rs
+++ b/src/commands/all_images_arg.rs
@@ -1,0 +1,9 @@
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(verbatim_doc_comment)]
+pub struct AllImagesArg {
+    /// Show all images
+    #[clap(short = 'a', long = "all", default_value_t = false)]
+    pub value: bool,
+}

--- a/src/commands/all_info_arg.rs
+++ b/src/commands/all_info_arg.rs
@@ -1,0 +1,15 @@
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(verbatim_doc_comment)]
+pub struct AllInfoArg {
+    /// Show all available information
+    #[clap(short = 'a', long = "all", default_value_t = false)]
+    pub value: bool,
+}
+
+impl From<bool> for AllInfoArg {
+    fn from(value: bool) -> Self {
+        Self { value }
+    }
+}

--- a/src/commands/all_instances_arg.rs
+++ b/src/commands/all_instances_arg.rs
@@ -1,0 +1,15 @@
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(verbatim_doc_comment)]
+pub struct AllInstancesArg {
+    /// Apply to all virtual machine instances
+    #[clap(short = 'a', long = "all", default_value_t = false)]
+    pub value: bool,
+}
+
+impl From<bool> for AllInstancesArg {
+    fn from(value: bool) -> Self {
+        Self { value }
+    }
+}

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -51,7 +51,7 @@ impl Command for DeleteCommand {
         if self.yes.value || ConfirmDialog::new("\nDo you want to proceed?").confirm(console) {
             // Stop the VM instances
             commands::StopCommand {
-                all: false,
+                all: false.into(),
                 wait: true,
                 kill: true,
                 instances: self.instances.value.clone().into(),

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -53,7 +53,7 @@ impl Command for DeleteCommand {
             commands::StopCommand {
                 all: false,
                 wait: true,
-                kill: false,
+                kill: true,
                 instances: self.instances.value.clone().into(),
             }
             .run(console, context)?;

--- a/src/commands/list_image_command.rs
+++ b/src/commands/list_image_command.rs
@@ -1,4 +1,4 @@
-use crate::commands::{Command, Context, fetch_image_list};
+use crate::commands::{AllImagesArg, Command, Context, fetch_image_list};
 use crate::error::Result;
 use crate::image::ImageStore;
 use crate::models::{DataSize, get_default_arch};
@@ -34,9 +34,8 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
 pub struct ListImageCommand {
-    /// Show all images
-    #[clap(short, long, action, global = true)]
-    all: bool,
+    #[clap(flatten)]
+    all: AllImagesArg,
 }
 
 impl Command for ListImageCommand {
@@ -51,7 +50,7 @@ impl Command for ListImageCommand {
             .add("Cached", Alignment::Right);
 
         for image in images {
-            if !self.all && image.arch != get_default_arch() {
+            if !self.all.value && image.arch != get_default_arch() {
                 continue;
             }
 

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -9,14 +9,24 @@ use clap::Parser;
 /// Examples:
 ///
 ///   $ cubic instances
-///   PID     Name           Arch    CPUs     Memory   Disk Used   Disk Total   Running
-///           noble-arm64    arm64      8    8.0 GiB     4.4 GiB    100.0 GiB       yes
-///   1059    trixie         amd64      6   16.0 GiB         n/a    100.0 GiB       yes
-///           fedora         amd64      4    4.0 GiB    10.0 GiB    100.0 GiB        no
+///   Name          Arch    CPUs     Memory   Disk Used   Disk Total   Running
+///   noble-arm64   arm64      8    8.0 GiB     4.4 GiB    100.0 GiB       yes
+///   trixie        amd64      6   16.0 GiB         n/a    100.0 GiB       yes
+///   fedora        amd64      4    4.0 GiB    10.0 GiB    100.0 GiB        no
+///
+///   Show the process id of each running VM instance:
+///   $ cubic instances --all
+///   PID    Name          Arch    CPUs     Memory   Disk Used   Disk Total   Running
+///          noble-arm64   arm64      8    8.0 GiB     4.4 GiB    100.0 GiB       yes
+///   1059   trixie        amd64      6   16.0 GiB         n/a    100.0 GiB       yes
+///          fedora        amd64      4    4.0 GiB    10.0 GiB    100.0 GiB        no
 ///
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
-pub struct ListInstanceCommand;
+pub struct ListInstanceCommand {
+    #[clap(flatten)]
+    pub all: commands::AllInfoArg,
+}
 
 impl Command for ListInstanceCommand {
     fn run(&self, console: &mut Console<'_>, context: &commands::Context) -> Result<()> {
@@ -24,8 +34,11 @@ impl Command for ListInstanceCommand {
         let instance_names = instance_store.get_instances();
 
         let mut view = TableView::new();
-        view.add_row()
-            .add("PID", Alignment::Left)
+        let header = view.add_row();
+        if self.all.value {
+            header.add("PID", Alignment::Left);
+        }
+        header
             .add("Name", Alignment::Left)
             .add("Arch", Alignment::Left)
             .add("CPUs", Alignment::Right)
@@ -36,14 +49,16 @@ impl Command for ListInstanceCommand {
 
         for instance_name in &instance_names {
             let instance = instance_store.load(instance_name)?;
-            let pid = instance_store
-                .get_pid(&instance)
-                .map(|pid| pid.to_string())
-                .unwrap_or_default();
 
-            view.add_row()
-                .add(&pid, Alignment::Left)
-                .add(instance_name, Alignment::Left)
+            let row = view.add_row();
+            if self.all.value {
+                let pid = instance_store
+                    .get_pid(&instance)
+                    .map(|pid| pid.to_string())
+                    .unwrap_or_default();
+                row.add(&pid, Alignment::Left);
+            }
+            row.add(instance_name, Alignment::Left)
                 .add(&instance.arch.to_string(), Alignment::Left)
                 .add(&instance.cpus.to_string(), Alignment::Right)
                 .add(&instance.mem.to_size(), Alignment::Right)
@@ -71,17 +86,22 @@ mod tests {
     use std::rc::Rc;
     use std::str::FromStr;
 
-    #[test]
-    fn test_list_instance_command() {
-        let system = SystemMock::new();
-        let console = &mut Console::new(&system);
+    fn build_context(instances: Vec<Instance>) -> commands::Context {
+        build_context_with_store(InstanceStoreMock::new(instances))
+    }
+
+    fn build_context_with_store(store: InstanceStoreMock) -> commands::Context {
         let env = Environment::new(
             UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
             String::new(),
         );
-        let instance_store = InstanceStoreMock::new(vec![
+        commands::Context::new(Rc::new(SystemMock::new()), env, Box::new(store))
+    }
+
+    fn build_instances() -> Vec<Instance> {
+        vec![
             Instance {
                 name: "test".to_string(),
                 arch: Arch::AMD64,
@@ -104,11 +124,38 @@ mod tests {
                 hostfwd: Vec::new(),
                 ..Instance::default()
             },
-        ]);
-        let context =
-            commands::Context::new(Rc::new(SystemMock::new()), env, Box::new(instance_store));
+        ]
+    }
 
-        ListInstanceCommand {}.run(console, &context).unwrap();
+    #[test]
+    fn test_list_instance_command() {
+        let system = SystemMock::new();
+        let console = &mut Console::new(&system);
+        let context = build_context(build_instances());
+
+        ListInstanceCommand { all: false.into() }
+            .run(console, &context)
+            .unwrap();
+
+        assert_eq!(
+            system.get_output(),
+            "\
+Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
+test    amd64      1   1.0 KiB         n/a      1.0 MiB        no
+test2   amd64      5     0   B         n/a      4.9 KiB        no
+"
+        );
+    }
+
+    #[test]
+    fn test_list_instance_command_all_adds_the_pid_column() {
+        let system = SystemMock::new();
+        let console = &mut Console::new(&system);
+        let context = build_context(build_instances());
+
+        ListInstanceCommand { all: true.into() }
+            .run(console, &context)
+            .unwrap();
 
         assert_eq!(
             system.get_output(),
@@ -121,24 +168,41 @@ PID   Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
     }
 
     #[test]
-    fn test_list_instance_command_empty() {
+    fn test_list_instance_command_all_shows_the_pid_of_a_running_instance() {
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
-        let instance_store = InstanceStoreMock::new(Vec::new());
-        let env = Environment::new(
-            UserName::from_str("cubic").unwrap(),
-            String::new(),
-            String::new(),
-            String::new(),
+        let context = build_context_with_store(
+            InstanceStoreMock::new_with_running(build_instances(), &["test2"])
+                .set_pid("test2", 1059),
         );
-        let context =
-            commands::Context::new(Rc::new(SystemMock::new()), env, Box::new(instance_store));
 
-        ListInstanceCommand {}.run(console, &context).unwrap();
+        ListInstanceCommand { all: true.into() }
+            .run(console, &context)
+            .unwrap();
 
         assert_eq!(
             system.get_output(),
-            "PID   Name   Arch   CPUs   Memory   Disk Used   Disk Total   Running\n"
+            "\
+PID    Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
+       test    amd64      1   1.0 KiB         n/a      1.0 MiB        no
+1059   test2   amd64      5     0   B         n/a      4.9 KiB       yes
+"
+        );
+    }
+
+    #[test]
+    fn test_list_instance_command_empty() {
+        let system = SystemMock::new();
+        let console = &mut Console::new(&system);
+        let context = build_context(Vec::new());
+
+        ListInstanceCommand { all: false.into() }
+            .run(console, &context)
+            .unwrap();
+
+        assert_eq!(
+            system.get_output(),
+            "Name   Arch   CPUs   Memory   Disk Used   Disk Total   Running\n"
         );
     }
 }

--- a/src/commands/list_port_command.rs
+++ b/src/commands/list_port_command.rs
@@ -7,17 +7,20 @@ use clap::Parser;
 /// List ports for VM instances
 ///
 /// Shows port forwarding rules from VM instance to host. Use cubic modify <instance>
-/// to configure the forwarding.
+/// to configure the forwarding. The SSH port is assigned by cubic and is shown by
+/// cubic show instead.
 ///
 /// Examples:
 ///
 ///   $ cubic ports
-///   Instance       Host              Guest   Protocol   In Use
-///   noble-arm64    127.0.0.1:30612   :22     /tcp       no
-///   noble-arm64    127.0.0.1:2222    :22     /tcp       no
-///   trixie         127.0.0.1:30200   :22     /tcp       yes
-///   trixie         127.0.0.1:4000    :4000   /tcp       yes
-///   fedora         127.0.0.1:59153   :22     /tcp       no
+///   Instance      Host             Guest   Protocol   In Use
+///   noble-arm64   127.0.0.1:2222   :22     /tcp       no
+///   trixie        127.0.0.1:4000   :4000   /tcp       yes
+///   trixie        0.0.0.0:80       :8000   /udp       yes
+///
+///   $ cubic ports
+///   No port forwarding rules are configured.
+///   Add one with cubic modify <instance> --port <host_port>:<guest_port>
 ///
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
@@ -28,6 +31,7 @@ impl Command for ListPortCommand {
         let instance_store = context.get_instance_store();
         let instance_names = instance_store.get_instances();
 
+        let mut rule_count = 0;
         let mut view = TableView::new();
         view.add_row()
             .add("Instance", Alignment::Left)
@@ -38,15 +42,11 @@ impl Command for ListPortCommand {
 
         for instance_name in instance_names {
             let instance = &instance_store.load(&instance_name)?;
+            if instance.hostfwd.is_empty() {
+                continue;
+            }
+
             let status = util::to_yes_no(instance_store.is_running(instance));
-
-            view.add_row()
-                .add(&instance_name, Alignment::Left)
-                .add(&format!("127.0.0.1:{}", instance.ssh_port), Alignment::Left)
-                .add(":22", Alignment::Left)
-                .add("/tcp", Alignment::Left)
-                .add(status, Alignment::Left);
-
             for rule in &instance.hostfwd {
                 view.add_row()
                     .add(&instance_name, Alignment::Left)
@@ -57,8 +57,16 @@ impl Command for ListPortCommand {
                     .add(&format!(":{}", rule.get_guest_port()), Alignment::Left)
                     .add(&format!("/{}", rule.get_protocol()), Alignment::Left)
                     .add(status, Alignment::Left);
+                rule_count += 1;
             }
         }
+
+        if rule_count == 0 {
+            console.print("No port forwarding rules are configured.");
+            console.print("Add one with cubic modify <instance> --port <host_port>:<guest_port>");
+            return Ok(());
+        }
+
         view.print(console);
         Ok(())
     }
@@ -87,22 +95,39 @@ mod tests {
         )
     }
 
+    const NO_RULES: &str = "\
+No port forwarding rules are configured.
+Add one with cubic modify <instance> --port <host_port>:<guest_port>
+";
+
     #[test]
-    fn test_list_ports_empty() {
+    fn test_list_ports_without_instances_explains_how_to_add_a_rule() {
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let context = build_context(Vec::new());
 
         ListPortCommand {}.run(console, &context).unwrap();
 
-        assert_eq!(
-            system.get_output(),
-            "Instance   Host   Guest   Protocol   In Use\n"
-        );
+        assert_eq!(system.get_output(), NO_RULES);
     }
 
     #[test]
-    fn test_list_ports_adds_row_per_forward_rule() {
+    fn test_list_ports_without_rules_explains_how_to_add_a_rule() {
+        let system = SystemMock::new();
+        let console = &mut Console::new(&system);
+        let context = build_context(vec![Instance {
+            name: "test".to_string(),
+            ssh_port: 9000,
+            ..Instance::default()
+        }]);
+
+        ListPortCommand {}.run(console, &context).unwrap();
+
+        assert_eq!(system.get_output(), NO_RULES);
+    }
+
+    #[test]
+    fn test_list_ports_skips_instances_without_rules() {
         let system = SystemMock::new();
         let console = &mut Console::new(&system);
         let context = build_context(vec![
@@ -125,8 +150,6 @@ mod tests {
             system.get_output(),
             "\
 Instance   Host             Guest   Protocol   In Use
-test       127.0.0.1:9000   :22     /tcp       no
-test2      127.0.0.1:8000   :22     /tcp       no
 test2      127.0.0.1:4000   :40     /tcp       no
 "
         );

--- a/src/commands/restart_command.rs
+++ b/src/commands/restart_command.rs
@@ -23,7 +23,7 @@ pub struct RestartCommand {
 impl Command for RestartCommand {
     fn run(&self, console: &mut Console<'_>, context: &commands::Context) -> Result<()> {
         commands::StopCommand {
-            all: false,
+            all: false.into(),
             wait: true,
             kill: false,
             instances: self.instances.value.clone().into(),

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -12,8 +12,7 @@ use clap::Parser;
 ///
 ///   Show information of a VM instance
 ///   $ cubic show trixie
-///   Status:       running
-///   PID:          12345
+///   Running:      yes
 ///   Arch:         amd64
 ///   CPUs:         6
 ///   Memory:       16.0 GiB
@@ -24,15 +23,16 @@ use clap::Parser;
 ///   SSH Port:     54315
 ///   Monitor Port: 54316
 ///   Console Port: 54317
+///   Forward:      127.0.0.1:4000:4000/tcp
 ///
-///   Show all information, adding file locations, the SSH command and forwards
+///   Show all information, adding the process id, file locations and the SSH command
 ///   $ cubic show --all trixie
 ///   ... (fields above, then)
+///   PID:          12345
 ///   Disk Image:   ~/.local/share/cubic/machines/trixie/machine.img
 ///   Config:       ~/.local/share/cubic/machines/trixie/instance.toml
 ///   SSH Key:      ~/.local/share/cubic/machines/trixie/ssh_client_key
 ///   SSH:          ssh -i .../trixie/ssh_client_key -p 54315 cubic@localhost
-///   Forward:      127.0.0.1:4000:4000/tcp
 ///
 ///   Show information of a VM image
 ///   $ cubic show ubuntu:noble
@@ -56,9 +56,8 @@ pub struct ShowCommand {
     /// Name of the virtual machine image or instance
     name: InstanceImageName,
 
-    /// Show all available information
-    #[arg(short = 'a', long = "all")]
-    all: bool,
+    #[clap(flatten)]
+    all: commands::AllInfoArg,
 }
 
 impl Command for ShowCommand {
@@ -66,12 +65,12 @@ impl Command for ShowCommand {
         match &self.name {
             InstanceImageName::Image(name) => commands::ShowImageCommand {
                 name: name.clone(),
-                all: self.all,
+                all: self.all.value.into(),
             }
             .run(console, context),
             InstanceImageName::Instance(instance) => commands::ShowInstanceCommand {
                 instance: instance.clone().into(),
-                all: self.all,
+                all: self.all.value.into(),
             }
             .run(console, context),
         }
@@ -113,7 +112,7 @@ mod tests {
 
         ShowCommand {
             name: InstanceImageName::from_str("test").unwrap(),
-            all: false,
+            all: false.into(),
         }
         .run(console, &context)
         .unwrap();
@@ -129,7 +128,7 @@ mod tests {
 
         let result = ShowCommand {
             name: InstanceImageName::from_str("missing").unwrap(),
-            all: false,
+            all: false.into(),
         }
         .run(console, &context);
 

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -12,9 +12,8 @@ pub struct ShowImageCommand {
     /// Name of the virtual machine image
     pub name: ImageName,
 
-    /// Show all available information
-    #[arg(short = 'a', long = "all")]
-    pub all: bool,
+    #[clap(flatten)]
+    pub all: commands::AllInfoArg,
 }
 
 impl Command for ShowImageCommand {
@@ -37,7 +36,7 @@ impl Command for ShowImageCommand {
             util::to_yes_no(ImageStore::new().exists(context.get_system(), env, &image)),
         );
 
-        if self.all {
+        if self.all.value {
             view.add("Checksum", &image.hash_alg.to_string());
             view.add(
                 "Image File",

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -21,16 +21,12 @@ impl Command for ShowImageCommand {
         let env = context.get_env();
         let image = fetch_image_info(console, context.get_system(), env, &self.name)?;
 
-        let size = util::format_or_na(
-            image
-                .size
-                .map(|size| DataSize::new(size as usize).to_size()),
-        );
-
         let mut view = MapView::new();
         view.add("Name", &image.get_image_names());
         view.add("Architecture", &image.arch.to_string());
-        view.add("Size", &size);
+        if let Some(size) = image.size {
+            view.add("Size", &DataSize::new(size as usize).to_size());
+        }
         view.add(
             "Cached",
             util::to_yes_no(ImageStore::new().exists(context.get_system(), env, &image)),

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -10,9 +10,8 @@ pub struct ShowInstanceCommand {
     #[clap(flatten)]
     pub instance: commands::InstanceArg,
 
-    /// Show all available information
-    #[arg(short = 'a', long = "all")]
-    pub all: bool,
+    #[clap(flatten)]
+    pub all: commands::AllInfoArg,
 }
 
 impl Command for ShowInstanceCommand {
@@ -32,16 +31,12 @@ impl Command for ShowInstanceCommand {
             "Running",
             util::to_yes_no(instance_store.is_running(&instance)),
         );
-        view.add(
-            "PID",
-            &util::format_or_na(instance_store.get_pid(&instance)),
-        );
         view.add("Arch", &instance.arch.to_string());
         view.add("CPUs", &instance.cpus.to_string());
         view.add("Memory", &instance.mem.to_size());
         view.add(
             "Disk Used",
-            &util::format_or_na(instance.disk_used.map(|size| size.to_size())),
+            &util::format_or_na(instance.disk_used.as_ref().map(|size| size.to_size())),
         );
         view.add("Disk Total", &instance.disk_capacity.to_size());
         view.add("User", instance.user.as_str());
@@ -56,7 +51,11 @@ impl Command for ShowInstanceCommand {
             view.add(key, &rule.to_string());
         }
 
-        if self.all {
+        if self.all.value {
+            view.add(
+                "PID",
+                &util::format_or_na(instance_store.get_pid(&instance)),
+            );
             view.add("Disk Image", &env.get_instance_image_file(&instance.name));
             view.add("Config", &env.get_instance_toml_config_file(&instance.name));
             view.add("SSH Key", &ssh_key);
@@ -111,7 +110,7 @@ mod tests {
 
         ShowInstanceCommand {
             instance: InstanceName::from_str("test").unwrap().into(),
-            all: false,
+            all: false.into(),
         }
         .run(console, &context)
         .unwrap();
@@ -120,7 +119,6 @@ mod tests {
             system.get_output(),
             "\
 Running:      no
-PID:          n/a
 Arch:         amd64
 CPUs:         1
 Memory:       1.0 KiB
@@ -182,7 +180,7 @@ Forward:      127.0.0.1:4000:40/tcp
 
         ShowInstanceCommand {
             instance: InstanceName::from_str("test").unwrap().into(),
-            all: true,
+            all: true.into(),
         }
         .run(console, &context)
         .unwrap();
@@ -192,7 +190,6 @@ Forward:      127.0.0.1:4000:40/tcp
             format!(
                 "\
 Running:      no
-PID:          n/a
 Arch:         arm64
 CPUs:         2
 Memory:       1   B
@@ -205,6 +202,7 @@ Monitor Port: 8001
 Console Port: 8002
 Forward:      127.0.0.1:4000:40/tcp
               0.0.0.0:80:8000/udp
+PID:          n/a
 Disk Image:   {disk_image}
 Config:       {config}
 SSH Key:      {ssh_key}
@@ -231,7 +229,7 @@ SSH:          ssh -i {ssh_key} -p 8000 john@localhost
         assert!(matches!(
             ShowInstanceCommand {
                 instance: InstanceName::from_str("test").unwrap().into(),
-                all: false,
+                all: false.into(),
             }
             .run(console, &context),
             Err(Error::UnknownInstance(_))

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -34,16 +34,19 @@ impl Command for ShowInstanceCommand {
         view.add("Arch", &instance.arch.to_string());
         view.add("CPUs", &instance.cpus.to_string());
         view.add("Memory", &instance.mem.to_size());
-        view.add(
-            "Disk Used",
-            &util::format_or_na(instance.disk_used.as_ref().map(|size| size.to_size())),
-        );
+        if let Some(disk_used) = &instance.disk_used {
+            view.add("Disk Used", &disk_used.to_size());
+        }
         view.add("Disk Total", &instance.disk_capacity.to_size());
         view.add("User", instance.user.as_str());
         view.add("Isolated", util::to_yes_no(instance.isolate));
         view.add("SSH Port", &instance.ssh_port.to_string());
-        view.add("Monitor Port", &util::format_or_na(instance.monitor_port));
-        view.add("Console Port", &util::format_or_na(instance.console_port));
+        if let Some(monitor_port) = instance.monitor_port {
+            view.add("Monitor Port", &monitor_port.to_string());
+        }
+        if let Some(console_port) = instance.console_port {
+            view.add("Console Port", &console_port.to_string());
+        }
 
         // Port forwarding
         for (index, rule) in instance.hostfwd.iter().enumerate() {
@@ -52,10 +55,9 @@ impl Command for ShowInstanceCommand {
         }
 
         if self.all.value {
-            view.add(
-                "PID",
-                &util::format_or_na(instance_store.get_pid(&instance)),
-            );
+            if let Some(pid) = instance_store.get_pid(&instance) {
+                view.add("PID", &pid.to_string());
+            }
             view.add("Disk Image", &env.get_instance_image_file(&instance.name));
             view.add("Config", &env.get_instance_toml_config_file(&instance.name));
             view.add("SSH Key", &ssh_key);
@@ -118,18 +120,15 @@ mod tests {
         assert_eq!(
             system.get_output(),
             "\
-Running:      no
-Arch:         amd64
-CPUs:         1
-Memory:       1.0 KiB
-Disk Used:    n/a
-Disk Total:   1.0 MiB
-User:         myuser
-Isolated:     no
-SSH Port:     9000
-Monitor Port: n/a
-Console Port: n/a
-Forward:      127.0.0.1:4000:40/tcp
+Running:    no
+Arch:       amd64
+CPUs:       1
+Memory:     1.0 KiB
+Disk Total: 1.0 MiB
+User:       myuser
+Isolated:   no
+SSH Port:   9000
+Forward:    127.0.0.1:4000:40/tcp
 "
         );
     }
@@ -193,7 +192,6 @@ Running:      no
 Arch:         arm64
 CPUs:         2
 Memory:       1   B
-Disk Used:    n/a
 Disk Total:   1   B
 User:         john
 Isolated:     yes
@@ -202,7 +200,6 @@ Monitor Port: 8001
 Console Port: 8002
 Forward:      127.0.0.1:4000:40/tcp
               0.0.0.0:80:8000/udp
-PID:          n/a
 Disk Image:   {disk_image}
 Config:       {config}
 SSH Key:      {ssh_key}

--- a/src/commands/stop_command.rs
+++ b/src/commands/stop_command.rs
@@ -27,9 +27,8 @@ use std::time::Duration;
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
 pub struct StopCommand {
-    /// Stop all virtual machine instances
-    #[clap(short, long, default_value_t = false)]
-    pub all: bool,
+    #[clap(flatten)]
+    pub all: commands::AllInstancesArg,
     /// Wait for the virtual machine instance to be stopped
     #[clap(short, long, default_value_t = false)]
     pub wait: bool,
@@ -44,11 +43,11 @@ impl Command for StopCommand {
     fn run(&self, console: &mut Console<'_>, context: &commands::Context) -> Result<()> {
         let instance_store = context.get_instance_store();
 
-        if !self.all {
+        if !self.all.value {
             self.instances.require_names()?;
         }
 
-        let stop_instances = if self.all {
+        let stop_instances = if self.all.value {
             instance_store.get_instances()
         } else {
             self.instances.get_names()
@@ -109,7 +108,7 @@ mod tests {
 
         assert!(matches!(
             StopCommand {
-                all: false,
+                all: false.into(),
                 wait: false,
                 kill: false,
                 instances: Vec::new().into(),
@@ -137,7 +136,7 @@ mod tests {
 
         assert!(
             StopCommand {
-                all: true,
+                all: true.into(),
                 wait: false,
                 kill: false,
                 instances: Vec::new().into(),

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -57,7 +57,15 @@ impl<'a> ImageFactory<'a> {
         console.debug(&format!(
             "Fetching image directory listing '{image_dir_url}'"
         ));
-        let image_content = web.download_content(&image_dir_url).unwrap();
+        let image_content = match web.download_content(&image_dir_url) {
+            Ok(content) => content,
+            Err(e) => {
+                console.debug(&format!(
+                    "Cannot fetch image directory listing '{image_dir_url}' ({e})"
+                ));
+                return None;
+            }
+        };
 
         let image_file = util::find_and_extract(
             &format!(

--- a/src/instance/instance_store_mock.rs
+++ b/src/instance/instance_store_mock.rs
@@ -10,6 +10,7 @@ pub mod tests {
     pub struct InstanceStoreMock {
         instances: Vec<Instance>,
         running: Vec<String>,
+        pids: Vec<(String, u64)>,
         killed: Mutex<Vec<String>>,
     }
 
@@ -22,8 +23,14 @@ pub mod tests {
             Self {
                 instances,
                 running: running.iter().map(|name| name.to_string()).collect(),
+                pids: Vec::new(),
                 killed: Mutex::new(Vec::new()),
             }
+        }
+
+        pub fn set_pid(mut self, name: &str, pid: u64) -> Self {
+            self.pids.push((name.to_string(), pid));
+            self
         }
 
         pub fn get_killed(&self) -> Vec<String> {
@@ -68,8 +75,11 @@ pub mod tests {
             self.running.contains(&instance.name)
         }
 
-        fn get_pid(&self, _instance: &Instance) -> Option<u64> {
-            None
+        fn get_pid(&self, instance: &Instance) -> Option<u64> {
+            self.pids
+                .iter()
+                .find(|(name, _)| *name == instance.name)
+                .map(|(_, pid)| *pid)
         }
 
         fn kill(&self, instance: &Instance) -> Result<()> {


### PR DESCRIPTION
## Summary

Six small fixes, one per commit.

**1. The process id moves behind `--all`.** `cubic show` printed `PID` as the second row and `cubic instances` had a `PID` column. Both are now shown only with `--all`, where the pid joins `Disk Image`, `Config` and `SSH Key` at the bottom.

**2. `cubic show` omits a field instead of printing `n/a`.** This affects `Disk Used`, `Monitor Port` and `Console Port` on an instance, `PID` under `--all`, and `Size` on an image. Since the key column is sized from the longest label present, dropping `Monitor Port` also narrows the block.

```
before                          after
Running:      no                Running:    no
PID:          n/a               Arch:       amd64
Arch:         amd64             CPUs:       1
CPUs:         1                 Memory:     1.0 GiB
Memory:       1.0 GiB           Disk Total: 2.2 GiB
Disk Used:    n/a               User:       cubic
Disk Total:   2.2 GiB           Isolated:   no
User:         cubic             SSH Port:   14357
Isolated:     no
SSH Port:     14357
Monitor Port: n/a
Console Port: n/a
```

**3. `cubic ports` drops the invented ssh row.** It printed `127.0.0.1:<ssh_port>` to `:22` for every instance, which no user configured, while never showing the monitor or console ports. It now prints `instance.hostfwd` only. With no rules anywhere you used to get a bare header, so that case now explains itself.

```
before                                          after
Instance   Host             Guest  Protocol     No port forwarding rules are configured.
noble      127.0.0.1:30612  :22    /tcp         Add one with cubic modify <instance> --port <host_port>:<guest_port>
trixie     127.0.0.1:30200  :22    /tcp
```

**4. `cubic delete` kills instead of stopping gracefully.** It ran `StopCommand` with `kill: false, wait: true`, so deleting a running machine waited out a full guest shutdown before erasing the disk image.

**5. A failed image listing no longer aborts cubic.** `image_factory.rs` did `web.download_content(&image_dir_url).unwrap()`, and release builds set `panic = 'abort'`, so a mirror timeout or a 404 killed the process. The function already returns `Option<Image>`, so it now returns `None` and logs the url and the error under `--verbose`.

**6. `--all` gets one type per meaning.** It means all information in `show` and `instances`, all instances in `stop`, and all images in `images`. Only the first had a type, so flattening it into `stop` would have silently changed that command's help text. Now there is `AllInfoArg`, `AllInstancesArg` and `AllImagesArg`. The flags and their short forms are unchanged.

## Related Issue(s)

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

`make format`, `make lint`, `make yamllint` and `make test` pass, with 437 tests. Four are new, covering the `cubic instances --all` column with a running instance that reports a pid, and the empty state of `cubic ports`. The existing output assertions were updated by hand, not just made to pass.

The help and doc examples were rendered through the real view code and corrected. Two were already wrong before this branch, calling the running state `Status` and listing the forwards after the detail fields.

Checked against a real run over 18 local instances, and `images` still returns 37 rows by default and 61 with `--all`.

`cubic delete` and `cubic show <image>` ship untested. Both need a test seam that is out of scope here.

## Notes for the reviewer

`cubic delete` no longer shuts a running guest down cleanly. The prompt already asks about losing the machine, but anyone relying on delete to flush guest state will notice.

`stop --all` help text now reads "Apply to all virtual machine instances" so a later `delete --all` can share the same type. Behavior is unchanged.

## Checklist

- [ ] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed