### PR TITLE
refactor: keep every error message in the error enum

### DIFF
--- a/src/actions/load_instance_action.rs
+++ b/src/actions/load_instance_action.rs
@@ -22,9 +22,9 @@ impl LoadInstanceAction {
         name: &str,
     ) -> Result<Instance> {
         match context.get_instance_store().load(name) {
-            Err(Error::InvalidInstanceConfig(_, reason)) => {
+            Err(error @ Error::InvalidInstanceConfig { .. }) => {
                 console.warn(&format!(
-                    "Config of instance '{name}' is invalid, resetting it to the default settings.\n{reason}"
+                    "{error}\n\nResetting instance '{name}' to the default settings."
                 ));
 
                 let instance = self.build_default_instance(context, name)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,11 +120,8 @@ Error:
 {1}
 
 Troubleshoot:
-  - Make sure the following tools are installed and the PATH variable is set
-    correctly:
-    - qemu-system-x86_64
-    - qemu-system-aarch64
-    - qemu-img
+  - Run the command again with --verbose to see the full QEMU command line
+  - Check the QEMU version with `qemu-system-x86_64 --version`
 
   - Report error at https://github.com/cubic-vm/cubic/issues
 "

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,34 +1,67 @@
 use crate::models::Arch;
+use std::fmt;
 use std::io;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Names the operation so every file system implementation words it the same.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FsOperation {
+    CreateDir,
+    ReadMetadata,
+    RemoveDir,
+    ReadDir,
+    CreateFile,
+    OpenFile,
+    ReadFile,
+    WriteFile,
+    RemoveFile,
+}
+
+impl fmt::Display for FsOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                FsOperation::CreateDir => "create directory",
+                FsOperation::ReadMetadata => "read metadata of",
+                FsOperation::RemoveDir => "remove directory",
+                FsOperation::ReadDir => "read directory",
+                FsOperation::CreateFile => "create file",
+                FsOperation::OpenFile => "open file",
+                FsOperation::ReadFile => "read file",
+                FsOperation::WriteFile => "write file",
+                FsOperation::RemoveFile => "delete file",
+            }
+        )
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error(
-        "CPU arch '{0}' is not supported.\n\nChoose a supported architecture: 'amd64' or 'arm64'"
-    )]
-    UnknownArch(String),
-
-    #[error(
-        "Hardware acceleration needs a guest arch equal to the host arch.\n\nInstance '{0}' is {1} and this host is {2}.\n\nRun it with `--accel off` to use software emulation."
-    )]
-    ArchMismatch(String, Arch, Arch),
-
+    // Instances
     #[error(
         "Instance '{0}' does not exist.\n\nOptions:\n  - Use an existing instance name\n  - Create it first: `cubic create {0} [...]`"
     )]
     UnknownInstance(String),
 
-    #[error("Config of instance '{0}' is invalid.\n\n{1}")]
-    InvalidInstanceConfig(String, String),
-
-    #[error("Image '{0}' not found.\n\nList available images with: `cubic images`")]
-    UnknownImage(String),
+    #[error("Config of instance '{name}' is invalid.\n\n{source}")]
+    InvalidInstanceConfig {
+        name: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 
     #[error("No instance name was given.\n\nProvide at least one instance name.")]
     MissingInstanceName,
+
+    #[error(
+        "Instance name '{0}' is already taken.\n\nOptions:\n  - Choose a different name\n  - Connect to existing instance: `cubic ssh {0}`"
+    )]
+    InstanceAlreadyExists(String),
 
     #[error(
         "Instance '{0}' must be stopped to proceed.\n\nRun `cubic stop --wait {0}` to stop it now."
@@ -37,14 +70,6 @@ pub enum Error {
 
     #[error("Instance '{0}' is not running")]
     InstanceNotRunning(String),
-
-    #[error("Process {0} is not running")]
-    ProcessNotFound(u64),
-
-    #[error(
-        "Cannot kill process {0}.\n\nTroubleshoot:\n  - Check that the process belongs to you\n  - Kill it manually and try again\n"
-    )]
-    KillFailed(u64),
 
     #[error(
         "Timed out waiting for instance(s) to start.\n\nTroubleshoot:\n  - Run with --verbose to see the QEMU command\n  - Check that QEMU can open /dev/kvm and firmware files\n  - Try again; the system may be under load\n"
@@ -61,16 +86,22 @@ pub enum Error {
     )]
     NotEnoughMemory(String),
 
-    #[error(
-        "Instance name '{0}' is already taken.\n\nOptions:\n  - Choose a different name\n  - Connect to existing instance: `cubic ssh {0}`"
-    )]
-    InstanceAlreadyExists(String),
+    #[error("Cannot shrink the disk of the instance '{0}'")]
+    CannotShrinkDisk(String),
 
     #[error(
-        "Environment variable '{0}' is not set.\n\nTemporary (current session):\n  - Linux/macOS: export {0}=value\n  - Windows (PowerShell): $env:{0} = \"value\"\n  - Windows (CMD): set {0}=value\n\nPermanent: Add to your shell profile or Windows Environment Variables settings."
+        "Hardware acceleration needs a guest arch equal to the host arch.\n\nInstance '{0}' is {1} and this host is {2}.\n\nRun it with `--accel off` to use software emulation."
     )]
-    UnsetEnvVar(String),
+    ArchMismatch(String, Arch, Arch),
 
+    // Images
+    #[error("Image '{0}' not found.\n\nList available images with: `cubic images`")]
+    UnknownImage(String),
+
+    #[error("Verification of image failed")]
+    InvalidChecksum,
+
+    // QEMU and system commands
     #[error("{}", format_qemu_not_found_help())]
     QemuNotFound,
 
@@ -100,49 +131,60 @@ Troubleshoot:
     )]
     SystemCommandFailed(String, String),
 
-    #[error("IO Error: {0}")]
-    Io(#[from] io::Error),
+    #[error("Failed to apply port forwarding rule on the running instance: {0}")]
+    HostfwdCommandFailed(String),
 
-    #[error("FS Error: {0}")]
-    FS(String),
+    #[error("Process {0} is not running")]
+    ProcessNotFound(u64),
 
-    #[error("Cannot shrink the disk of the instance '{0}'")]
-    CannotShrinkDisk(String),
-
-    #[error("TLS certificate generation error: {0}")]
-    TlsCertGeneration(String),
-
-    #[error("TLS connection error: {0}")]
-    TlsConnection(String),
-
-    #[error("Web Error: {0}")]
-    Web(#[from] reqwest::Error),
-
-    #[error("JSON Error: {0}")]
-    SerdeJson(#[from] serde_json::Error),
-
-    #[error("TOML Error: {0}")]
-    SerdeToml(#[from] toml::ser::Error),
-
-    #[error("Verification of image failed")]
-    InvalidChecksum,
+    #[error(
+        "Cannot kill process {0}.\n\nTroubleshoot:\n  - Check that the process belongs to you\n  - Kill it manually and try again\n"
+    )]
+    KillFailed(u64),
 
     #[error("Could not detect shell")]
     CouldNotDetectShell,
 
-    #[error("SSH Error: {0}")]
-    Ssh(#[from] russh::keys::ssh_key::Error),
+    #[error(
+        "Environment variable '{0}' is not set.\n\nTemporary (current session):\n  - Linux/macOS: export {0}=value\n  - Windows (PowerShell): $env:{0} = \"value\"\n  - Windows (CMD): set {0}=value\n\nPermanent: Add to your shell profile or Windows Environment Variables settings."
+    )]
+    UnsetEnvVar(String),
+
+    // File system
+    #[error("Cannot {operation} '{}' ({source})", path.display())]
+    FileSystem {
+        operation: FsOperation,
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("Cannot rename file from '{}' to '{}' ({source})", from.display(), to.display())]
+    RenameFile {
+        from: PathBuf,
+        to: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("Cannot write directory '{}'", .0.display())]
+    ReadOnlyDir(PathBuf),
 
     #[error("Invalid path: {0}")]
     InvalidPath(String),
+
+    // Fallback. Anything that knows a path or a port reports that instead.
+    #[error("IO Error: {0}")]
+    Io(#[from] io::Error),
+
+    // Network and SSH
+    #[error("Cannot connect to port {0} ({1})")]
+    ConnectionFailed(u16, #[source] io::Error),
 
     #[error(
         "No available port found.\n\nAll ports are currently in use. Stop unused processes and try again."
     )]
     NoPortAvailable,
-
-    #[error("SFTP Error: {0}")]
-    Sftp(String),
 
     #[error("Connection to instance '{0}' failed")]
     SshConnectionFailed(String),
@@ -156,13 +198,94 @@ Troubleshoot:
     #[error("The new SSH host key of instance '{0}' was not trusted")]
     SshHostKeyRejected(String),
 
+    #[error("SSH Error: {0}")]
+    Ssh(#[from] russh::keys::ssh_key::Error),
+
+    #[error("Cannot {operation} '{path}' on the instance ({source})")]
+    Sftp {
+        operation: FsOperation,
+        path: String,
+        #[source]
+        source: russh_sftp::client::error::Error,
+    },
+
+    #[error("Cannot open an SFTP session on instance '{instance}' ({source})")]
+    SftpSession {
+        instance: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("Web Error: {0}")]
+    Web(#[from] reqwest::Error),
+
+    // TLS
+    #[error("TLS certificate generation error: {0}")]
+    TlsCertGeneration(#[from] rcgen::Error),
+
+    #[error("TLS connection error: {0}")]
+    TlsConnection(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    // Parsing
+    #[error(
+        "CPU arch '{0}' is not supported.\n\nChoose a supported architecture: 'amd64' or 'arm64'"
+    )]
+    UnknownArch(String),
+
     #[error(
         "Invalid username '{0}'.\n\nUsernames must start with a lowercase letter or underscore, followed by lowercase letters, numbers, underlines or dashes"
     )]
     InvalidUsername(String),
 
-    #[error("Failed to apply port forwarding rule on the running instance: {0}")]
-    HostfwdCommandFailed(String),
+    // Serialization
+    #[error("JSON Error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+
+    #[error("TOML Error: {0}")]
+    SerdeToml(#[from] toml::ser::Error),
+}
+
+impl Error {
+    pub fn from_fs(operation: FsOperation, path: &Path, source: io::Error) -> Self {
+        Error::FileSystem {
+            operation,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+
+    pub fn from_sftp(
+        operation: FsOperation,
+        path: &str,
+        source: russh_sftp::client::error::Error,
+    ) -> Self {
+        Error::Sftp {
+            operation,
+            path: path.to_string(),
+            source,
+        }
+    }
+
+    pub fn from_config(name: &str, source: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Error::InvalidInstanceConfig {
+            name: name.to_string(),
+            source: Box::new(source),
+        }
+    }
+
+    pub fn from_tls(source: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Error::TlsConnection(Box::new(source))
+    }
+
+    pub fn from_sftp_session(
+        instance: &str,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Error::SftpSession {
+            instance: instance.to_string(),
+            source: Box::new(source),
+        }
+    }
 }
 
 fn format_qemu_not_found_help() -> String {

--- a/src/instance/instance_cert_generator.rs
+++ b/src/instance/instance_cert_generator.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::models::InstanceCertPaths;
 use crate::platform::System;
 use rcgen::{
@@ -25,7 +25,7 @@ impl<'a> InstanceCertGenerator<'a> {
     pub fn generate(&self) -> Result<InstanceCertPaths> {
         let certs = InstanceCertPaths::load(&self.dir);
 
-        let ca_key = KeyPair::generate().map_err(|e| Error::TlsCertGeneration(e.to_string()))?;
+        let ca_key = KeyPair::generate()?;
         let mut ca_params = CertificateParams::default();
 
         ca_params.distinguished_name = {
@@ -35,23 +35,16 @@ impl<'a> InstanceCertGenerator<'a> {
         };
         ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
         ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
-        let ca = CertifiedIssuer::self_signed(ca_params, ca_key)
-            .map_err(|e| Error::TlsCertGeneration(e.to_string()))?;
+        let ca = CertifiedIssuer::self_signed(ca_params, ca_key)?;
 
-        let server_key =
-            KeyPair::generate().map_err(|e| Error::TlsCertGeneration(e.to_string()))?;
+        let server_key = KeyPair::generate()?;
 
-        let server_cert = CertificateParams::new(vec!["localhost".to_string()])
-            .map_err(|e| Error::TlsCertGeneration(e.to_string()))?
-            .signed_by(&server_key, &ca)
-            .map_err(|e| Error::TlsCertGeneration(e.to_string()))?;
+        let server_cert =
+            CertificateParams::new(vec!["localhost".to_string()])?.signed_by(&server_key, &ca)?;
 
-        let client_key =
-            KeyPair::generate().map_err(|e| Error::TlsCertGeneration(e.to_string()))?;
+        let client_key = KeyPair::generate()?;
 
-        let client_cert = CertificateParams::default()
-            .signed_by(&client_key, &ca)
-            .map_err(|e| Error::TlsCertGeneration(e.to_string()))?;
+        let client_cert = CertificateParams::default().signed_by(&client_key, &ca)?;
 
         self.system
             .write_file(&certs.ca_cert, ca.pem().as_bytes())?;

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -80,7 +80,7 @@ impl InstanceStore for InstanceDao {
         let mut file = self
             .system
             .open_file(Path::new(&path))
-            .map_err(|error| Error::InvalidInstanceConfig(name.to_string(), error.to_string()))?;
+            .map_err(|error| Error::from_config(name, error))?;
 
         let mut instance = TomlInstanceDeserializer::new().deserialize(name, &mut file)?;
         QemuImg::new(self.system.as_ref()).read_disk_info(&self.env, &mut instance);
@@ -221,27 +221,13 @@ mod tests {
     }
 
     #[test]
-    fn test_load_reports_a_broken_config() {
-        let env = build_env();
-        let system = SystemMock::new()
-            .add_dir("/data/machines/test")
-            .add_file(&env.get_instance_toml_config_file("test"), b"cpus = ");
-        let dao = InstanceDao::new(Rc::new(system), &env).unwrap();
-
-        assert!(matches!(
-            dao.load("test"),
-            Err(Error::InvalidInstanceConfig(name, _)) if name == "test"
-        ));
-    }
-
-    #[test]
     fn test_load_reports_a_missing_config() {
         let system = SystemMock::new().add_dir("/data/machines/test");
         let dao = InstanceDao::new(Rc::new(system), &build_env()).unwrap();
 
         assert!(matches!(
             dao.load("test"),
-            Err(Error::InvalidInstanceConfig(name, _)) if name == "test"
+            Err(Error::InvalidInstanceConfig { name, .. }) if name == "test"
         ));
     }
 

--- a/src/instance/toml_instance_deserializer.rs
+++ b/src/instance/toml_instance_deserializer.rs
@@ -15,14 +15,14 @@ impl TomlInstanceDeserializer {
         let mut data = String::new();
         reader
             .read_to_string(&mut data)
-            .map_err(|error| Error::InvalidInstanceConfig(name.to_string(), error.to_string()))?;
+            .map_err(|error| Error::from_config(name, error))?;
 
         toml::from_str(&data)
             .map(|mut instance: Instance| {
                 instance.name = name.to_string();
                 instance
             })
-            .map_err(|error| Error::InvalidInstanceConfig(name.to_string(), error.to_string()))
+            .map_err(|error| Error::from_config(name, error))
     }
 }
 
@@ -33,20 +33,11 @@ mod tests {
     use std::io::BufReader;
 
     #[test]
-    fn test_deserialize_empty_file() {
-        let reader = &mut BufReader::new("".as_bytes());
-        assert!(matches!(
-            TomlInstanceDeserializer::new().deserialize("test", reader),
-            Err(Error::InvalidInstanceConfig(name, _)) if name == "test"
-        ));
-    }
-
-    #[test]
     fn test_deserialize_broken_file() {
         let reader = &mut BufReader::new("cpus = ".as_bytes());
         assert!(matches!(
             TomlInstanceDeserializer::new().deserialize("test", reader),
-            Err(Error::InvalidInstanceConfig(name, _)) if name == "test"
+            Err(Error::InvalidInstanceConfig { name, .. }) if name == "test"
         ));
     }
 

--- a/src/models/target_path.rs
+++ b/src/models/target_path.rs
@@ -28,7 +28,7 @@ impl FromStr for TargetPath {
                 target: Some(Target::from_str(target)?),
                 path: path.to_string(),
             }),
-            _ => Err("Target path must have the format [[user@]instance:]path (e.g. 'cubic@mymachine:/home/cubic', 'mymachine:~/' or 'my_file'".to_string()),
+            _ => Err("Target path must have the format [[user@]instance:]path (e.g. 'cubic@mymachine:/home/cubic', 'mymachine:~/' or 'my_file')".to_string()),
         }
     }
 }

--- a/src/platform/file_system_mock.rs
+++ b/src/platform/file_system_mock.rs
@@ -1,7 +1,8 @@
-use crate::error::{Error, Result};
+use crate::error::{Error, FsOperation, Result};
 use crate::platform::{FileSystem, SystemMock};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::io;
 use std::io::{Cursor, Read, Write};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -218,10 +219,11 @@ impl FileSystem for SystemMock {
     fn read_dir(&self, path: &Path) -> Result<Vec<PathBuf>> {
         let file_system = self.file_system.borrow();
         if !file_system.exists_dir(path) {
-            return Err(Error::FS(format!(
-                "Cannot read directory '{}' (not found)",
-                path.display()
-            )));
+            return Err(Error::from_fs(
+                FsOperation::ReadDir,
+                path,
+                io::ErrorKind::NotFound.into(),
+            ));
         }
         Ok(file_system.list_children(path))
     }
@@ -239,15 +241,22 @@ impl FileSystem for SystemMock {
             .borrow()
             .get_file(path)
             .map(|content| Box::new(Cursor::new(content)) as Box<dyn Read>)
-            .ok_or_else(|| Error::FS(format!("Cannot open file '{}' (not found)", path.display())))
+            .ok_or_else(|| {
+                Error::from_fs(FsOperation::OpenFile, path, io::ErrorKind::NotFound.into())
+            })
     }
 
     fn read_file_to_string(&self, path: &Path) -> Result<String> {
         let content = self.file_system.borrow().get_file(path).ok_or_else(|| {
-            Error::FS(format!("Cannot read file '{}' (not found)", path.display()))
+            Error::from_fs(FsOperation::ReadFile, path, io::ErrorKind::NotFound.into())
         })?;
-        String::from_utf8(content)
-            .map_err(|e| Error::FS(format!("Cannot read file '{}' ({e})", path.display())))
+        String::from_utf8(content).map_err(|e| {
+            Error::from_fs(
+                FsOperation::ReadFile,
+                path,
+                io::Error::new(io::ErrorKind::InvalidData, e),
+            )
+        })
     }
 
     fn write_file(&self, path: &Path, contents: &[u8]) -> Result<()> {
@@ -263,11 +272,11 @@ impl FileSystem for SystemMock {
         if self.file_system.borrow_mut().rename_path(from, to) {
             Ok(())
         } else {
-            Err(Error::FS(format!(
-                "Cannot rename file from '{}' to '{}' (not found)",
-                from.display(),
-                to.display()
-            )))
+            Err(Error::RenameFile {
+                from: from.to_path_buf(),
+                to: to.to_path_buf(),
+                source: io::ErrorKind::NotFound.into(),
+            })
         }
     }
 
@@ -277,10 +286,11 @@ impl FileSystem for SystemMock {
             .remove_file(path)
             .map(|_| ())
             .ok_or_else(|| {
-                Error::FS(format!(
-                    "Cannot delete file '{}' (not found)",
-                    path.display()
-                ))
+                Error::from_fs(
+                    FsOperation::RemoveFile,
+                    path,
+                    io::ErrorKind::NotFound.into(),
+                )
             })
     }
 }

--- a/src/platform/network_mock.rs
+++ b/src/platform/network_mock.rs
@@ -52,7 +52,10 @@ impl NetworkMock {
         match self.find(port) {
             Some(PortState::Listening) => Ok(Box::new(StreamMock::new(GREETING))),
             Some(PortState::Silent) => Ok(Box::new(StreamMock::new(b""))),
-            _ => Err(Error::Io(std::io::ErrorKind::ConnectionRefused.into())),
+            _ => Err(Error::ConnectionFailed(
+                port,
+                std::io::ErrorKind::ConnectionRefused.into(),
+            )),
         }
     }
 
@@ -185,7 +188,7 @@ mod tests {
 
         assert!(matches!(
             system.connect_port(22, Duration::from_secs(1)),
-            Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::ConnectionRefused
+            Err(Error::ConnectionFailed(22, e)) if e.kind() == std::io::ErrorKind::ConnectionRefused
         ));
     }
 

--- a/src/platform/os_file_system.rs
+++ b/src/platform/os_file_system.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::error::{Error, FsOperation, Result};
 use crate::platform::{FileSystem, OsSystem};
 use std::fs;
 use std::io::{Read, Write};
@@ -32,49 +32,31 @@ impl FileSystem for OsSystem {
     }
 
     fn create_dir(&self, path: &Path) -> Result<()> {
-        fs::create_dir_all(path).map_err(|e| {
-            Error::FS(format!(
-                "Cannot create directory '{}' ({e})",
-                path.display()
-            ))
-        })
+        fs::create_dir_all(path).map_err(|e| Error::from_fs(FsOperation::CreateDir, path, e))
     }
 
     fn create_writable_dir(&self, path: &Path) -> Result<()> {
         self.create_dir(path)?;
 
         let permission = fs::metadata(path)
-            .map_err(|e| {
-                Error::FS(format!(
-                    "Cannot read directory metadata '{}' ({e})",
-                    path.display()
-                ))
-            })?
+            .map_err(|e| Error::from_fs(FsOperation::ReadMetadata, path, e))?
             .permissions();
 
         if permission.readonly() {
-            return Err(Error::FS(format!(
-                "Cannot write directory '{}'",
-                path.display()
-            )));
+            return Err(Error::ReadOnlyDir(path.to_path_buf()));
         }
 
         Ok(())
     }
 
     fn remove_dir(&self, path: &Path) -> Result<()> {
-        fs::remove_dir_all(path).map_err(|e| {
-            Error::FS(format!(
-                "Cannot remove directory '{}' ({e})",
-                path.display()
-            ))
-        })
+        fs::remove_dir_all(path).map_err(|e| Error::from_fs(FsOperation::RemoveDir, path, e))
     }
 
     fn read_dir(&self, path: &Path) -> Result<Vec<PathBuf>> {
         fs::read_dir(path)
             .map(|dir| dir.flatten().map(|entry| entry.path()).collect())
-            .map_err(|e| Error::FS(format!("Cannot read directory '{}' ({e})", path.display())))
+            .map_err(|e| Error::from_fs(FsOperation::ReadDir, path, e))
     }
 
     fn create_file(&self, path: &Path) -> Result<Box<dyn Write>> {
@@ -84,23 +66,21 @@ impl FileSystem for OsSystem {
             .truncate(true)
             .open(path)
             .map(|f| Box::new(f) as Box<dyn Write>)
-            .map_err(|e| Error::FS(format!("Cannot create file '{}' ({e})", path.display())))
+            .map_err(|e| Error::from_fs(FsOperation::CreateFile, path, e))
     }
 
     fn open_file(&self, path: &Path) -> Result<Box<dyn Read>> {
         fs::File::open(path)
             .map(|f| Box::new(f) as Box<dyn Read>)
-            .map_err(|e| Error::FS(format!("Cannot open file '{}' ({e})", path.display())))
+            .map_err(|e| Error::from_fs(FsOperation::OpenFile, path, e))
     }
 
     fn read_file_to_string(&self, path: &Path) -> Result<String> {
-        fs::read_to_string(path)
-            .map_err(|e| Error::FS(format!("Cannot read file '{}' ({e})", path.display())))
+        fs::read_to_string(path).map_err(|e| Error::from_fs(FsOperation::ReadFile, path, e))
     }
 
     fn write_file(&self, path: &Path, contents: &[u8]) -> Result<()> {
-        fs::write(path, contents)
-            .map_err(|e| Error::FS(format!("Cannot write file '{}' ({e})", path.display())))
+        fs::write(path, contents).map_err(|e| Error::from_fs(FsOperation::WriteFile, path, e))
     }
 
     // Writes a file only the owner may read, for private keys and other
@@ -118,21 +98,18 @@ impl FileSystem for OsSystem {
         options
             .open(path)
             .and_then(|mut file| file.write_all(contents))
-            .map_err(|e| Error::FS(format!("Cannot write file '{}' ({e})", path.display())))
+            .map_err(|e| Error::from_fs(FsOperation::WriteFile, path, e))
     }
 
     fn rename_file(&self, from: &Path, to: &Path) -> Result<()> {
-        fs::rename(from, to).map_err(|e| {
-            Error::FS(format!(
-                "Cannot rename file from '{}' to '{}' ({e})",
-                from.display(),
-                to.display()
-            ))
+        fs::rename(from, to).map_err(|e| Error::RenameFile {
+            from: from.to_path_buf(),
+            to: to.to_path_buf(),
+            source: e,
         })
     }
 
     fn remove_file(&self, path: &Path) -> Result<()> {
-        fs::remove_file(path)
-            .map_err(|e| Error::FS(format!("Cannot delete file '{}' ({e})", path.display())))
+        fs::remove_file(path).map_err(|e| Error::from_fs(FsOperation::RemoveFile, path, e))
     }
 }

--- a/src/platform/os_network.rs
+++ b/src/platform/os_network.rs
@@ -5,13 +5,14 @@ use std::time::Duration;
 
 impl Network for OsSystem {
     fn connect_port(&self, port: u16, timeout: Duration) -> Result<Box<dyn ReadWrite>> {
-        let stream = TcpStream::connect(format!("127.0.0.1:{port}")).map_err(Error::from)?;
+        let stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+            .map_err(|e| Error::ConnectionFailed(port, e))?;
         stream
             .set_read_timeout(Some(timeout))
-            .map_err(Error::from)?;
+            .map_err(|e| Error::ConnectionFailed(port, e))?;
         stream
             .set_write_timeout(Some(timeout))
-            .map_err(Error::from)?;
+            .map_err(|e| Error::ConnectionFailed(port, e))?;
         Ok(Box::new(stream))
     }
 

--- a/src/qemu/qemu_monitor_client.rs
+++ b/src/qemu/qemu_monitor_client.rs
@@ -25,10 +25,10 @@ impl QemuMonitorClient {
         let socket = stream.get_mut();
         socket
             .set_read_timeout(Some(QMP_TIMEOUT))
-            .map_err(Error::from)?;
+            .map_err(|e| Error::ConnectionFailed(port, e))?;
         socket
             .set_write_timeout(Some(QMP_TIMEOUT))
-            .map_err(Error::from)?;
+            .map_err(|e| Error::ConnectionFailed(port, e))?;
 
         let mut client = QemuMonitorClient {
             counter: 0,

--- a/src/qemu/tls_client.rs
+++ b/src/qemu/tls_client.rs
@@ -14,26 +14,23 @@ pub struct TlsClient {
 
 impl TlsClient {
     pub fn new(certs: &InstanceCertPaths) -> Result<Self> {
-        let ca_der = CertificateDer::from_pem_file(&certs.ca_cert)
-            .map_err(|e| Error::TlsConnection(e.to_string()))?;
+        let ca_der = CertificateDer::from_pem_file(&certs.ca_cert).map_err(Error::from_tls)?;
 
         let mut root_store = RootCertStore::empty();
-        root_store
-            .add(ca_der)
-            .map_err(|e| Error::TlsConnection(e.to_string()))?;
+        root_store.add(ca_der).map_err(Error::from_tls)?;
 
         let client_certs = CertificateDer::pem_file_iter(&certs.client_cert)
-            .map_err(|e| Error::TlsConnection(e.to_string()))?
+            .map_err(Error::from_tls)?
             .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|e| Error::TlsConnection(e.to_string()))?;
+            .map_err(Error::from_tls)?;
 
-        let client_key = PrivateKeyDer::from_pem_file(&certs.client_key)
-            .map_err(|e| Error::TlsConnection(e.to_string()))?;
+        let client_key =
+            PrivateKeyDer::from_pem_file(&certs.client_key).map_err(Error::from_tls)?;
 
         let config = ClientConfig::builder()
             .with_root_certificates(root_store)
             .with_client_auth_cert(client_certs, client_key)
-            .map_err(|e| Error::TlsConnection(e.to_string()))?;
+            .map_err(Error::from_tls)?;
 
         Ok(Self {
             config: Arc::new(config),
@@ -41,23 +38,22 @@ impl TlsClient {
     }
 
     pub fn connect(&self, port: u16) -> Result<StreamOwned<ClientConnection, TcpStream>> {
-        let server_name =
-            ServerName::try_from("localhost").map_err(|e| Error::TlsConnection(e.to_string()))?;
-        let conn = ClientConnection::new(self.config.clone(), server_name)
-            .map_err(|e| Error::TlsConnection(e.to_string()))?;
-        let tcp = TcpStream::connect(format!("127.0.0.1:{port}")).map_err(Error::from)?;
+        let server_name = ServerName::try_from("localhost").map_err(Error::from_tls)?;
+        let conn =
+            ClientConnection::new(self.config.clone(), server_name).map_err(Error::from_tls)?;
+        let tcp = TcpStream::connect(format!("127.0.0.1:{port}"))
+            .map_err(|e| Error::ConnectionFailed(port, e))?;
         Ok(StreamOwned::new(conn, tcp))
     }
 
     pub async fn connect_async(&self, port: u16) -> Result<TlsStream<tokio::net::TcpStream>> {
-        let server_name =
-            ServerName::try_from("localhost").map_err(|e| Error::TlsConnection(e.to_string()))?;
+        let server_name = ServerName::try_from("localhost").map_err(Error::from_tls)?;
         let tcp = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
             .await
-            .map_err(Error::from)?;
+            .map_err(|e| Error::ConnectionFailed(port, e))?;
         TlsConnector::from(self.config.clone())
             .connect(server_name, tcp)
             .await
-            .map_err(|e| Error::TlsConnection(e.to_string()))
+            .map_err(Error::from_tls)
     }
 }

--- a/src/ssh/sftp_path.rs
+++ b/src/ssh/sftp_path.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::error::{Error, FsOperation, Result};
 use crate::view::{AsyncTransferView, Console, TransferView};
 use russh_sftp::{self, client::SftpSession};
 use std::cmp::max;
@@ -48,7 +48,7 @@ impl SftpPath {
             Some(sftp) => sftp
                 .try_exists(self.to_str())
                 .await
-                .map_err(|e| Error::Sftp(e.to_string())),
+                .map_err(|e| Error::from_sftp(FsOperation::ReadMetadata, self.to_str(), e)),
         }
     }
 
@@ -57,12 +57,12 @@ impl SftpPath {
             None => self
                 .path
                 .metadata()
-                .map_err(|_| Error::InvalidPath(self.to_str().to_string()))
+                .map_err(|e| Error::from_fs(FsOperation::ReadMetadata, &self.path, e))
                 .map(|metadata| metadata.len() as usize),
             Some(sftp) => sftp
                 .metadata(self.to_str())
                 .await
-                .map_err(|_| Error::InvalidPath(self.to_str().to_string()))
+                .map_err(|e| Error::from_sftp(FsOperation::ReadMetadata, self.to_str(), e))
                 .and_then(|metadata| {
                     metadata
                         .size
@@ -78,7 +78,7 @@ impl SftpPath {
             Some(sftp) => sftp
                 .metadata(self.to_str())
                 .await
-                .map_err(|_| Error::InvalidPath(self.to_str().to_string()))
+                .map_err(|e| Error::from_sftp(FsOperation::ReadMetadata, self.to_str(), e))
                 .map(|metadata| metadata.file_type().is_file()),
         }
     }
@@ -89,7 +89,7 @@ impl SftpPath {
             Some(sftp) => sftp
                 .metadata(self.to_str())
                 .await
-                .map_err(|_| Error::InvalidPath(self.to_str().to_string()))
+                .map_err(|e| Error::from_sftp(FsOperation::ReadMetadata, self.to_str(), e))
                 .map(|metadata| metadata.file_type().is_dir()),
         }
     }
@@ -107,12 +107,12 @@ impl SftpPath {
             None => tokio::fs::File::open(self.path.clone())
                 .await
                 .map(|f| Box::new(f) as Box<dyn AsyncRead + Unpin>)
-                .map_err(Error::Io),
+                .map_err(|e| Error::from_fs(FsOperation::OpenFile, &self.path, e)),
             Some(sftp) => sftp
                 .open(self.to_str())
                 .await
                 .map(|f| Box::new(f) as Box<dyn AsyncRead + Unpin>)
-                .map_err(|e| Error::Sftp(e.to_string())),
+                .map_err(|e| Error::from_sftp(FsOperation::OpenFile, self.to_str(), e)),
         }
     }
 
@@ -121,12 +121,12 @@ impl SftpPath {
             None => tokio::fs::File::create(self.path.clone())
                 .await
                 .map(|f| Box::new(f) as Box<dyn AsyncWrite + Unpin>)
-                .map_err(Error::Io),
+                .map_err(|e| Error::from_fs(FsOperation::CreateFile, &self.path, e)),
             Some(sftp) => sftp
                 .create(self.to_str())
                 .await
                 .map(|f| Box::new(f) as Box<dyn AsyncWrite + Unpin>)
-                .map_err(|e| Error::Sftp(e.to_string())),
+                .map_err(|e| Error::from_sftp(FsOperation::CreateFile, self.to_str(), e)),
         }
     }
 
@@ -144,7 +144,7 @@ impl SftpPath {
         let result = tokio::io::copy(read, &mut self.create_file().await?)
             .await
             .map(|_| ())
-            .map_err(Error::Io);
+            .map_err(|e| Error::from_fs(FsOperation::WriteFile, &self.path, e));
         console.stop();
         result
     }
@@ -166,7 +166,7 @@ impl SftpPath {
                 for entry in sftp
                     .read_dir(self.to_str())
                     .await
-                    .map_err(|e| Error::Sftp(e.to_string()))?
+                    .map_err(|e| Error::from_sftp(FsOperation::ReadDir, self.to_str(), e))?
                 {
                     children.push(Self {
                         sftp: Some(sftp.clone()),
@@ -181,11 +181,12 @@ impl SftpPath {
 
     pub async fn create_path(&self) -> Result<()> {
         match &self.sftp {
-            None => fs::create_dir(self.path.clone()).map_err(Error::Io),
+            None => fs::create_dir(self.path.clone())
+                .map_err(|e| Error::from_fs(FsOperation::CreateDir, &self.path, e)),
             Some(sftp) => sftp
                 .create_dir(self.to_str())
                 .await
-                .map_err(|e| Error::Sftp(e.to_string())),
+                .map_err(|e| Error::from_sftp(FsOperation::CreateDir, self.to_str(), e)),
         }
     }
 

--- a/src/ssh/ssh_client.rs
+++ b/src/ssh/ssh_client.rs
@@ -414,11 +414,11 @@ impl<'a> SshClient<'a> {
         channel
             .request_subsystem(true, "sftp")
             .await
-            .map_err(|error| Error::Sftp(error.to_string()))?;
+            .map_err(|error| Error::from_sftp_session(&instance.name, error))?;
         SftpSession::new(channel.into_stream())
             .await
             .map(Rc::new)
-            .map_err(|error| Error::Sftp(error.to_string()))
+            .map_err(|error| Error::from_sftp_session(&instance.name, error))
     }
 
     async fn open_target_fs(


### PR DESCRIPTION
## Summary

Errors were built as strings in two places: the file system layer formatted its own message text, and foreign errors from rcgen, rustls and toml were flattened with `to_string`. Both now live in `src/error.rs`, with one `FsOperation` template shared by the real and mock file systems, and foreign errors kept as a `#[source]` so the chain survives.

Errors that carry the data also say more. A refused connection names the port, an SFTP call names the operation and the path, and the `FS Error` prefix is gone since it doubled up with the console's own label.

The second commit fixes two message texts: a failed system command no longer suggests installing QEMU (only QEMU commands reach that error, and by then it has run), and the target path message closes its bracket.

## Related Issue(s)

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

`make test`, `make lint` and `make format` pass, and each commit builds and passes on its own.

Messages were checked against the built binary: a missing config prints `Cannot open file '/…/instance.toml' (No such file or directory (os error 2))` under the config error, a broken config shows the TOML parse error, and `cubic scp a:b:c d` shows the closed bracket.

Two tests were deleted rather than updated, both duplicates of a deserializer test that asserts the same thing.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed