### PR TITLE
feat: keep everything an instance owns in one directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ COPY . .
 ENV DEBIAN_FRONTEND=noninteractive
 ENV XDG_DATA_HOME=/tmp/data
 ENV XDG_CACHE_HOME=/tmp/cache
-ENV XDG_RUNTIME_DIR=/tmp/runtime
 ENV PATH=/root/bin:${PATH}
 RUN apt update && \
     apt install -y \

--- a/docs/internals/how_it_works.rst
+++ b/docs/internals/how_it_works.rst
@@ -42,7 +42,8 @@ initialising cloud VMs on first boot. Cubic uses it to configure each instance
 automatically without user interaction.
 
 For each new instance Cubic assembles a cloud-init configuration and packs it
-into a small ISO 9660 image. QEMU attaches that image as a virtio disk, and
+into a small ISO 9660 image, stored as ``cloud-init.iso`` in the instance
+directory. QEMU attaches that image as a virtio disk, and
 cloud-init finds it on first boot. It then applies the configuration —
 including creating the default user and installing the instance's SSH public
 key — and marks provisioning as done. The seed disk is no longer consulted on
@@ -67,8 +68,10 @@ model Cubic passes is shared with the TCG path, and the mismatch makes the
 guest hang at the OVMF firmware screen. See `issue #500
 <https://github.com/cubic-vm/cubic/issues/500>`_.
 
-Each instance stores its own disk image under
-``~/.local/share/cubic/machines/<name>/``, keeping instances fully isolated
+Each instance keeps everything it owns in one directory under
+``~/.local/share/cubic/machines/<name>/``. That directory holds the
+configuration, the disk image, the SSH key, the cloud-init seed image and,
+while the machine runs, the QEMU pid file. This keeps instances fully isolated
 from each other and from the shared image cache.
 
 UEFI Firmware (EDK2)

--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -137,11 +137,11 @@ Keeping Instances Apart
 -----------------------
 
 Everything that belongs to a virtual machine, including its SSH private key, its
-TLS certificates, and its disk images, is stored under your own data directory,
-for example ``~/.local/share/cubic/machines/<name>/`` on Linux. Reaching a
-running machine therefore comes down to two things: the file permissions on that
-directory, and holding the SSH key or the TLS client certificate that is kept
-inside it.
+TLS certificates, its disk images and its cloud-init seed image, is stored under
+your own data directory, for example ``~/.local/share/cubic/machines/<name>/``
+on Linux. Reaching a running machine therefore comes down to two things: the
+file permissions on that directory, and holding the SSH key or the TLS client
+certificate that is kept inside it.
 
 Cubic currently relies on the file permissions that the operating system applies
 by default. Restricting the private keys and certificates so that only their

--- a/src/actions/load_instance_action.rs
+++ b/src/actions/load_instance_action.rs
@@ -72,7 +72,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             "/data".to_string(),
             "/cache".to_string(),
-            "/run".to_string(),
         )
     }
 

--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -1,4 +1,4 @@
-use crate::cloudinit::UserDataImageFactory;
+use crate::cloudinit::CloudInitImageFactory;
 use crate::commands::Context;
 use crate::error::{Error, Result};
 use crate::instance::InstanceCertGenerator;
@@ -7,7 +7,7 @@ use crate::platform::System;
 use crate::qemu::{QemuFirmware, QemuInstall, QemuPathBuilder, QemuSystem};
 use crate::ssh::PortChecker;
 use crate::view::Console;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub struct StartInstanceAction {
     instance: Instance,
@@ -32,10 +32,7 @@ impl StartInstanceAction {
 
         let env = context.get_env();
         let system = context.get_system();
-        system.create_writable_dir(Path::new(
-            &env.get_instance_runtime_dir(&self.instance.name),
-        ))?;
-        UserDataImageFactory.create_rust(system, env, &self.instance)?;
+        CloudInitImageFactory.create(system, env, &self.instance)?;
 
         let instance_dir = PathBuf::from(env.get_instance_dir2(&self.instance.name));
         let cert_generator = InstanceCertGenerator::new(system, instance_dir.clone());
@@ -94,7 +91,7 @@ impl StartInstanceAction {
         qemu_system.set_memory(self.instance.mem.get_bytes() as u64);
         qemu_system.set_console(self.instance.console_port.unwrap(), &instance_dir);
         qemu_system.add_drive(&env.get_instance_image_file(&self.instance.name), "qcow2");
-        qemu_system.add_drive(&env.get_user_data_image_file(&self.instance.name), "raw");
+        qemu_system.add_drive(&env.get_cloud_init_file(&self.instance.name), "raw");
         qemu_system.set_network(
             &self.instance.hostfwd,
             self.instance.ssh_port,

--- a/src/cloudinit.rs
+++ b/src/cloudinit.rs
@@ -1,7 +1,7 @@
+mod cloud_init_image_factory;
 mod meta_data_factory;
 mod user_data_factory;
-mod user_data_image_factory;
 
+pub use cloud_init_image_factory::*;
 pub use meta_data_factory::MetaDataFactory;
 pub use user_data_factory::UserDataFactory;
-pub use user_data_image_factory::*;

--- a/src/cloudinit/cloud_init_image_factory.rs
+++ b/src/cloudinit/cloud_init_image_factory.rs
@@ -8,18 +8,18 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 #[derive(Default)]
-pub struct UserDataImageFactory;
+pub struct CloudInitImageFactory;
 
-impl UserDataImageFactory {
-    pub fn create_rust(
+impl CloudInitImageFactory {
+    pub fn create(
         &self,
         system: &dyn System,
         env: &Environment,
         instance: &Instance,
     ) -> Result<()> {
-        let user_data_img_path = PathBuf::from(env.get_user_data_image_file(&instance.name));
+        let cloud_init_path = PathBuf::from(env.get_cloud_init_file(&instance.name));
 
-        if system.exists_path(&user_data_img_path) {
+        if system.exists_path(&cloud_init_path) {
             return Ok(());
         }
 
@@ -37,7 +37,6 @@ impl UserDataImageFactory {
             UserDataFactory.create(&instance.user, &pubkey, instance.execute.as_deref());
 
         // Generate ISO file
-        system.create_dir(Path::new(&env.get_instance_cache_dir(&instance.name)))?;
         let mut iso_writer = IsoWriter::new();
         iso_writer.pvd.system_id = "LINUX".to_string();
         iso_writer.pvd.volume_id = "cidata".to_string();
@@ -51,7 +50,7 @@ impl UserDataImageFactory {
 
         let mut buffer = Cursor::new(Vec::new());
         iso_writer.create_iso(&mut buffer)?;
-        system.write_file(&user_data_img_path, buffer.get_ref())?;
+        system.write_file(&cloud_init_path, buffer.get_ref())?;
         Ok(())
     }
 }
@@ -68,7 +67,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             "/data".to_string(),
             "/cache".to_string(),
-            "/run".to_string(),
         )
     }
 
@@ -80,22 +78,22 @@ mod tests {
     }
 
     #[test]
-    fn test_create_rust_writes_the_cloud_init_image() {
+    fn test_create_writes_the_cloud_init_image() {
         let system = SystemMock::new();
         let env = build_env();
 
-        UserDataImageFactory
-            .create_rust(&system, &env, &build_instance())
+        CloudInitImageFactory
+            .create(&system, &env, &build_instance())
             .unwrap();
 
         let image = system
-            .get_written_file(&env.get_user_data_image_file("test"))
+            .get_written_file(&env.get_cloud_init_file("test"))
             .expect("expected the cloud init image to have been written");
         assert!(!image.is_empty());
     }
 
     #[test]
-    fn test_create_rust_embeds_the_public_key_of_the_instance() {
+    fn test_create_embeds_the_public_key_of_the_instance() {
         let system = SystemMock::new();
         let env = build_env();
         let key_path = Path::new(&env.get_instance_dir2("test")).join("ssh_client_key");
@@ -103,15 +101,15 @@ mod tests {
             .generate_key(&system, &key_path)
             .unwrap();
 
-        UserDataImageFactory
-            .create_rust(&system, &env, &build_instance())
+        CloudInitImageFactory
+            .create(&system, &env, &build_instance())
             .unwrap();
 
         let pubkey = SshKeyGenerator::new()
             .generate_public_key(&system, &key_path)
             .unwrap();
         let image = system
-            .get_written_file(&env.get_user_data_image_file("test"))
+            .get_written_file(&env.get_cloud_init_file("test"))
             .unwrap();
         assert!(
             image
@@ -121,16 +119,16 @@ mod tests {
     }
 
     #[test]
-    fn test_create_rust_keeps_an_existing_image() {
+    fn test_create_keeps_an_existing_image() {
         let env = build_env();
-        let system = SystemMock::new().add_file(&env.get_user_data_image_file("test"), b"existing");
+        let system = SystemMock::new().add_file(&env.get_cloud_init_file("test"), b"existing");
 
-        UserDataImageFactory
-            .create_rust(&system, &env, &build_instance())
+        CloudInitImageFactory
+            .create(&system, &env, &build_instance())
             .unwrap();
 
         assert_eq!(
-            system.get_written_file(&env.get_user_data_image_file("test")),
+            system.get_written_file(&env.get_cloud_init_file("test")),
             Some(b"existing".to_vec())
         );
     }

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -78,7 +78,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         Context::new(
             Rc::new(SystemMock::new()),
@@ -120,7 +119,6 @@ mod tests {
         let console = &mut Console::new(&system);
         let env = Environment::new(
             UserName::from_str("cubic").unwrap(),
-            String::new(),
             String::new(),
             String::new(),
         );

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -143,7 +143,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         let context = Context::new(
             Rc::new(SystemMock::new()),

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -96,7 +96,6 @@ mod tests {
             UserName::from_str("myuser").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         let context = commands::Context::new(
             Rc::new(SystemMock::new()),

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -70,7 +70,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         let image = Image {
             vendor: "debian".to_string(),

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -96,7 +96,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         commands::Context::new(Rc::new(SystemMock::new()), env, Box::new(store))
     }

--- a/src/commands/list_port_command.rs
+++ b/src/commands/list_port_command.rs
@@ -87,7 +87,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         commands::Context::new(
             Rc::new(SystemMock::new()),

--- a/src/commands/modify_command.rs
+++ b/src/commands/modify_command.rs
@@ -129,7 +129,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         commands::Context::new(Rc::new(SystemMock::new()), env, Box::new(instance_store))
     }

--- a/src/commands/prune_command.rs
+++ b/src/commands/prune_command.rs
@@ -3,11 +3,14 @@ use crate::error::Result;
 use crate::models::DataSize;
 use crate::view::{ConfirmDialog, Console};
 use clap::Parser;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+
+const LEGACY_INSTANCES_DIR: &str = "instances";
 
 /// Clear caches
 ///
-/// This commands removes cached VM images files.
+/// This command removes cached VM image files and instance files left behind
+/// by older versions of cubic.
 ///
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
@@ -21,38 +24,113 @@ impl Command for PruneCommand {
         let env = context.get_env();
         let system = context.get_system();
 
-        // Calculate size
-        let paths = [
-            PathBuf::from(env.get_image_cache_file()),
+        let dirs = [
             PathBuf::from(env.get_image_dir()),
+            PathBuf::from(env.get_cache_dir()).join(LEGACY_INSTANCES_DIR),
         ];
+
+        // Calculate size
+        let cache_file = PathBuf::from(env.get_image_cache_file());
         let total = DataSize::new(
-            paths
-                .iter()
+            dirs.iter()
+                .chain([&cache_file])
                 .fold(0, |total, path| total + system.get_path_size(path)) as usize,
         )
         .to_size();
 
-        console.print("The following items will be deleted:");
-        console.print("  - VM image list cache");
-        console.print("  - Downloaded VM images");
-
         // Print size of files to be deleted
-        console.print(&format!("\nTotal size: {total}\n"));
+        console.print(&format!("Pruning caches frees {total} of disk space.\n"));
 
         if self.yes.value
             || ConfirmDialog::new("Are you sure you want to continue?").confirm(console)
         {
             // Delete files
-            system
-                .remove_file(Path::new(&env.get_image_cache_file()))
-                .ok();
-            system.remove_dir(Path::new(&env.get_image_dir())).ok();
+            system.remove_file(&cache_file).ok();
+            for dir in &dirs {
+                system.remove_dir(dir).ok();
+            }
 
             // Print size of deleted files
             console.print(&format!("Successfully freed {total} of disk space."));
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instance::InstanceStoreMock;
+    use crate::models::{Environment, UserName};
+    use crate::platform::{FileSystem, System, SystemMock};
+    use std::path::Path;
+    use std::rc::Rc;
+    use std::str::FromStr;
+
+    fn build_env() -> Environment {
+        Environment::new(
+            UserName::from_str("cubic").unwrap(),
+            "/data".to_string(),
+            "/cache".to_string(),
+        )
+    }
+
+    fn build_context(system: &Rc<SystemMock>, env: &Environment) -> commands::Context {
+        commands::Context::new(
+            Rc::clone(system) as Rc<dyn System>,
+            env.clone(),
+            Box::new(InstanceStoreMock::new(Vec::new())),
+        )
+    }
+
+    fn run_prune(system: &Rc<SystemMock>, env: &Environment) -> String {
+        let console = &mut Console::new(system.as_ref());
+        PruneCommand {
+            yes: commands::YesArg { value: true },
+        }
+        .run(console, &build_context(system, env))
+        .unwrap();
+        system.get_output()
+    }
+
+    #[test]
+    fn test_delete_the_image_cache_and_the_legacy_cache_instance_dir() {
+        let env = build_env();
+        let system = Rc::new(
+            SystemMock::new()
+                .add_file(&env.get_image_cache_file(), b"cache")
+                .add_file(&format!("{}/debian", env.get_image_dir()), b"image")
+                .add_file("/cache/instances/test/user-data.img", b"seed"),
+        );
+
+        run_prune(&system, &env);
+
+        assert!(!system.exists_path(Path::new(&env.get_image_cache_file())));
+        assert!(!system.exists_path(Path::new(&env.get_image_dir())));
+        assert!(!system.exists_path(Path::new("/cache/instances")));
+    }
+
+    #[test]
+    fn test_keep_the_instance_data_dir() {
+        let env = build_env();
+        let instance_file = format!("{}/cloud-init.iso", env.get_instance_dir2("test"));
+        let system = Rc::new(SystemMock::new().add_file(&instance_file, b"seed"));
+
+        run_prune(&system, &env);
+
+        assert!(system.exists_path(Path::new(&instance_file)));
+    }
+
+    #[test]
+    fn test_report_the_size_of_everything_it_deletes() {
+        let env = build_env();
+        let system = Rc::new(
+            SystemMock::new()
+                .add_file(&format!("{}/debian", env.get_image_dir()), &[0; 1024])
+                .add_file("/cache/instances/test/user-data.img", &[0; 1024]),
+        );
+
+        assert!(run_prune(&system, &env).contains("frees 2.0 KiB"));
     }
 }

--- a/src/commands/rename_command.rs
+++ b/src/commands/rename_command.rs
@@ -47,7 +47,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         commands::Context::new(
             Rc::new(SystemMock::new()),

--- a/src/commands/scp_command.rs
+++ b/src/commands/scp_command.rs
@@ -124,7 +124,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         commands::Context::new(Rc::new(SystemMock::new()), env, Box::new(instance_store))
     }

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -92,7 +92,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         commands::Context::new(
             Rc::new(SystemMock::new()),

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -96,7 +96,6 @@ mod tests {
             UserName::from_str("myuser").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         let instance_store = InstanceStoreMock::new(vec![Instance {
             name: "test".to_string(),
@@ -141,7 +140,6 @@ Forward:    127.0.0.1:4000:40/tcp
         let console = &mut Console::new(&system);
         let env = Environment::new(
             UserName::from_str("cubic").unwrap(),
-            String::new(),
             String::new(),
             String::new(),
         );
@@ -217,7 +215,6 @@ SSH:          ssh -i {ssh_key} -p 8000 john@localhost
         let console = &mut Console::new(&system);
         let env = Environment::new(
             UserName::from_str("testuser").unwrap(),
-            String::new(),
             String::new(),
             String::new(),
         );

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -183,7 +183,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             "/data".to_string(),
             "/cache".to_string(),
-            "/run".to_string(),
         )
     }
 

--- a/src/commands/stop_command.rs
+++ b/src/commands/stop_command.rs
@@ -106,7 +106,6 @@ mod tests {
             UserName::from_str("myuser").unwrap(),
             String::new(),
             String::new(),
-            String::new(),
         );
         let context = commands::Context::new(
             Rc::new(SystemMock::new()),
@@ -132,7 +131,6 @@ mod tests {
         let console = &mut Console::new(&system);
         let env = Environment::new(
             UserName::from_str("myuser").unwrap(),
-            String::new(),
             String::new(),
             String::new(),
         );

--- a/src/env/environment_factory.rs
+++ b/src/env/environment_factory.rs
@@ -39,14 +39,11 @@ impl EnvironmentFactory {
             })?;
         let cache_dir = Self::read_env(system, "XDG_CACHE_HOME")
             .or_else(|_| Self::read_env(system, "HOME").map(|home| format!("{home}/.cache")))?;
-        let runtime_dir = Self::read_env(system, "XDG_RUNTIME_DIR")
-            .or_else(|_| Self::read_env(system, "UID").map(|uid| format!("/run/user/{uid}")))?;
 
         Ok(Environment::new(
             Self::get_username(system),
             format!("{data_dir}/cubic"),
             format!("{cache_dir}/cubic"),
-            format!("{runtime_dir}/cubic"),
         ))
     }
 
@@ -57,7 +54,6 @@ impl EnvironmentFactory {
         Ok(Environment::new(
             Self::get_username(system),
             format!("{home_dir}/Library/cubic"),
-            format!("{home_dir}/Library/Caches/cubic"),
             format!("{home_dir}/Library/Caches/cubic"),
         ))
     }
@@ -70,7 +66,6 @@ impl EnvironmentFactory {
         Ok(Environment::new(
             Self::get_username(system),
             format!("{local_app_data_dir}\\cubic"),
-            format!("{temp_dir}\\cubic"),
             format!("{temp_dir}\\cubic"),
         ))
     }
@@ -139,8 +134,7 @@ mod tests {
     fn test_create_env_falls_back_through_xdg_and_home() {
         let system = SystemMock::new()
             .add_env_var("USER", "alice")
-            .add_env_var("HOME", "/home/alice")
-            .add_env_var("XDG_RUNTIME_DIR", "/run/user/1000");
+            .add_env_var("HOME", "/home/alice");
 
         let env = EnvironmentFactory::create_env(&system).unwrap();
 
@@ -149,7 +143,6 @@ mod tests {
             "/home/alice/.local/share/cubic/machines"
         );
         assert_eq!(env.get_cache_dir(), "/home/alice/.cache/cubic");
-        assert_eq!(env.get_runtime_dir(), "/run/user/1000/cubic");
     }
 
     #[cfg(target_os = "linux")]
@@ -159,7 +152,6 @@ mod tests {
             .add_env_var("USER", "alice")
             .add_env_var("SNAP_USER_COMMON", "/snap/cubic/common")
             .add_env_var("XDG_CACHE_HOME", "/cache")
-            .add_env_var("XDG_RUNTIME_DIR", "/run/user/1000")
             .add_env_var("HOME", "/home/alice");
 
         let env = EnvironmentFactory::create_env(&system).unwrap();

--- a/src/image/image_store.rs
+++ b/src/image/image_store.rs
@@ -27,7 +27,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             String::new(),
             "/cache".to_string(),
-            String::new(),
         )
     }
 

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -18,7 +18,6 @@ impl InstanceDao {
     pub fn new(system: Rc<dyn System>, env: &Environment) -> Result<Self> {
         system.create_writable_dir(Path::new(&env.get_instance_dir()))?;
         system.create_writable_dir(Path::new(env.get_cache_dir()))?;
-        system.create_writable_dir(Path::new(env.get_runtime_dir()))?;
 
         Ok(InstanceDao {
             env: env.clone(),
@@ -134,15 +133,6 @@ impl InstanceStore for InstanceDao {
             Err(Error::InstanceNotStopped(instance.name.to_string()))
         } else {
             self.system
-                .remove_dir(Path::new(
-                    &self.env.get_instance_runtime_dir(&instance.name),
-                ))
-                .ok();
-            self.system
-                .remove_dir(Path::new(&self.env.get_instance_cache_dir(&instance.name)))
-                .ok();
-
-            self.system
                 .remove_dir(Path::new(&self.env.get_instance_dir2(&instance.name)))
                 .ok();
             Ok(())
@@ -196,7 +186,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             "/data".to_string(),
             "/cache".to_string(),
-            "/run".to_string(),
         )
     }
 

--- a/src/models/environment.rs
+++ b/src/models/environment.rs
@@ -7,21 +7,14 @@ pub struct Environment {
     username: UserName,
     data_dir: String,
     cache_dir: String,
-    runtime_dir: String,
 }
 
 impl Environment {
-    pub fn new(
-        username: UserName,
-        data_dir: String,
-        cache_dir: String,
-        runtime_dir: String,
-    ) -> Self {
+    pub fn new(username: UserName, data_dir: String, cache_dir: String) -> Self {
         Self {
             username,
             data_dir,
             cache_dir,
-            runtime_dir,
         }
     }
 
@@ -31,10 +24,6 @@ impl Environment {
 
     pub fn get_cache_dir(&self) -> &str {
         &self.cache_dir
-    }
-
-    pub fn get_runtime_dir(&self) -> &str {
-        &self.runtime_dir
     }
 
     pub fn get_instance_dir(&self) -> String {
@@ -86,31 +75,15 @@ impl Environment {
             .into_owned()
     }
 
-    pub fn get_instance_cache_dir(&self, instance: &str) -> String {
-        PathBuf::from(&self.cache_dir)
-            .join("instances")
-            .join(instance)
-            .to_string_lossy()
-            .into_owned()
-    }
-
-    pub fn get_user_data_image_file(&self, instance: &str) -> String {
-        PathBuf::from(self.get_instance_cache_dir(instance))
-            .join("user-data.img")
-            .to_string_lossy()
-            .into_owned()
-    }
-
-    pub fn get_instance_runtime_dir(&self, instance: &str) -> String {
-        PathBuf::from(&self.runtime_dir)
-            .join("instances")
-            .join(instance)
+    pub fn get_cloud_init_file(&self, instance: &str) -> String {
+        PathBuf::from(self.get_instance_dir2(instance))
+            .join("cloud-init.iso")
             .to_string_lossy()
             .into_owned()
     }
 
     pub fn get_qemu_pid_file(&self, instance: &str) -> String {
-        PathBuf::from(self.get_instance_runtime_dir(instance))
+        PathBuf::from(self.get_instance_dir2(instance))
             .join("qemu.pid")
             .to_string_lossy()
             .into_owned()
@@ -175,7 +148,6 @@ mod tests {
             UserName::from_str("testuser").unwrap(),
             "/data/cubic".to_string(),
             "/cache/cubic".to_string(),
-            "/runtime/cubic".to_string(),
         );
 
         assert_eq!(env.get_username().as_str(), "testuser");
@@ -184,7 +156,6 @@ mod tests {
             PathBuf::from(env.get_ssh_private_key_file("mymachine")),
             join_all("/data/cubic", &["machines", "mymachine", "ssh_client_key"])
         );
-        assert_eq!(env.get_runtime_dir(), "/runtime/cubic");
         assert_eq!(
             PathBuf::from(env.get_instance_dir()),
             PathBuf::from("/data/cubic").join("machines")
@@ -214,20 +185,12 @@ mod tests {
             join_all("/data/cubic", &["machines", "mymachine", "machine.img"])
         );
         assert_eq!(
-            PathBuf::from(env.get_instance_cache_dir("mymachine")),
-            join_all("/cache/cubic", &["instances", "mymachine"])
-        );
-        assert_eq!(
-            PathBuf::from(env.get_user_data_image_file("mymachine")),
-            join_all("/cache/cubic", &["instances", "mymachine", "user-data.img"])
-        );
-        assert_eq!(
-            PathBuf::from(env.get_instance_runtime_dir("mymachine")),
-            join_all("/runtime/cubic", &["instances", "mymachine"])
+            PathBuf::from(env.get_cloud_init_file("mymachine")),
+            join_all("/data/cubic", &["machines", "mymachine", "cloud-init.iso"])
         );
         assert_eq!(
             PathBuf::from(env.get_qemu_pid_file("mymachine")),
-            join_all("/runtime/cubic", &["instances", "mymachine", "qemu.pid"])
+            join_all("/data/cubic", &["machines", "mymachine", "qemu.pid"])
         );
     }
 }

--- a/src/qemu/qemu_img.rs
+++ b/src/qemu/qemu_img.rs
@@ -102,7 +102,6 @@ mod tests {
             UserName::from_str("cubic").unwrap(),
             "/data".to_string(),
             "/cache".to_string(),
-            "/run".to_string(),
         )
     }
 


### PR DESCRIPTION
## Summary

An instance used to be spread over three trees, so backup, delete and rename each had to visit all of them. The cloud init image and the pid file now sit next to the config, so copying or deleting an instance is one operation on one path.

The cloud init image moves from the cache directory to the instance directory and is renamed to `cloud-init.iso`. The qemu pid file moves from the runtime directory to the instance directory. Cubic no longer has a runtime directory at all, so it also starts where `XDG_RUNTIME_DIR` is unset. Prune now reclaims what older versions left behind in the cache directory.

Nothing needs to migrate, because both files are derived. An instance that runs across the upgrade keeps its pid file at the old path and reads as stopped.

## Related Issue(s)

First step of #534.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [x] Documentation
- [ ] Other

## Test Plan

- New unit tests in `prune_command.rs` cover deleting the image cache and the legacy cache instance directory, keeping the instance data directory, and reporting the freed size.
- Updated unit tests in `environment.rs` cover the new cloud init and pid file paths.
- `make test` passes.
- Started, stopped and deleted a machine to confirm the cloud init image and the pid file land in the instance directory.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed