### PR TITLE
fix: enable the security pocket for arm64 snap builds

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -46,7 +46,7 @@ package-repositories:
     architectures: [arm64]
     formats: [deb, deb-src]
     components: [main]
-    suites: [noble, noble-updates, noble-backports]
+    suites: [noble, noble-updates, noble-backports, noble-security]
     key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
     url: http://ports.ubuntu.com/ubuntu-ports
 


### PR DESCRIPTION
## Summary

The arm64 apt entry in `snapcraft.yaml` listed only `noble`, `noble-updates` and `noble-backports`. Without `noble-security` every arm64 stage package stayed at its release version, so Snapcraft kept reporting outdated packages such as `libkmod2` and rebuilding the snap changed nothing.

This adds `noble-security` to the arm64 suites. Ports carries every pocket.
## Related Issue(s)

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

`make yamllint` passes. The real check comes with the next arm64 build, which should now pull `libkmod2` and the other stage packages from `noble-security`.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed

Fill in the issue number if one exists, otherwise drop that section.