### PR TITLE
fix: name only the instances that are started or stopped

### DIFF
--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -53,6 +53,7 @@ impl Command for StartCommand {
 
         // Launch virtual machine instances
         let mut actions = Vec::new();
+        let mut starting = Vec::new();
         for name in &self.instances.value {
             let instance = &mut instance_store.load(name.as_str())?;
             if !instance_store.is_running(instance) {
@@ -77,14 +78,16 @@ impl Command for StartCommand {
                 action.run(context, &self.qemu_args, console)?;
 
                 actions.push(action);
+                // Only the instances that are launched are named
+                starting.push(instance.name.clone());
             }
         }
 
         // Wait for virtual machine instances to be started
-        if self.wait {
+        if self.wait && !starting.is_empty() {
             console.play(Arc::new(Mutex::new(Spinner::new(format!(
                 "Starting {}",
-                self.instances.get_names().join(", ")
+                starting.join(", ")
             )))));
             let deadline = Instant::now() + Duration::from_secs(300);
             while actions.iter().any(|a| !a.is_done(context.get_system())) {

--- a/src/commands/stop_command.rs
+++ b/src/commands/stop_command.rs
@@ -53,17 +53,25 @@ impl Command for StopCommand {
             self.instances.get_names()
         };
 
+        // Only the instances that are running are stopped, so only those are named
         let mut actions = Vec::new();
-        for instance in &stop_instances {
-            let mut action = StopInstanceAction::new(&instance_store.load(instance)?);
+        let mut stopping = Vec::new();
+        for name in &stop_instances {
+            let instance = instance_store.load(name)?;
+            if !instance_store.is_running(&instance) {
+                continue;
+            }
+
+            let mut action = StopInstanceAction::new(&instance);
             action.run(instance_store, self.kill)?;
             actions.push(action);
+            stopping.push(name.clone());
         }
 
-        if self.wait && !stop_instances.is_empty() {
+        if self.wait && !stopping.is_empty() {
             console.play(Arc::new(Mutex::new(Spinner::new(format!(
                 "Stopping {}",
-                stop_instances.join(", ")
+                stopping.join(", ")
             )))));
             while actions.iter().any(|action| !action.is_done(instance_store)) {
                 thread::sleep(Duration::from_secs(1))


### PR DESCRIPTION

## Summary

Start and stop name every requested instance in the spinner, including the ones they skip. `cubic start a b --wait` says `Starting a, b` even when `b` was already up, and `cubic restart b` shows a `Stopping b` spinner for an instance that was never running. Each command now collects the instances it actually acts on and names only those, and says nothing when that list is empty. Restart follows along through the two commands it calls. This is output only, the set of instances that get started or stopped is unchanged.

## Related Issue(s)

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Manual tests

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed