### PR TITLE
feat: remember the ssh host key of each instance

### DIFF
--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -109,11 +109,15 @@ of the guest, and that prompt accepts only a password, so it stays closed until
 you set one from an SSH session. Set a password while SSH works if you want the
 console available as a way in later. See :ref:`console login` for the steps.
 
-One area that can still be improved is host key verification. Today the host key
-that the guest presents is accepted as it is, which is reasonable while
-connections only ever go to ``127.0.0.1``. Remembering each machine's host key on
-the first connection would let Cubic notice if it ever reached the wrong
-endpoint.
+Cubic also remembers the host key of each guest. The first connection stores the
+key the guest presents in the machine's ``instance.toml`` file, and every later
+connection compares against it, the same idea as a known hosts file kept per
+machine.
+
+A key that does not match stops the connection. Cubic shows both fingerprints,
+points out that this may be a malicious attempt to take over the connection, and
+asks whether to trust the new key. Answering yes stores it, which is how you
+carry on after you recreated the guest yourself.
 
 Encrypted QEMU Control Channels
 -------------------------------

--- a/src/actions/stop_instance_action.rs
+++ b/src/actions/stop_instance_action.rs
@@ -67,7 +67,7 @@ mod tests {
             .run(&store, true)
             .unwrap();
 
-        assert_eq!(store.get_killed(), ["test"]);
+        assert_eq!(*store.killed.lock().unwrap(), ["test"]);
     }
 
     #[test]
@@ -79,7 +79,7 @@ mod tests {
             .run(&store, true)
             .unwrap();
 
-        assert!(store.get_killed().is_empty());
+        assert!(store.killed.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -92,7 +92,7 @@ mod tests {
         let result = StopInstanceAction::new(&instance).run(&store, false);
 
         assert!(result.is_err());
-        assert!(store.get_killed().is_empty());
+        assert!(store.killed.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -53,6 +53,9 @@ impl Command for CloneCommand {
         let mut target = source.clone();
         target.name = self.new_name.to_string();
         target.ssh_port = context.get_system().bind_port()?;
+        // The clone gets its own cloud-init seed, so the guest generates new
+        // host keys on the first boot.
+        target.ssh_host_key = None;
 
         // Create VM instance
         CreateInstanceAction::new().run(context, image_path, target)?;
@@ -70,6 +73,7 @@ mod tests {
     use crate::models::Instance;
     use crate::models::UserName;
     use crate::platform::SystemMock;
+    use std::path::PathBuf;
     use std::rc::Rc;
     use std::str::FromStr;
 
@@ -144,6 +148,56 @@ mod tests {
             result,
             Err(Error::InstanceNotStopped(ref name)) if name == "test"
         ));
+    }
+
+    #[test]
+    fn test_clone_drops_the_host_key_of_the_source() {
+        let source_image = PathBuf::from("machines")
+            .join("test")
+            .join("machine.img")
+            .to_string_lossy()
+            .into_owned();
+        // The action builds the temporary image path itself, so the expected
+        // command has to be spelled the same way.
+        let target_dir = PathBuf::from("machines")
+            .join("test2")
+            .to_string_lossy()
+            .into_owned();
+        let target_image = format!("{target_dir}.tmp/machine.img");
+        let system = SystemMock::new()
+            .add_command_output(
+                &format!("qemu-img convert -f qcow2 -O qcow2 {source_image} {target_image}"),
+                b"",
+            )
+            .add_command_output(&format!("qemu-img resize {target_image} 0"), b"");
+        let console_system = SystemMock::new();
+        let console = &mut Console::new(&console_system);
+        let store = InstanceStoreMock::new(vec![Instance {
+            name: "test".to_string(),
+            ssh_host_key: Some("ssh-ed25519 AAAA".to_string()),
+            ..Instance::default()
+        }]);
+        let stored = Arc::clone(&store.stored);
+        let context = Context::new(
+            Rc::new(system),
+            Environment::new(
+                UserName::from_str("cubic").unwrap(),
+                String::new(),
+                String::new(),
+            ),
+            Box::new(store),
+        );
+
+        CloneCommand {
+            name: InstanceName::from_str("test").unwrap(),
+            new_name: InstanceName::from_str("test2").unwrap(),
+        }
+        .run(console, &context)
+        .unwrap();
+
+        let stored = stored.lock().unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].ssh_host_key, None);
     }
 
     #[test]

--- a/src/commands/exec_command.rs
+++ b/src/commands/exec_command.rs
@@ -53,7 +53,6 @@ impl Command for ExecCommand {
         ssh.set_private_keys(env.get_home_ssh_private_key_paths(context.get_system()));
         ssh.set_cmd(Some(self.cmd.clone()));
         ssh.set_env_vars(self.env_args.env_vars.clone());
-        ssh.shell(console, name.as_str(), &client_key, &user, ssh_port);
-        Ok(())
+        ssh.shell(console, name.as_str(), &client_key, &user, ssh_port)
     }
 }

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -32,6 +32,7 @@ use clap::Parser;
 ///   Disk Image:   ~/.local/share/cubic/machines/trixie/machine.img
 ///   Config:       ~/.local/share/cubic/machines/trixie/instance.toml
 ///   SSH Key:      ~/.local/share/cubic/machines/trixie/ssh_client_key
+///   SSH Host Key: SHA256:ZkAslGjFiUHdGf/WUL8rQvkib4PTvQatUV0OUQSncCA
 ///   SSH:          ssh -i .../trixie/ssh_client_key -p 54315 cubic@localhost
 ///
 ///   Show information of a VM image

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -1,6 +1,7 @@
 use crate::actions::LoadInstanceAction;
 use crate::commands::{self, Command};
 use crate::error::{Error, Result};
+use crate::ssh::HostKeyChecker;
 use crate::util;
 use crate::view::{Console, MapView};
 use clap::Parser;
@@ -63,6 +64,12 @@ impl Command for ShowInstanceCommand {
             view.add("Disk Image", &env.get_instance_image_file(&instance.name));
             view.add("Config", &env.get_instance_toml_config_file(&instance.name));
             view.add("SSH Key", &ssh_key);
+            if let Some(host_key) = &instance.ssh_host_key {
+                view.add(
+                    "SSH Host Key",
+                    &HostKeyChecker::new().get_fingerprint(host_key),
+                );
+            }
             view.add(
                 "SSH",
                 &format!(
@@ -158,6 +165,10 @@ Forward:    127.0.0.1:4000:40/tcp
                 "0.0.0.0:80:8000/udp".parse().unwrap(),
             ],
             isolate: true,
+            ssh_host_key: Some(
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4f"
+                    .to_string(),
+            ),
             ..Instance::default()
         }]);
         let context =
@@ -203,6 +214,7 @@ Forward:      127.0.0.1:4000:40/tcp
 Disk Image:   {disk_image}
 Config:       {config}
 SSH Key:      {ssh_key}
+SSH Host Key: SHA256:ZkAslGjFiUHdGf/WUL8rQvkib4PTvQatUV0OUQSncCA
 SSH:          ssh -i {ssh_key} -p 8000 john@localhost
 "
             )

--- a/src/commands/ssh_command.rs
+++ b/src/commands/ssh_command.rs
@@ -51,7 +51,6 @@ impl Command for SshCommand {
         let mut ssh = SshClient::new(context);
         ssh.set_private_keys(env.get_home_ssh_private_key_paths(context.get_system()));
         ssh.set_env_vars(self.env_args.env_vars.clone());
-        ssh.shell(console, name.as_str(), &client_key, &user, ssh_port);
-        Ok(())
+        ssh.shell(console, name.as_str(), &client_key, &user, ssh_port)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -138,6 +138,18 @@ Troubleshoot:
     #[error("SFTP Error: {0}")]
     Sftp(String),
 
+    #[error("Connection to instance '{0}' failed")]
+    SshConnectionFailed(String),
+
+    #[error("Authentication on instance '{0}' failed")]
+    SshAuthFailed(String),
+
+    #[error("Authentication on instance '{0}' was cancelled")]
+    SshAuthCancelled(String),
+
+    #[error("The new SSH host key of instance '{0}' was not trusted")]
+    SshHostKeyRejected(String),
+
     #[error(
         "Invalid username '{0}'.\n\nUsernames must start with a lowercase letter or underscore, followed by lowercase letters, numbers, underlines or dashes"
     )]

--- a/src/instance/instance_serializer.rs
+++ b/src/instance/instance_serializer.rs
@@ -78,6 +78,7 @@ isolate = false
                     hostfwd: Vec::new(),
                     execute: Some("echo hello world".to_string()),
                     isolate: true,
+                    ssh_host_key: Some("ssh-ed25519 AAAA".to_string()),
                     ..Instance::default()
                 },
                 &mut writer,
@@ -96,6 +97,7 @@ ssh_port = 10000
 hostfwd = []
 execute = "echo hello world"
 isolate = true
+ssh_host_key = "ssh-ed25519 AAAA"
 "#
         );
     }

--- a/src/instance/instance_store_mock.rs
+++ b/src/instance/instance_store_mock.rs
@@ -5,13 +5,16 @@ pub mod tests {
     use crate::instance::InstanceStore;
     use crate::models::Instance;
     use crate::qemu::QemuMonitorClient;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     pub struct InstanceStoreMock {
         instances: Vec<Instance>,
         running: Vec<String>,
         pids: Vec<(String, u64)>,
-        killed: Mutex<Vec<String>>,
+        // Shared, so a test keeps a handle on what the store recorded after it
+        // moved into a Context.
+        pub killed: Arc<Mutex<Vec<String>>>,
+        pub stored: Arc<Mutex<Vec<Instance>>>,
     }
 
     impl InstanceStoreMock {
@@ -24,17 +27,14 @@ pub mod tests {
                 instances,
                 running: running.iter().map(|name| name.to_string()).collect(),
                 pids: Vec::new(),
-                killed: Mutex::new(Vec::new()),
+                killed: Arc::new(Mutex::new(Vec::new())),
+                stored: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
         pub fn set_pid(mut self, name: &str, pid: u64) -> Self {
             self.pids.push((name.to_string(), pid));
             self
-        }
-
-        pub fn get_killed(&self) -> Vec<String> {
-            self.killed.lock().unwrap().clone()
         }
     }
 
@@ -55,7 +55,8 @@ pub mod tests {
                 .ok_or(Error::UnknownInstance(name.to_string()))
         }
 
-        fn store(&self, _instance: &Instance) -> Result<()> {
+        fn store(&self, instance: &Instance) -> Result<()> {
+            self.stored.lock().unwrap().push(instance.clone());
             Ok(())
         }
 

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -74,6 +74,7 @@ ssh_port = 14357
         assert!(instance.hostfwd.is_empty());
         assert_eq!(instance.execute, None);
         assert!(!instance.isolate);
+        assert_eq!(instance.ssh_host_key, None);
     }
 
     #[test]
@@ -88,6 +89,7 @@ ssh_port = 14357
 hostfwd = ["tcp:127.0.0.1:8000-:8000", "tcp:127.0.0.1:9000-:10000"]
 execute = "sudo apt update"
 isolate = true
+ssh_host_key = "ssh-ed25519 AAAA"
 "#
             .as_bytes(),
         );
@@ -111,6 +113,7 @@ isolate = true
         );
         assert_eq!(instance.execute, Some("sudo apt update".to_string()));
         assert!(instance.isolate);
+        assert_eq!(instance.ssh_host_key, Some("ssh-ed25519 AAAA".to_string()));
     }
 
     #[test]

--- a/src/models/instance.rs
+++ b/src/models/instance.rs
@@ -25,4 +25,7 @@ pub struct Instance {
     pub execute: Option<String>,
     #[serde(default)]
     pub isolate: bool,
+    /// Guest SSH host key, pinned on the first connect
+    #[serde(default)]
+    pub ssh_host_key: Option<String>,
 }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,8 +1,10 @@
+mod host_key_checker;
 mod port_checker;
 mod sftp_path;
 mod ssh_client;
 mod ssh_key_generator;
 
+pub use host_key_checker::{HostKeyChecker, KeyCheck};
 pub use port_checker::PortChecker;
 pub use sftp_path::SftpPath;
 pub use ssh_client::SshClient;

--- a/src/ssh/host_key_checker.rs
+++ b/src/ssh/host_key_checker.rs
@@ -1,0 +1,91 @@
+use russh::keys::ssh_key::{HashAlg, PublicKey};
+
+#[derive(Debug, PartialEq)]
+pub enum KeyCheck {
+    /// No key was pinned yet, so the offered key is trusted on first use
+    Unknown,
+    Match,
+    Changed,
+}
+
+/// Compares the host key a guest offers against the key pinned in the
+/// instance config. The key itself is stored by the instance store, this
+/// type only decides what the comparison means.
+#[derive(Default)]
+pub struct HostKeyChecker;
+
+impl HostKeyChecker {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn check_key(&self, pinned: Option<&str>, offered: &str) -> KeyCheck {
+        match pinned {
+            None => KeyCheck::Unknown,
+            Some(pinned) if pinned.trim() == offered.trim() => KeyCheck::Match,
+            Some(_) => KeyCheck::Changed,
+        }
+    }
+
+    /// Formats a key the way OpenSSH shows it, falling back to the raw key
+    /// when it cannot be parsed.
+    pub fn get_fingerprint(&self, key: &str) -> String {
+        PublicKey::from_openssh(key.trim())
+            .map(|key| key.fingerprint(HashAlg::Sha256).to_string())
+            .unwrap_or_else(|_| key.trim().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use getrandom::SysRng;
+    use getrandom::rand_core::UnwrapErr;
+    use russh::keys::ssh_key::{Algorithm, PrivateKey};
+
+    fn build_key() -> String {
+        PrivateKey::random(&mut UnwrapErr(SysRng), Algorithm::Ed25519)
+            .unwrap()
+            .public_key()
+            .to_openssh()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_check_key_without_pinned_key_is_unknown() {
+        assert_eq!(
+            HostKeyChecker::new().check_key(None, &build_key()),
+            KeyCheck::Unknown
+        );
+    }
+
+    #[test]
+    fn test_check_key_with_same_key_matches() {
+        let key = build_key();
+
+        assert_eq!(
+            HostKeyChecker::new().check_key(Some(&key), &format!("{key}\n")),
+            KeyCheck::Match
+        );
+    }
+
+    #[test]
+    fn test_check_key_with_other_key_has_changed() {
+        assert_eq!(
+            HostKeyChecker::new().check_key(Some(&build_key()), &build_key()),
+            KeyCheck::Changed
+        );
+    }
+
+    #[test]
+    fn test_get_fingerprint_of_key() {
+        let fingerprint = HostKeyChecker::new().get_fingerprint(&build_key());
+
+        assert!(fingerprint.starts_with("SHA256:"));
+    }
+
+    #[test]
+    fn test_get_fingerprint_of_broken_key() {
+        assert_eq!(HostKeyChecker::new().get_fingerprint("broken"), "broken");
+    }
+}

--- a/src/ssh/ssh_client.rs
+++ b/src/ssh/ssh_client.rs
@@ -1,15 +1,15 @@
 use crate::commands::Context;
 use crate::error::Error;
 use crate::models::{Instance, TargetInstancePath};
-use crate::ssh::{SftpPath, SshKeyGenerator};
+use crate::ssh::{HostKeyChecker, KeyCheck, SftpPath, SshKeyGenerator};
 use crate::util;
-use crate::view::{Console, Spinner};
+use crate::view::{ConfirmDialog, Console, Spinner};
 use russh::keys::*;
 use russh::*;
 use russh_sftp::client::SftpSession;
 use std::path::Path;
 use std::rc::Rc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio_util::codec::FramedRead;
 use tokio_util::io::StreamReader;
 
@@ -49,16 +49,28 @@ pub struct SshClient<'a> {
     context: &'a Context,
 }
 
-struct ServerKeyHandler {}
+/// Verifies the host key of the guest. The handler is moved into the russh
+/// session, so it cannot borrow the console or the context. It records the
+/// offered key instead and lets the caller report and store it.
+struct ServerKeyHandler {
+    pinned: Option<String>,
+    offered: Arc<Mutex<Option<String>>>,
+}
 
 impl client::Handler for ServerKeyHandler {
     type Error = russh::Error;
 
     async fn check_server_key(
         &mut self,
-        _server_public_key: &ssh_key::PublicKey,
+        server_public_key: &ssh_key::PublicKey,
     ) -> Result<bool, Self::Error> {
-        Ok(true)
+        let Ok(key) = server_public_key.to_openssh() else {
+            return Ok(false);
+        };
+        let check = HostKeyChecker::new().check_key(self.pinned.as_deref(), &key);
+        *self.offered.lock().unwrap() = Some(key);
+
+        Ok(check != KeyCheck::Changed)
     }
 }
 
@@ -106,15 +118,16 @@ impl<'a> SshClient<'a> {
         session: &mut russh::client::Handle<ServerKeyHandler>,
         user: &str,
         machine: &str,
-    ) -> Result<(), ()> {
+    ) -> Result<(), Error> {
         loop {
-            let password =
-                console.prompt_secret(&format!("Enter password for {user}@{machine}: "))?;
+            let password = console
+                .prompt_secret(&format!("Enter password for {user}@{machine}: "))
+                .map_err(|_| Error::SshAuthCancelled(machine.to_string()))?;
 
             if session
                 .authenticate_password(user, password)
                 .await
-                .map_err(|_| ())?
+                .map_err(|_| Error::SshAuthFailed(machine.to_string()))?
                 .success()
             {
                 break;
@@ -131,7 +144,7 @@ impl<'a> SshClient<'a> {
         user: &str,
         machine: &str,
         client_key: &str,
-    ) -> Result<AuthMethod, ()> {
+    ) -> Result<AuthMethod, Error> {
         // The cubic per-instance ssh_client_key is the only supported method.
         // Everything below is a deprecated fallback.
         console.debug(&format!(
@@ -193,6 +206,28 @@ impl<'a> SshClient<'a> {
         Ok(())
     }
 
+    /// Reports a host key that does not match the pinned one and asks whether
+    /// to trust it from now on.
+    fn confirm_new_host_key(
+        &self,
+        console: &mut Console<'_>,
+        machine: &str,
+        pinned: &str,
+        offered: &str,
+    ) -> bool {
+        let checker = HostKeyChecker::new();
+
+        console.stop();
+        console.warn(&format!(
+            "The host key of instance '{machine}' does not match the stored key."
+        ));
+        console.warn(&format!("  expected  {}", checker.get_fingerprint(pinned)));
+        console.warn(&format!("  actual    {}", checker.get_fingerprint(offered)));
+        console.warn("This may be a malicious attempt to take over the connection to the guest.");
+
+        ConfirmDialog::new("Do you want to trust the new key and continue?").confirm(console)
+    }
+
     async fn open_channel(
         &self,
         console: &mut Console<'_>,
@@ -200,22 +235,49 @@ impl<'a> SshClient<'a> {
         client_key: &str,
         user: &str,
         port: u16,
-    ) -> Result<Channel<russh::client::Msg>, ()> {
+    ) -> Result<Channel<russh::client::Msg>, Error> {
         let mut session;
+        let store = self.context.get_instance_store();
+        let mut instance = store.load(machine)?;
+        let mut pinned = instance.ssh_host_key.clone();
+        let offered = Arc::new(Mutex::new(None));
 
-        console.play(Arc::new(std::sync::Mutex::new(Spinner::new(format!(
+        console.play(Arc::new(Mutex::new(Spinner::new(format!(
             "Connecting to {machine}"
         )))));
         console.debug(&format!("Connecting to 127.0.0.1:{port}"));
         let mut failed = false;
         loop {
-            let sh = ServerKeyHandler {};
+            let sh = ServerKeyHandler {
+                pinned: pinned.clone(),
+                offered: Arc::clone(&offered),
+            };
             let addrs = ("127.0.0.1", port);
             let config = Arc::new(client::Config::default());
-            if let Ok(s) = client::connect(config, addrs, sh).await.map_err(|_| ()) {
+            if let Ok(s) = client::connect(config, addrs, sh).await {
                 session = s;
                 break;
             }
+
+            // A rejected host key fails like any other connect error, so it has
+            // to end the retry loop on its own.
+            let key = offered.lock().unwrap().clone();
+            if let (Some(key), Some(pinned_key)) = (key, pinned.clone())
+                && HostKeyChecker::new().check_key(Some(&pinned_key), &key) == KeyCheck::Changed
+            {
+                if !self.confirm_new_host_key(console, machine, &pinned_key, &key) {
+                    return Err(Error::SshHostKeyRejected(machine.to_string()));
+                }
+
+                instance.ssh_host_key = Some(key.clone());
+                store.store(&instance)?;
+                pinned = Some(key);
+                console.play(Arc::new(Mutex::new(Spinner::new(format!(
+                    "Connecting to {machine}"
+                )))));
+                continue;
+            }
+
             if !failed {
                 failed = true;
                 console.debug(&format!("Connection to 127.0.0.1:{port} failed, retrying"));
@@ -223,7 +285,21 @@ impl<'a> SshClient<'a> {
         }
 
         console.debug(&format!("Connected to 127.0.0.1:{port}"));
-        console.play(Arc::new(std::sync::Mutex::new(Spinner::new(format!(
+
+        // Trust the key of a guest that has none stored yet on this first connect.
+        if pinned.is_none() {
+            let key = offered.lock().unwrap().clone();
+            if let Some(key) = key {
+                console.debug(&format!(
+                    "Pinning host key {}",
+                    HostKeyChecker::new().get_fingerprint(&key)
+                ));
+                instance.ssh_host_key = Some(key);
+                store.store(&instance)?;
+            }
+        }
+
+        console.play(Arc::new(Mutex::new(Spinner::new(format!(
             "Authenticating on {machine}"
         )))));
 
@@ -236,7 +312,10 @@ impl<'a> SshClient<'a> {
             self.warn_deprecated_auth(console, machine, client_key).ok();
         }
 
-        session.channel_open_session().await.map_err(|_| ())
+        session
+            .channel_open_session()
+            .await
+            .map_err(|_| Error::SshConnectionFailed(machine.to_string()))
     }
 
     async fn handle_interactive_shell(
@@ -246,7 +325,7 @@ impl<'a> SshClient<'a> {
         client_key: &str,
         user: &str,
         port: u16,
-    ) -> Result<(), ()> {
+    ) -> Result<(), Error> {
         let channel = self
             .open_channel(console, machine, client_key, user, port)
             .await?;
@@ -270,7 +349,7 @@ impl<'a> SshClient<'a> {
                 &[],
             )
             .await
-            .map_err(|_| ())?;
+            .map_err(|_| Error::SshConnectionFailed(machine.to_string()))?;
 
         for var in &self.env_vars {
             let (name, value) = if let Some((k, v)) = var.split_once('=') {
@@ -284,13 +363,22 @@ impl<'a> SshClient<'a> {
                         .unwrap_or_default(),
                 )
             };
-            channel.set_env(false, name, value).await.map_err(|_| ())?;
+            channel
+                .set_env(false, name, value)
+                .await
+                .map_err(|_| Error::SshConnectionFailed(machine.to_string()))?;
         }
 
         if let Some(cmd) = &self.cmd {
-            channel.exec(true, cmd.as_str()).await.map_err(|_| ())?;
+            channel
+                .exec(true, cmd.as_str())
+                .await
+                .map_err(|_| Error::SshConnectionFailed(machine.to_string()))?;
         } else {
-            channel.request_shell(true).await.map_err(|_| ())?;
+            channel
+                .request_shell(true)
+                .await
+                .map_err(|_| Error::SshConnectionFailed(machine.to_string()))?;
         }
         let (mut ssh_in, ssh_out) = channel.split();
         let mut ssh_reader = ssh_in.make_reader();
@@ -318,14 +406,19 @@ impl<'a> SshClient<'a> {
         instance: &Instance,
         user: &Option<String>,
         client_key: &str,
-    ) -> Rc<SftpSession> {
+    ) -> Result<Rc<SftpSession>, Error> {
         let user = user.as_deref().unwrap_or(instance.user.as_str());
         let channel = self
             .open_channel(console, &instance.name, client_key, user, instance.ssh_port)
+            .await?;
+        channel
+            .request_subsystem(true, "sftp")
             .await
-            .unwrap();
-        channel.request_subsystem(true, "sftp").await.unwrap();
-        Rc::new(SftpSession::new(channel.into_stream()).await.unwrap())
+            .map_err(|error| Error::Sftp(error.to_string()))?;
+        SftpSession::new(channel.into_stream())
+            .await
+            .map(Rc::new)
+            .map_err(|error| Error::Sftp(error.to_string()))
     }
 
     async fn open_target_fs(
@@ -333,7 +426,7 @@ impl<'a> SshClient<'a> {
         console: &mut Console<'_>,
         path: &TargetInstancePath,
         client_key: Option<&str>,
-    ) -> SftpPath {
+    ) -> Result<SftpPath, Error> {
         let sftp = if let Some(instance) = &path.instance {
             Some(
                 self.open_sftp(
@@ -342,15 +435,15 @@ impl<'a> SshClient<'a> {
                     &path.user,
                     client_key.unwrap_or_default(),
                 )
-                .await,
+                .await?,
             )
         } else {
             None
         };
-        SftpPath {
+        Ok(SftpPath {
             sftp,
             path: path.to_pathbuf(),
-        }
+        })
     }
 
     async fn async_copy(
@@ -362,8 +455,8 @@ impl<'a> SshClient<'a> {
         to: &TargetInstancePath,
         to_key: Option<&str>,
     ) -> Result<(), Error> {
-        let source = self.open_target_fs(console, from, from_key).await;
-        let target = self.open_target_fs(console, to, to_key).await;
+        let source = self.open_target_fs(console, from, from_key).await?;
+        let target = self.open_target_fs(console, to, to_key).await?;
 
         source.copy(console, target).await
     }
@@ -387,10 +480,9 @@ impl<'a> SshClient<'a> {
         client_key: &str,
         user: &str,
         port: u16,
-    ) -> bool {
+    ) -> Result<(), Error> {
         util::AsyncCaller::new()
             .call(self.handle_interactive_shell(console, machine, client_key, user, port))
-            .is_ok()
     }
 
     pub fn copy(
@@ -404,5 +496,57 @@ impl<'a> SshClient<'a> {
     ) -> Result<(), Error> {
         util::AsyncCaller::new()
             .call(self.async_copy(console, root_dir, from, from_key, to, to_key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use getrandom::SysRng;
+    use getrandom::rand_core::UnwrapErr;
+    use russh::client::Handler;
+    use russh::keys::ssh_key::{Algorithm, PrivateKey};
+
+    fn build_key() -> ssh_key::PublicKey {
+        PrivateKey::random(&mut UnwrapErr(SysRng), Algorithm::Ed25519)
+            .unwrap()
+            .public_key()
+            .clone()
+    }
+
+    fn check_key(
+        pinned: Option<&ssh_key::PublicKey>,
+        offered: &ssh_key::PublicKey,
+    ) -> (bool, bool) {
+        let seen = Arc::new(Mutex::new(None));
+        let mut handler = ServerKeyHandler {
+            pinned: pinned.map(|key| key.to_openssh().unwrap()),
+            offered: Arc::clone(&seen),
+        };
+
+        let accepted = util::AsyncCaller::new()
+            .call(handler.check_server_key(offered))
+            .unwrap();
+        let recorded =
+            seen.lock().unwrap().as_deref() == Some(offered.to_openssh().unwrap().as_str());
+
+        (accepted, recorded)
+    }
+
+    #[test]
+    fn test_check_server_key_accepts_the_first_key() {
+        assert_eq!(check_key(None, &build_key()), (true, true));
+    }
+
+    #[test]
+    fn test_check_server_key_accepts_the_pinned_key() {
+        let key = build_key();
+
+        assert_eq!(check_key(Some(&key), &key), (true, true));
+    }
+
+    #[test]
+    fn test_check_server_key_rejects_a_changed_key() {
+        assert_eq!(check_key(Some(&build_key()), &build_key()), (false, true));
     }
 }


### PR DESCRIPTION
## Summary

Cubic accepted any SSH host key a guest offered, so it could not notice when something else answered on the forwarded port. The key from the first connect is now stored in `instance.toml` and compared on later connects. A mismatch stops the connection, shows both fingerprints, and asks whether to trust the new key. Answering yes stores it, which is how a user carries on after recreating a guest.

```
warn: The host key of instance 'my-instance' does not match the stored key.
warn:   expected  SHA256:4kL8QpX2vN0mR7sT1uY6bE3wZ9cA5dF2gH8jK4nP0qs
warn:   actual    SHA256:9xKp2LmQ7rV4tB1nS6yU3wE0aZ8cD5fG2hJ4kM7pR1o
warn: This may be a malicious attempt to take over the connection to the guest.
Do you want to trust the new key and continue? [y/N]:
```

`cubic ssh` and `cubic exec` now exit with a failure when the session fails, scp no longer panics on a refused key, and `cubic show --all` prints the stored fingerprint. A clone starts without a key, since it generates new host keys on first boot.

## Related Issue(s)

Closes #445

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

`make test`, `make lint` and `make fix-format` pass. New unit tests cover the key comparison, the fingerprint format, the russh handler accepting a first and a pinned key and rejecting a changed one, the clone dropping the key, and the config round trip. All run on mocks.

End to end: first `cubic ssh` writes `ssh_host_key`, a second connects silently, a hand-edited key produces the prompt where `n` aborts and `y` re-pins, and `cubic clone` plus `cubic ssh` pins the clone's own key.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed