### PR TITLE
chore: update vulnlog and format vulnlog.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV XDG_DATA_HOME=/tmp/data
 ENV XDG_CACHE_HOME=/tmp/cache
 ENV XDG_RUNTIME_DIR=/tmp/runtime
+ENV PATH=/root/bin:${PATH}
 RUN apt update && \
     apt install -y \
         qemu-utils \
@@ -23,5 +24,4 @@ RUN apt update && \
     git config --global --add safe.directory /usr/local/app
 RUN rustup component add clippy rustfmt && \
     cargo install --locked cargo-audit &&\
-    echo 'alias cubic="cargo run"' >> ~/.bashrc &&\
-    echo 'alias vulnlog="/root/bin/vulnlog"' >> ~/.bashrc
+    echo 'alias cubic="cargo run"' >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && \
         yamllint \
         unzip \
         curl &&\
-    curl -fsSL https://github.com/vulnlog/vulnlog/releases/download/v0.14.0/install-vulnlog.sh | sh &&\
+    curl -fsSL https://github.com/vulnlog/vulnlog/releases/download/v0.16.0/install-vulnlog.sh | sh &&\
     git config --global --add safe.directory /usr/local/app
 RUN rustup component add clippy rustfmt && \
     cargo install --locked cargo-audit &&\

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,11 @@ cleanall: build-image
 
 format: build-image
 	${DOCKER_CMD} ${IMAGE} cargo fmt --check
+	${DOCKER_CMD} ${IMAGE} vulnlog fmt --check vulnlog.yml
 
 fix-format: build-image
 	${DOCKER_CMD} ${IMAGE} cargo fmt
+	${DOCKER_CMD} ${IMAGE} vulnlog fmt vulnlog.yml
 
 lint: build-image
 	${DOCKER_CMD} ${IMAGE} cargo clippy -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ doc: build-image
 	@${DOCKER_CMD} -p 4000:4000 -it ${IMAGE} python3 -m http.server -d target/page 4000
 
 suppress: build-image
-	@${DOCKER_CMD} -it ${IMAGE} /root/bin/vulnlog suppress vulnlog.yml -o .cargo/audit.toml
+	@${DOCKER_CMD} -it ${IMAGE} vulnlog suppress vulnlog.yml -o .cargo/audit.toml
 
 release: build-image
 	sed "s/^\(version =\).*$$/\1 \"${version}\"/g" -i Cargo.toml

--- a/vulnlog.yml
+++ b/vulnlog.yml
@@ -2,23 +2,21 @@
 schemaVersion: "1"
 
 project:
-  organization: "cubic-vm"
-  name: "cubic"
-  author: "Cubic VM team"
+  organization: cubic-vm
+  name: cubic
+  author: Cubic VM team
 
 releases: []
 
 vulnerabilities:
+
   - id: RUSTSEC-2023-0071
+    description: This is a timing attack that could allow an attacker to recover RSA keys from the server.
     releases: []
     packages: ["pkg:cargo/rsa@0.9.10"]
     reports:
       - reporter: cargo-audit
+    analysis: The RSA crate is only used for client authentication.
     verdict: not affected
     justification: vulnerable code not in execute path
-    description: >
-      This is a timing attack that could allow an attacker to recover RSA keys from the server.
-    analysis: >
-      The RSA crate is only used for client authentication.
-    comment: >
-      See https://github.com/Eugeny/russh/issues/637
+    comment: "See https://github.com/Eugeny/russh/issues/637"


### PR DESCRIPTION
## Summary

Update vulnlog in the dev image from 0.14.0 to 0.16.0 and use its new `fmt` command. The install script installs the version matching its own release tag, so the tag in the URL is the version pin. Along the way `/root/bin` goes on the image path so the bare name works under `docker run`, which makes the bashrc alias redundant. The `format` and `fix-format` rules now run `vulnlog fmt` the way they run `cargo fmt`, and `vulnlog.yml` moves to the canonical style so the check passes.

## Related Issue(s)

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Other

Build tooling.

## Test Plan

All vulnlog commands ran in the container. Each of the three commits was verified before it was committed, so the branch is green at every point.

- `make check` passes on the final state, covering fmt, clippy, yamllint, 432 tests and `cargo audit`.
- The new check is a real gate. The pre format `vulnlog.yml` exits 3 under `vulnlog fmt --check`, so `make format` fails on drift.
- `make suppress` regenerates `.cargo/audit.toml` with no diff under 0.16.0.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed