### PR TITLE
feat: ask qemu which accelerator works on the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Cubic fits a lot of everyday workflows:
   - **Ubuntu**
 - Supports the following host OS: **Linux**, **macOS**, **Windows**
 - Supports **amd64** and **arm64** CPU architectures
-- Supports hardware acceleration with **KVM** (Linux) and **Hypervisor** (macOS), Windows runs on **TCG** software emulation for now
+- Supports hardware acceleration with **KVM** (Linux), **Hypervisor** (macOS), **WHPX** (Windows) and **NVMM** (BSD)
 - Daemonless design which does not require root privileges
 - Written in Rust
 

--- a/docs/internals/how_it_works.rst
+++ b/docs/internals/how_it_works.rst
@@ -54,19 +54,17 @@ QEMU and Hardware Acceleration
 
 `QEMU <https://www.qemu.org>`_ is an open-source machine emulator and
 virtualiser. Cubic translates the instance configuration into a QEMU command
-line and executes it directly. The accelerator is selected automatically based
-on the host platform:
+line and executes it directly. Every platform has one hardware accelerator:
 
 * **KVM** on Linux
 * **HVF** (Hypervisor Framework) on macOS
+* **WHPX** on Windows
 * **NVMM** on the BSDs
-* **TCG** (software emulation) as a fallback
 
-On Windows the **WHPX** accelerator is currently disabled and instances run on
-TCG software emulation. WHPX requires the ``host`` CPU model, while the CPU
-model Cubic passes is shared with the TCG path, and the mismatch makes the
-guest hang at the OVMF firmware screen. See `issue #500
-<https://github.com/cubic-vm/cubic/issues/500>`_.
+Cubic checks with QEMU that the accelerator works on the host and falls back to
+**TCG** software emulation when it does not. Use ``cubic start --accel on`` to
+insist on hardware acceleration and ``--accel off`` to run in software
+emulation.
 
 Each instance keeps everything it owns in one directory under
 ``~/.local/share/cubic/machines/<name>/``. That directory holds the

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -100,7 +100,7 @@ Features
 * Supports Alma Linux, Arch Linux, Debian, Fedora, Gentoo, OpenSUSE, Rocky Linux and Ubuntu guest images
 * Uses official, checksum-verified cloud images downloaded straight from each distribution
 * Supports Linux, macOS and Windows hosts with amd64 and arm64 architecture
-* Supports hardware acceleration with KVM (Linux) and Hypervisor (macOS), Windows runs on TCG software emulation for now
+* Supports hardware acceleration with KVM (Linux), Hypervisor (macOS), WHPX (Windows) and NVMM (BSD)
 * Boots each VM with EDK2 UEFI firmware, discovered automatically per architecture
 * No background privileged service and runs with standard user rights, no admin or root needed
 * Written in Rust

--- a/src/actions/load_instance_action.rs
+++ b/src/actions/load_instance_action.rs
@@ -1,6 +1,6 @@
 use crate::commands::{Context, DEFAULT_DISK_SIZE};
 use crate::error::{Error, Result};
-use crate::models::{DataSize, Instance, ResourceAllocator, get_default_arch};
+use crate::models::{Arch, DataSize, Instance, ResourceAllocator};
 use crate::qemu::QemuImg;
 use crate::view::Console;
 use std::str::FromStr;
@@ -41,7 +41,7 @@ impl LoadInstanceAction {
 
         let mut instance = Instance {
             name: name.to_string(),
-            arch: get_default_arch(),
+            arch: Arch::get_host(),
             user: context.get_env().get_username().clone(),
             cpus,
             mem,

--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -1,10 +1,12 @@
 use crate::cloudinit::CloudInitImageFactory;
-use crate::commands::Context;
+use crate::commands::{Accel, Context};
 use crate::error::{Error, Result};
 use crate::instance::InstanceCertGenerator;
-use crate::models::Instance;
+use crate::models::{Arch, Instance};
 use crate::platform::System;
-use crate::qemu::{QemuFirmware, QemuInstall, QemuPathBuilder, QemuSystem};
+use crate::qemu::{
+    QemuAcceleratorProbe, QemuFirmware, QemuInstall, QemuPathBuilder, QemuSystem, SOFTWARE_ACCEL,
+};
 use crate::ssh::PortChecker;
 use crate::view::Console;
 use std::path::PathBuf;
@@ -24,11 +26,15 @@ impl StartInstanceAction {
         &mut self,
         context: &Context,
         qemu_args: &Option<String>,
+        accel: Accel,
         console: &mut Console<'_>,
     ) -> Result<()> {
         if context.get_instance_store().is_running(&self.instance) {
             return Ok(());
         }
+
+        let host_arch = Arch::get_host();
+        self.check_accel_arch(accel, host_arch)?;
 
         let env = context.get_env();
         let system = context.get_system();
@@ -70,22 +76,54 @@ impl StartInstanceAction {
         console.debug(&format!("Using firmware '{}'", firmware.display()));
         qemu_system.set_firmware(&firmware);
 
-        if let Some(install) = &install {
-            match install.find_module_dir() {
-                Some(module_dir) => {
-                    console.debug(&format!("Using module dir '{}'", module_dir.display()));
-                    qemu_system.set_module_dir(&module_dir);
-                }
-                None => console.debug("No module dir found"),
+        let module_dir = install
+            .as_ref()
+            .and_then(|install| install.find_module_dir());
+        let datadir = install.as_ref().and_then(|install| install.find_datadir());
+        match &module_dir {
+            Some(module_dir) => {
+                console.debug(&format!("Using module dir '{}'", module_dir.display()));
+                qemu_system.set_module_dir(module_dir);
             }
-            match install.find_datadir() {
-                Some(datadir) => {
-                    console.debug(&format!("Using data dir '{}'", datadir.display()));
-                    qemu_system.add_datadir(&datadir);
-                }
-                None => console.debug("No data dir found"),
+            None => console.debug("No module dir found"),
+        }
+        match &datadir {
+            Some(datadir) => {
+                console.debug(&format!("Using data dir '{}'", datadir.display()));
+                qemu_system.add_datadir(datadir);
+            }
+            None => console.debug("No data dir found"),
+        }
+
+        let probe = QemuAcceleratorProbe::new(
+            system,
+            self.instance.arch,
+            &firmware,
+            module_dir.as_deref(),
+            datadir.as_deref(),
+        );
+        let accelerator = self.select_accelerator(
+            accel,
+            QemuAcceleratorProbe::get_host_accelerator(),
+            host_arch,
+            &probe,
+            console,
+        );
+        console.debug(&format!(
+            "Using accelerator '{}' with CPU model '{}'",
+            accelerator,
+            QemuSystem::get_cpu(accelerator)
+        ));
+        // The hints only help when the arch matches and the host still says no.
+        if accel == Accel::Auto && accelerator == SOFTWARE_ACCEL && self.instance.arch == host_arch
+        {
+            // One call per line, so every line carries the warn label.
+            console.warn("No hardware acceleration detected on this host.");
+            for hint in QemuAcceleratorProbe::get_enable_hints(system) {
+                console.warn(hint);
             }
         }
+        qemu_system.set_accelerator(accelerator);
 
         qemu_system.set_cpus(self.instance.cpus);
         qemu_system.set_memory(self.instance.mem.get_bytes() as u64);
@@ -111,7 +149,151 @@ impl StartInstanceAction {
             .map_err(QemuSystem::map_error)
     }
 
+    // An accelerator runs guest code on the host CPU, so it needs both archs to
+    // be the same. Say so before the start does any work.
+    fn check_accel_arch(&self, accel: Accel, host_arch: Arch) -> Result<()> {
+        if accel == Accel::On && self.instance.arch != host_arch {
+            return Err(Error::ArchMismatch(
+                self.instance.name.clone(),
+                self.instance.arch,
+                host_arch,
+            ));
+        }
+        Ok(())
+    }
+
+    // `on` and `off` overrule the probe and go straight to QEMU. A guest arch
+    // that differs from the host arch rules out every hardware accelerator, so
+    // it needs no probe.
+    fn select_accelerator(
+        &self,
+        accel: Accel,
+        host_accel: &'static str,
+        host_arch: Arch,
+        probe: &QemuAcceleratorProbe,
+        console: &mut Console<'_>,
+    ) -> &'static str {
+        match accel {
+            Accel::Off => SOFTWARE_ACCEL,
+            Accel::On => host_accel,
+            Accel::Auto if self.instance.arch != host_arch => {
+                console.debug(&format!(
+                    "No hardware acceleration: guest arch {} differs from host arch {host_arch}",
+                    self.instance.arch
+                ));
+                SOFTWARE_ACCEL
+            }
+            Accel::Auto => match probe.detect(host_accel) {
+                Ok(()) => host_accel,
+                Err(reason) => {
+                    console.debug(&format!("No hardware acceleration: {reason}"));
+                    SOFTWARE_ACCEL
+                }
+            },
+        }
+    }
+
     pub fn is_done(&self, system: &dyn System) -> bool {
         PortChecker::new().is_open(system, self.instance.ssh_port)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::SystemMock;
+    use std::path::Path;
+
+    fn build_action(guest_arch: Arch) -> StartInstanceAction {
+        StartInstanceAction::new(&Instance {
+            name: "test".to_string(),
+            arch: guest_arch,
+            ..Instance::default()
+        })
+    }
+
+    fn select_for(
+        system: &SystemMock,
+        accel: Accel,
+        guest_arch: Arch,
+        host_arch: Arch,
+    ) -> &'static str {
+        let mut console = Console::new(system);
+        let probe = QemuAcceleratorProbe::new(
+            system,
+            guest_arch,
+            Path::new("/usr/share/qemu/OVMF.fd"),
+            None,
+            None,
+        );
+        build_action(guest_arch).select_accelerator(accel, "kvm", host_arch, &probe, &mut console)
+    }
+
+    fn select(system: &SystemMock, accel: Accel) -> &'static str {
+        select_for(system, accel, Arch::AMD64, Arch::AMD64)
+    }
+
+    #[test]
+    fn test_accel_off_runs_on_tcg_without_asking_qemu() {
+        let system = SystemMock::new();
+
+        assert_eq!(select(&system, Accel::Off), "tcg");
+        assert!(system.get_executed_commands().is_empty());
+    }
+
+    #[test]
+    fn test_accel_on_takes_the_accelerator_without_asking_qemu() {
+        let system = SystemMock::new();
+
+        assert_eq!(select(&system, Accel::On), "kvm");
+        assert!(system.get_executed_commands().is_empty());
+    }
+
+    #[test]
+    fn test_accel_auto_asks_qemu() {
+        let system = SystemMock::new();
+
+        let accelerator = select(&system, Accel::Auto);
+
+        assert_eq!(accelerator, "tcg");
+        assert_eq!(system.get_executed_commands().len(), 1);
+    }
+
+    #[test]
+    fn test_accel_on_fails_when_the_guest_arch_differs_from_the_host() {
+        let result = build_action(Arch::ARM64).check_accel_arch(Accel::On, Arch::AMD64);
+
+        assert!(matches!(
+            result,
+            Err(Error::ArchMismatch(ref name, Arch::ARM64, Arch::AMD64)) if name == "test"
+        ));
+    }
+
+    #[test]
+    fn test_accel_on_passes_the_check_on_the_host_arch() {
+        assert!(
+            build_action(Arch::AMD64)
+                .check_accel_arch(Accel::On, Arch::AMD64)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_accel_auto_passes_the_check_on_a_foreign_arch() {
+        assert!(
+            build_action(Arch::ARM64)
+                .check_accel_arch(Accel::Auto, Arch::AMD64)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_accel_auto_skips_the_probe_on_a_foreign_arch() {
+        let system = SystemMock::new();
+
+        let accelerator = select_for(&system, Accel::Auto, Arch::ARM64, Arch::AMD64);
+
+        assert_eq!(accelerator, "tcg");
+        assert!(system.get_executed_commands().is_empty());
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,3 +1,4 @@
+mod accel_arg;
 mod all_images_arg;
 mod all_info_arg;
 mod all_instances_arg;
@@ -30,6 +31,7 @@ mod stop_command;
 mod verbosity;
 mod yes_arg;
 
+pub use accel_arg::*;
 pub use all_images_arg::*;
 pub use all_info_arg::*;
 pub use all_instances_arg::*;

--- a/src/commands/accel_arg.rs
+++ b/src/commands/accel_arg.rs
@@ -1,0 +1,19 @@
+use clap::{Parser, ValueEnum};
+
+// Names the kind of acceleration, not the accelerator, since every platform
+// has exactly one hardware accelerator.
+#[derive(Clone, Copy, Debug, Default, PartialEq, ValueEnum)]
+pub enum Accel {
+    #[default]
+    Auto,
+    On,
+    Off,
+}
+
+#[derive(Clone, Copy, Default, Parser)]
+#[clap(verbatim_doc_comment)]
+pub struct AccelArg {
+    /// Set hardware acceleration
+    #[clap(id = "accel", long = "accel", value_enum, default_value_t)]
+    pub value: Accel,
+}

--- a/src/commands/console_command.rs
+++ b/src/commands/console_command.rs
@@ -31,6 +31,8 @@ const PROBE_IO_TIMEOUT: Duration = Duration::from_secs(1);
 #[clap(verbatim_doc_comment)]
 pub struct ConsoleCommand {
     #[clap(flatten)]
+    pub accel: commands::AccelArg,
+    #[clap(flatten)]
     instance: commands::InstanceArg,
 }
 
@@ -38,6 +40,7 @@ impl Command for ConsoleCommand {
     fn run(&self, console: &mut Console<'_>, context: &commands::Context) -> Result<()> {
         commands::StartCommand {
             qemu_args: None,
+            accel: self.accel,
             wait: false,
             yes: commands::YesArg { value: false },
             instances: self.instance.value.clone().into(),

--- a/src/commands/exec_command.rs
+++ b/src/commands/exec_command.rs
@@ -21,6 +21,8 @@ pub struct ExecCommand {
     /// Command to execute in the virtual machine instance
     pub cmd: String,
     #[clap(flatten)]
+    pub accel: commands::AccelArg,
+    #[clap(flatten)]
     pub env_args: commands::EnvArgs,
 }
 
@@ -31,6 +33,7 @@ impl Command for ExecCommand {
 
         commands::StartCommand {
             qemu_args: None,
+            accel: self.accel,
             wait: true,
             yes: commands::YesArg { value: false },
             instances: name.clone().into(),

--- a/src/commands/list_image_command.rs
+++ b/src/commands/list_image_command.rs
@@ -1,7 +1,7 @@
 use crate::commands::{AllImagesArg, Command, Context, fetch_image_list};
 use crate::error::Result;
 use crate::image::ImageStore;
-use crate::models::{DataSize, get_default_arch};
+use crate::models::{Arch, DataSize};
 use crate::view::{Alignment, Console, TableView};
 use clap::Parser;
 
@@ -50,7 +50,7 @@ impl Command for ListImageCommand {
             .add("Cached", Alignment::Right);
 
         for image in images {
-            if !self.all.value && image.arch != get_default_arch() {
+            if !self.all.value && image.arch != Arch::get_host() {
                 continue;
             }
 

--- a/src/commands/restart_command.rs
+++ b/src/commands/restart_command.rs
@@ -17,6 +17,8 @@ use clap::Parser;
 #[clap(verbatim_doc_comment)]
 pub struct RestartCommand {
     #[clap(flatten)]
+    pub accel: commands::AccelArg,
+    #[clap(flatten)]
     instances: commands::InstancesArg,
 }
 
@@ -31,6 +33,7 @@ impl Command for RestartCommand {
         .run(console, context)?;
         commands::StartCommand {
             qemu_args: None,
+            accel: self.accel,
             wait: true,
             yes: commands::YesArg { value: false },
             instances: self.instances.value.clone().into(),

--- a/src/commands/run_command.rs
+++ b/src/commands/run_command.rs
@@ -34,6 +34,8 @@ pub struct RunCommand {
     #[clap(flatten)]
     create_cmd: commands::CreateCommand,
     #[clap(flatten)]
+    accel: commands::AccelArg,
+    #[clap(flatten)]
     env_args: commands::EnvArgs,
 }
 
@@ -42,6 +44,7 @@ impl Command for RunCommand {
         self.create_cmd.run(console, context)?;
         commands::SshCommand {
             target: Target::from_instance_name(self.create_cmd.instance_name.value.clone()),
+            accel: self.accel,
             env_args: self.env_args.clone(),
         }
         .run(console, context)

--- a/src/commands/ssh_command.rs
+++ b/src/commands/ssh_command.rs
@@ -20,6 +20,8 @@ pub struct SshCommand {
     /// Target instance (format: [username@]instance, e.g. 'myinstance' or 'cubic@myinstance')
     pub target: Target,
     #[clap(flatten)]
+    pub accel: commands::AccelArg,
+    #[clap(flatten)]
     pub env_args: commands::EnvArgs,
 }
 
@@ -31,6 +33,7 @@ impl Command for SshCommand {
 
         commands::StartCommand {
             qemu_args: None,
+            accel: self.accel,
             wait: true,
             yes: commands::YesArg { value: false },
             instances: name.clone().into(),

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -34,6 +34,8 @@ pub struct StartCommand {
     /// Pass additional QEMU arguments
     #[clap(long)]
     pub qemu_args: Option<String>,
+    #[clap(flatten)]
+    pub accel: commands::AccelArg,
     /// Wait until the VM instance has started
     #[clap(short, long, default_value_t = false)]
     pub wait: bool,
@@ -75,7 +77,7 @@ impl Command for StartCommand {
                 )?;
 
                 let mut action = StartInstanceAction::new(instance);
-                action.run(context, &self.qemu_args, console)?;
+                action.run(context, &self.qemu_args, self.accel.value, console)?;
 
                 actions.push(action);
                 // Only the instances that are launched are named

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::models::Arch;
 use std::io;
 use thiserror::Error;
 
@@ -9,6 +10,11 @@ pub enum Error {
         "CPU arch '{0}' is not supported.\n\nChoose a supported architecture: 'amd64' or 'arm64'"
     )]
     UnknownArch(String),
+
+    #[error(
+        "Hardware acceleration needs a guest arch equal to the host arch.\n\nInstance '{0}' is {1} and this host is {2}.\n\nRun it with `--accel off` to use software emulation."
+    )]
+    ArchMismatch(String, Arch, Arch),
 
     #[error(
         "Instance '{0}' does not exist.\n\nOptions:\n  - Use an existing instance name\n  - Create it first: `cubic create {0} [...]`"

--- a/src/models/arch.rs
+++ b/src/models/arch.rs
@@ -11,6 +11,18 @@ pub enum Arch {
 }
 
 impl Arch {
+    // The arch cubic itself was built for, which is the arch a guest must have
+    // to run with hardware acceleration.
+    #[cfg(target_arch = "aarch64")]
+    pub fn get_host() -> Arch {
+        Arch::ARM64
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    pub fn get_host() -> Arch {
+        Arch::AMD64
+    }
+
     pub fn as_vendor_str(&self) -> &str {
         match self {
             Arch::AMD64 => "amd64",

--- a/src/models/image_name.rs
+++ b/src/models/image_name.rs
@@ -7,16 +7,6 @@ use std::sync::LazyLock;
 static IMAGE_NAME_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new("^(\\w+):([\\w\\.]+)(:(amd64|arm64))?$").unwrap());
 
-#[cfg(target_arch = "aarch64")]
-pub fn get_default_arch() -> Arch {
-    Arch::ARM64
-}
-
-#[cfg(not(target_arch = "aarch64"))]
-pub fn get_default_arch() -> Arch {
-    Arch::AMD64
-}
-
 #[derive(Clone, Debug)]
 pub struct ImageName {
     vendor: String,
@@ -49,7 +39,7 @@ impl FromStr for ImageName {
             let arch = tokens
                 .next()
                 .map(|x| Arch::from_str(x).unwrap())
-                .unwrap_or(get_default_arch());
+                .unwrap_or(Arch::get_host());
 
             Ok(Self { vendor, name, arch })
         } else {

--- a/src/platform/os_process.rs
+++ b/src/platform/os_process.rs
@@ -1,9 +1,12 @@
 use crate::error::{Error, Result};
 use crate::platform::{OsSystem, Process};
 use crate::util::SystemCommand;
-use std::io::{ErrorKind, Read};
+use std::io::{BufRead, BufReader, ErrorKind, Read};
 use std::process::{Command, Stdio};
 use std::str::from_utf8;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 impl OsSystem {
     // Refreshes a single process so a lookup sees the current state of the
@@ -67,6 +70,63 @@ impl Process for OsSystem {
                     ))
                 }
             })
+    }
+
+    // Reads rather than polls, so the command is only kept alive until it says
+    // it is up. Stdin stays open, or a command that reads it sees an early end
+    // of file and stops on its own.
+    fn run_command_until_output(
+        &self,
+        command: &SystemCommand,
+        marker: &str,
+        timeout: Duration,
+    ) -> Result<()> {
+        let mut child = Self::build_process(command)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| Self::map_spawn_error(command, e))?;
+
+        let (Some(stdout), Some(stderr)) = (child.stdout.take(), child.stderr.take()) else {
+            let _ = child.kill();
+            return Err(Error::SystemCommandFailed(
+                command.get_command(),
+                "The command offered no output to read.".to_string(),
+            ));
+        };
+
+        // Both pipes are drained on their own thread. A pipe that nobody reads
+        // fills up and stops the command it belongs to.
+        let (sender, receiver) = mpsc::channel();
+        let needle = marker.to_string();
+        thread::spawn(move || {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Some(Ok(line)) = lines.next() {
+                if line.contains(&needle) {
+                    return sender.send(()).unwrap_or_default();
+                }
+            }
+        });
+        let collector = thread::spawn(move || {
+            let mut text = String::new();
+            BufReader::new(stderr).read_to_string(&mut text).ok();
+            text
+        });
+
+        // The sender is dropped as soon as stdout ends, so a command that stops
+        // early is seen without waiting for the deadline.
+        let found = receiver.recv_timeout(timeout).is_ok();
+        let _ = child.kill();
+        let _ = child.wait();
+
+        if found {
+            return Ok(());
+        }
+        Err(Error::SystemCommandFailed(
+            command.get_command(),
+            collector.join().unwrap_or_default(),
+        ))
     }
 
     fn spawn_command(&self, command: &SystemCommand) -> Result<()> {

--- a/src/platform/process.rs
+++ b/src/platform/process.rs
@@ -1,8 +1,19 @@
 use crate::error::Result;
 use crate::util::SystemCommand;
+use std::time::Duration;
 
 pub trait Process {
     fn run_command(&self, command: &SystemCommand) -> Result<Vec<u8>>;
+    // Runs a command that is not expected to end by itself and waits for a
+    // marker on its stdout. The marker means the command came up, so it is
+    // killed right away. A command that ends first, or one that never prints
+    // the marker before the deadline, reports a failure carrying its stderr.
+    fn run_command_until_output(
+        &self,
+        command: &SystemCommand,
+        marker: &str,
+        timeout: Duration,
+    ) -> Result<()>;
     fn spawn_command(&self, command: &SystemCommand) -> Result<()>;
 
     fn exists_process(&self, pid: u64) -> bool;

--- a/src/platform/process_mock.rs
+++ b/src/platform/process_mock.rs
@@ -2,6 +2,7 @@ use crate::error::{Error, Result};
 use crate::platform::{Process, SystemMock};
 use crate::util::SystemCommand;
 use std::collections::HashMap;
+use std::time::Duration;
 
 // How a seeded pid answers a kill. Every state is visible to a liveness
 // check, they differ only in what killing one does.
@@ -142,6 +143,17 @@ impl SystemMock {
 impl Process for SystemMock {
     fn run_command(&self, command: &SystemCommand) -> Result<Vec<u8>> {
         self.commands.borrow_mut().run(command)
+    }
+
+    // A seeded command stands for one that comes up and prints the marker, so
+    // neither the marker nor the deadline matters here.
+    fn run_command_until_output(
+        &self,
+        command: &SystemCommand,
+        _marker: &str,
+        _timeout: Duration,
+    ) -> Result<()> {
+        self.commands.borrow_mut().run(command).map(|_| ())
     }
 
     // A detached start has nothing to wait for, so it only reports whether the

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -1,3 +1,4 @@
+mod qemu_accelerator;
 mod qemu_firmware;
 mod qemu_firmware_descriptor;
 mod qemu_img;
@@ -7,6 +8,7 @@ mod qemu_system;
 mod qmp_message;
 mod tls_client;
 
+pub use qemu_accelerator::QemuAcceleratorProbe;
 pub use qemu_firmware::{QemuFirmware, QemuInstall};
 pub use qemu_img::*;
 pub use qemu_monitor_client::*;

--- a/src/qemu/qemu_accelerator.rs
+++ b/src/qemu/qemu_accelerator.rs
@@ -1,0 +1,246 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+use crate::models::Arch;
+use crate::platform::System;
+use crate::qemu::{QemuSystem, SOFTWARE_ACCEL};
+use crate::util::SystemCommand;
+
+// Only reached by a QEMU that hangs, since one that cannot use an accelerator
+// says so within milliseconds and one that can is up just as fast.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+// QEMU greets a QMP client once the machine stands, which is after the
+// accelerator is initialised and the firmware is loaded.
+const QMP_GREETING: &str = "\"QMP\"";
+
+// Asks QEMU whether an accelerator works on this host, by starting it as the
+// instance would and killing it once it is up.
+pub struct QemuAcceleratorProbe<'a> {
+    system: &'a dyn System,
+    arch: Arch,
+    firmware: PathBuf,
+    module_dir: Option<PathBuf>,
+    datadir: Option<PathBuf>,
+}
+
+impl<'a> QemuAcceleratorProbe<'a> {
+    // Takes the firmware, module dir and data dir of the instance, or the probe
+    // answers for a machine the real start never builds.
+    pub fn new(
+        system: &'a dyn System,
+        arch: Arch,
+        firmware: &Path,
+        module_dir: Option<&Path>,
+        datadir: Option<&Path>,
+    ) -> Self {
+        Self {
+            system,
+            arch,
+            firmware: firmware.to_path_buf(),
+            module_dir: module_dir.map(Path::to_path_buf),
+            datadir: datadir.map(Path::to_path_buf),
+        }
+    }
+
+    pub fn get_host_accelerator() -> &'static str {
+        if cfg!(any(target_os = "linux", target_os = "android")) {
+            "kvm"
+        } else if cfg!(any(target_os = "macos", target_os = "ios")) {
+            "hvf"
+        } else if cfg!(target_os = "windows") {
+            "whpx"
+        } else if cfg!(any(
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        )) {
+            "nvmm"
+        } else {
+            SOFTWARE_ACCEL
+        }
+    }
+
+    // What the user can turn on to get hardware acceleration on this host. A
+    // snap reaches /dev/kvm through an interface that is not connected on
+    // install, which hides the device whatever the user belongs to.
+    pub fn get_enable_hints(system: &dyn System) -> Vec<&'static str> {
+        let mut hints = Vec::new();
+        if system.read_env_var("SNAP").is_some() {
+            hints.push("Connect the kvm interface with sudo snap connect cubic:kvm.");
+        }
+        hints.push(Self::get_platform_hint());
+        hints
+    }
+
+    fn get_platform_hint() -> &'static str {
+        if cfg!(any(target_os = "macos", target_os = "ios")) {
+            "Install QEMU from Homebrew to get the hypervisor entitlement."
+        } else if cfg!(target_os = "windows") {
+            "Enable virtualization in UEFI/BIOS and the Windows Hypervisor Platform."
+        } else if cfg!(any(
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        )) {
+            "Enable virtualization in UEFI/BIOS and load the nvmm module."
+        } else {
+            "Enable virtualization in UEFI/BIOS and add your user to the kvm group."
+        }
+    }
+
+    // Reports what QEMU said, not the generic wrapper around a failed command.
+    pub fn detect(&self, accel: &str) -> std::result::Result<(), String> {
+        let command = self
+            .build_command(accel)
+            .map_err(|error| error.to_string())?;
+        self.system
+            .run_command_until_output(&command, QMP_GREETING, PROBE_TIMEOUT)
+            .map_err(|error| match error {
+                Error::SystemCommandFailed(_, stderr) if stderr.trim().is_empty() => {
+                    "QEMU did not come up".to_string()
+                }
+                Error::SystemCommandFailed(_, stderr) => stderr.trim().to_string(),
+                other => other.to_string(),
+            })
+    }
+
+    // The machine of the probe is the machine of the start, firmware included,
+    // or the answer belongs to a different machine than the one that follows.
+    fn build_command(&self, accel: &str) -> Result<SystemCommand> {
+        let mut qemu = QemuSystem::from(self.system, self.arch)?;
+        qemu.set_firmware(&self.firmware);
+        if let Some(module_dir) = &self.module_dir {
+            qemu.set_module_dir(module_dir);
+        }
+        if let Some(datadir) = &self.datadir {
+            qemu.add_datadir(datadir);
+        }
+        qemu.set_accelerator(accel);
+
+        let mut command = qemu.build_command();
+        command.arg("-qmp").arg("stdio");
+        Ok(command)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::SystemMock;
+
+    const FIRMWARE: &str = "/usr/share/qemu/OVMF.fd";
+
+    fn build_probe(system: &SystemMock, arch: Arch) -> QemuAcceleratorProbe<'_> {
+        QemuAcceleratorProbe::new(system, arch, Path::new(FIRMWARE), None, None)
+    }
+
+    // The probe carries the whole machine, cpu model and firmware included, so
+    // the expected command comes from the builder rather than from a copy of it
+    // that can drift.
+    fn build_probe_command(arch: Arch, accel: &str) -> String {
+        let system = SystemMock::new();
+        build_probe(&system, arch)
+            .build_command(accel)
+            .unwrap()
+            .get_command()
+    }
+
+    #[test]
+    fn test_get_enable_hints_asks_a_snap_to_connect_the_interface_first() {
+        let system = SystemMock::new().add_env_var("SNAP", "/snap/cubic/current");
+
+        let hints = QemuAcceleratorProbe::get_enable_hints(&system);
+
+        assert_eq!(hints.len(), 2);
+        assert!(hints[0].contains("snap connect cubic:kvm"));
+    }
+
+    #[test]
+    fn test_get_enable_hints_names_the_platform_alone_off_snap() {
+        let hints = QemuAcceleratorProbe::get_enable_hints(&SystemMock::new());
+
+        assert_eq!(hints.len(), 1);
+        assert!(!hints[0].contains("snap"));
+    }
+
+    #[test]
+    fn test_detect_accepts_an_accelerator_that_comes_up() {
+        let system =
+            SystemMock::new().add_command_output(&build_probe_command(Arch::AMD64, "kvm"), b"");
+
+        assert!(build_probe(&system, Arch::AMD64).detect("kvm").is_ok());
+    }
+
+    #[test]
+    fn test_detect_reports_what_qemu_said() {
+        let system = SystemMock::new()
+            .add_failing_command(&build_probe_command(Arch::AMD64, "kvm"), "no kvm");
+
+        assert_eq!(
+            build_probe(&system, Arch::AMD64).detect("kvm"),
+            Err("no kvm".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_names_a_qemu_that_says_nothing() {
+        let system =
+            SystemMock::new().add_failing_command(&build_probe_command(Arch::AMD64, "kvm"), "  ");
+
+        assert_eq!(
+            build_probe(&system, Arch::AMD64).detect("kvm"),
+            Err("QEMU did not come up".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_probes_the_binary_of_the_arch() {
+        let system = SystemMock::new();
+
+        build_probe(&system, Arch::ARM64).detect("kvm").ok();
+
+        assert!(system.get_executed_commands()[0].starts_with("qemu-system-aarch64 -machine virt"));
+    }
+
+    #[test]
+    fn test_detect_probes_with_the_firmware_of_the_start() {
+        let system = SystemMock::new();
+
+        build_probe(&system, Arch::AMD64).detect("kvm").ok();
+
+        assert!(
+            system.get_executed_commands()[0]
+                .contains(&format!("-drive if=pflash,readonly=on,file={FIRMWARE}"))
+        );
+    }
+
+    #[test]
+    fn test_detect_asks_qemu_to_report_that_the_machine_is_up() {
+        let system = SystemMock::new();
+
+        build_probe(&system, Arch::AMD64).detect("kvm").ok();
+
+        assert!(system.get_executed_commands()[0].ends_with("-qmp stdio"));
+    }
+
+    #[test]
+    fn test_detect_probes_with_the_data_dir_of_the_install() {
+        let system = SystemMock::new();
+
+        QemuAcceleratorProbe::new(
+            &system,
+            Arch::AMD64,
+            Path::new(FIRMWARE),
+            Some(Path::new("/usr/lib/qemu")),
+            Some(Path::new("/usr/share/qemu")),
+        )
+        .detect("kvm")
+        .ok();
+
+        assert!(system.get_executed_commands()[0].contains("-L /usr/share/qemu"));
+    }
+}

--- a/src/qemu/qemu_system.rs
+++ b/src/qemu/qemu_system.rs
@@ -7,58 +7,30 @@ use crate::qemu::QemuPathBuilder;
 use crate::util::SystemCommand;
 
 pub const NETDEV_ID: &str = "net0";
+pub const SOFTWARE_ACCEL: &str = "tcg";
 
 pub struct QemuSystem {
     command: SystemCommand,
 }
 
 impl QemuSystem {
-    fn get_accelerator() -> Option<&'static str> {
-        if cfg!(any(target_os = "linux", target_os = "android")) {
-            Some("kvm")
-        } else if cfg!(any(
-            target_os = "freebsd",
-            target_os = "dragonfly",
-            target_os = "openbsd",
-            target_os = "netbsd"
-        )) {
-            Some("nvmm")
-        } else if cfg!(any(target_os = "macos", target_os = "ios")) {
-            Some("hvf")
-        } else {
-            // WHPX is disabled on Windows because it needs `-cpu host` while
-            // the shared `-cpu max` makes the guest hang at OVMF, see #500
-            None
+    pub fn get_machine(arch: Arch) -> &'static str {
+        match arch {
+            Arch::AMD64 => "q35",
+            Arch::ARM64 => "virt",
         }
     }
 
     pub fn from(system: &dyn System, arch: Arch) -> Result<QemuSystem> {
         let binary = format!("qemu-system-{}", arch.as_canonical_str());
-        let mut command = match arch {
-            Arch::AMD64 => {
-                let mut command = SystemCommand::new(&binary);
-                command.arg("-machine").arg("q35");
-                command.arg("-smbios").arg("type=0,uefi=on");
-                command
-            }
-            Arch::ARM64 => {
-                let mut command = SystemCommand::new(&binary);
-                command.arg("-machine").arg("virt");
-                command
-            }
-        };
+        let mut command = SystemCommand::new(&binary);
+        command.arg("-machine").arg(Self::get_machine(arch));
+        if arch == Arch::AMD64 {
+            command.arg("-smbios").arg("type=0,uefi=on");
+        }
 
         // Resolve the QEMU binary by name from the extended PATH.
         command.set_env("PATH", QemuPathBuilder::new(system).build());
-
-        // Set CPU type
-        command.arg("-cpu").arg("max");
-
-        // Enable accelerators
-        if let Some(accel) = Self::get_accelerator() {
-            command.arg("-accel").arg(accel);
-        }
-        command.arg("-accel").arg("tcg");
 
         // Only boot disk
         command.arg("-boot").arg("c");
@@ -78,6 +50,28 @@ impl QemuSystem {
         command.arg("-device").arg("virtio-balloon-pci");
 
         Ok(QemuSystem { command })
+    }
+
+    // The CPU model follows from the accelerator. Windows takes named models
+    // only, and a model richer than qemu64 faults the firmware, see #500.
+    pub fn get_cpu(accel: &str) -> &'static str {
+        if accel == SOFTWARE_ACCEL {
+            "max"
+        } else if cfg!(target_os = "windows") {
+            "qemu64"
+        } else {
+            "host"
+        }
+    }
+
+    // One accelerator only. QEMU takes the first of several that comes up,
+    // which hides an accelerator that starts and then fails.
+    pub fn set_accelerator(&mut self, accel: &str) {
+        self.command
+            .arg("-cpu")
+            .arg(Self::get_cpu(accel))
+            .arg("-accel")
+            .arg(accel);
     }
 
     pub fn set_cpus(&mut self, cpus: u16) {
@@ -236,6 +230,25 @@ mod tests {
             .build_command();
 
         assert!(command.get_command().starts_with("qemu-system-x86_64"));
+    }
+
+    #[test]
+    fn test_get_cpu_follows_the_accelerator() {
+        assert_eq!(QemuSystem::get_cpu(SOFTWARE_ACCEL), "max");
+        // Hardware acceleration never takes `max`, which hangs the firmware.
+        assert_ne!(QemuSystem::get_cpu("kvm"), "max");
+    }
+
+    #[test]
+    fn test_set_accelerator_names_one_accelerator_and_one_cpu_model() {
+        let mut qemu = QemuSystem::from(&SystemMock::new(), Arch::AMD64).unwrap();
+        qemu.set_accelerator(SOFTWARE_ACCEL);
+
+        let command = qemu.command.get_command();
+
+        assert!(command.contains("-cpu max -accel tcg"));
+        assert_eq!(command.matches("-accel").count(), 1);
+        assert_eq!(command.matches("-cpu").count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Cubic guessed the accelerator from the host platform and paired every one with `-cpu max`. WHPX takes named CPU models only, so Windows was left on TCG software emulation.

Cubic now asks QEMU. It starts QEMU the way the instance would, kills it once it is up, and keeps that accelerator. Otherwise the instance falls back to TCG with a warning that names the host and says what to switch on. The CPU model comes with the accelerator, `host` on KVM and HVF, `qemu64` on Windows, `max` on TCG.

The new `--accel auto|on|off` flag overrules the probe. It is on every command that starts an instance.

## Related Issue(s)

Closes #510

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Unit tests cover the probe against `SystemMock`, the CPU pairing, and that `on` and `off` skip the probe while `auto` runs one.

Checked by hand on Linux: `auto` picks `kvm` with `-cpu host` and the guest boots, `--accel off` boots on `tcg` with `-cpu max`, and a QEMU that rejects `kvm` falls back in 0.18s with the warning.

A successful probe waits the full 3s deadline, because only the kill ends a working accelerator.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed