### PR TITLE
ci: lint shell scripts with shellcheck

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,10 +41,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Tools
-        run: sudo apt-get update && sudo apt-get install -y yamllint
+        run: sudo apt-get update && sudo apt-get install -y yamllint shellcheck
 
       - name: Lint YAML
         run: yamllint --strict .
+
+      - name: Lint Shell Scripts
+        run: shellcheck .github/scripts/*.sh scripts/*.sh
 
   commits:
     name: Commit Messages

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt update && \
         git \
         vim \
         yamllint \
+        shellcheck \
         unzip \
         curl &&\
     curl -fsSL https://github.com/vulnlog/vulnlog/releases/download/v0.16.0/install-vulnlog.sh | sh &&\

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ fix-lint: build-image
 yamllint: build-image
 	${DOCKER_CMD} ${IMAGE} yamllint --strict .
 
+shellcheck: build-image
+	${DOCKER_CMD} ${IMAGE} shellcheck .github/scripts/*.sh scripts/*.sh
+
 test: build-image
 	${DOCKER_CMD} ${IMAGE} cargo test
 
@@ -53,7 +56,7 @@ update: build-image
 sh: build-image
 	${DOCKER_CMD} -it ${IMAGE} bash
 
-check: format lint yamllint test audit
+check: format lint yamllint shellcheck test audit
 
 fix: fix-format fix-lint
 

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -3,18 +3,18 @@ set -euo pipefail
 
 version="$1"
 
-CMDS="run create instances images ports show modify console ssh scp exec start \
-    stop restart rename clone delete prune completions"
+CMDS=(run create instances images ports show modify console ssh scp exec start \
+    stop restart rename clone delete prune completions)
 
 function generate_cmd_doc() {
     name="$1"
-    cmd="$2"
-    ref="$3"
-    file="$4"
+    ref="$2"
+    file="$3"
+    shift 3
     underline="${name//?/=}"
 
     echo -e ".. $ref:\n\n$name\n$underline\n\n.. code-block::\n\n    \$ $name --help" > "$file"
-    cargo run -- $cmd --help | sed "s/^/    /" >> "$file"
+    cargo run -- "$@" --help | sed "s/^/    /" >> "$file"
 }
 
 # Set version
@@ -24,11 +24,11 @@ sed "s/^release = .*$/release = '$version'/g" -i docs/conf.py
 mkdir -p docs/reference
 
 # Generate cubic help
-generate_cmd_doc "cubic" "" "_ref_cubic" "docs/reference/cubic.rst"
+generate_cmd_doc "cubic" "_ref_cubic" "docs/reference/cubic.rst"
 
 # Generate cubic subcommands help
-for cmd in ${CMDS}; do
-    generate_cmd_doc "cubic $cmd" "$cmd" "_ref_cubic_$cmd" "docs/reference/$cmd.rst"
+for cmd in "${CMDS[@]}"; do
+    generate_cmd_doc "cubic $cmd" "_ref_cubic_$cmd" "docs/reference/$cmd.rst" "$cmd"
 done
 
 # Generate reference/index.rst as the Command Reference landing page
@@ -42,7 +42,7 @@ Command Reference
    cubic
 REFEOF
 
-for cmd in ${CMDS}; do
+for cmd in "${CMDS[@]}"; do
     echo "   $cmd" >> docs/reference/index.rst
 done
 
@@ -83,7 +83,7 @@ Cubic
 
 EOF
 
-for cmd in ${CMDS}; do
+for cmd in "${CMDS[@]}"; do
     echo "   reference/$cmd" >> docs/index.rst
 done
 


### PR DESCRIPTION
## Summary

The lint job checked the YAML files but none of the shell scripts. This adds shellcheck to the container, to `make check` and to the lint job, mirroring the existing yamllint setup.

It found one issue. `scripts/generate-docs.sh` passed the subcommand unquoted so it would expand to nothing for the top level page. The command list becomes an array and the subcommand moves to trailing arguments, so `"$@"` stays quoted and still expands to zero words when empty.

## Related Issue(s)

Closes #471

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Test Plan

- `make shellcheck` passes over all three scripts. The same run against the previous `generate-docs.sh` fails with SC2086.
- Regenerated the docs with the new script. `git status docs/` is empty, so the output is byte identical.
- `yamllint --strict` still passes on the edited workflow.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed