### PR TITLE
chore: release v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "cubic"
-version = "0.0.0-dev"
+version = "0.25.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubic"
-version = "0.0.0-dev"
+version = "0.25.0"
 authors = ["Roger Knecht <rknecht@pm.me>"]
 license = "MIT OR Apache-2.0"
 description = "Cubic spins up Linux virtual machines on Linux, macOS and Windows with a single command."


### PR DESCRIPTION
chore: release v0.25.0

Bump version in Cargo.toml and Cargo.lock.