### PR TITLE
feat: warn when the host is low on disk space

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ russh-sftp = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
-sysinfo = { version = "0", default-features = false, features = ["system"] }
+sysinfo = { version = "0", default-features = false, features = ["disk", "system"] }
 thiserror = "2"
 tokio = { version = "1", default-features = false, features = [
     "fs",

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -1,7 +1,7 @@
 use crate::actions::{CreateInstanceAction, LoadInstanceAction};
 use crate::commands::{Command, Context};
 use crate::error::{Error, Result};
-use crate::models::InstanceName;
+use crate::models::{InstanceName, LOW_DISK_SPACE_WARNING, ResourceAllocator};
 use crate::view::{Console, Spinner};
 use clap::Parser;
 use std::sync::{Arc, Mutex};
@@ -29,6 +29,10 @@ impl Command for CloneCommand {
         // Verify that the target name is available
         if instance_store.exists(self.new_name.as_str()) {
             return Err(Error::InstanceAlreadyExists(self.new_name.to_string()));
+        }
+
+        if ResourceAllocator::is_disk_space_low(context.get_system(), context.get_env()) {
+            console.warn(LOW_DISK_SPACE_WARNING);
         }
 
         // Load source instance info

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -4,7 +4,9 @@ use crate::commands::{
     image::{fetch_image, fetch_image_info},
 };
 use crate::error::{Error, Result};
-use crate::models::{DataSize, ImageName, Instance, PortForward, ResourceAllocator, UserName};
+use crate::models::{
+    DataSize, ImageName, Instance, LOW_DISK_SPACE_WARNING, PortForward, ResourceAllocator, UserName,
+};
 use crate::view::Console;
 use crate::view::Spinner;
 use clap::{ArgAction, Parser};
@@ -77,6 +79,10 @@ impl Command for CreateCommand {
             return Err(Error::InstanceAlreadyExists(
                 self.instance_name.value.to_string(),
             ));
+        }
+
+        if ResourceAllocator::is_disk_space_low(context.get_system(), env) {
+            console.warn(LOW_DISK_SPACE_WARNING);
         }
 
         // Fetch image

--- a/src/models/resource_allocator.rs
+++ b/src/models/resource_allocator.rs
@@ -1,5 +1,6 @@
-use crate::models::DataSize;
+use crate::models::{DataSize, Environment};
 use crate::platform::System;
+use std::path::Path;
 
 const MIB: usize = 1024 * 1024;
 const GIB: usize = 1024 * MIB;
@@ -7,6 +8,9 @@ const GIB: usize = 1024 * MIB;
 /// Memory kept aside for the host and QEMU overhead so a machine never claims
 /// all of the available memory.
 pub const HOST_MEMORY_RESERVE: usize = GIB;
+
+pub const LOW_DISK_SPACE: u64 = 5 * GIB as u64;
+pub const LOW_DISK_SPACE_WARNING: &str = "Low disk space detected on the host.";
 
 /// Decides the default vCPU count and memory for a new machine based on the
 /// resources of the host it runs on.
@@ -71,6 +75,12 @@ impl ResourceAllocator {
     pub fn get_resources_for_budget(available_bytes: usize) -> Option<(u16, DataSize)> {
         let budget = available_bytes.saturating_sub(HOST_MEMORY_RESERVE);
         (budget >= 512 * MIB).then(|| Self::resources_for_level(budget / GIB))
+    }
+
+    pub fn is_disk_space_low(system: &dyn System, env: &Environment) -> bool {
+        system
+            .get_available_space(Path::new(&env.get_instance_dir()))
+            .is_some_and(|free| free < LOW_DISK_SPACE)
     }
 
     /// Map a level to its machine size. Level N is 2N vCPUs and N GiB, and the

--- a/src/platform/file_system.rs
+++ b/src/platform/file_system.rs
@@ -6,6 +6,7 @@ pub trait FileSystem {
     fn exists_path(&self, path: &Path) -> bool;
     fn exists_dir(&self, path: &Path) -> bool;
     fn get_path_size(&self, path: &Path) -> u64;
+    fn get_available_space(&self, path: &Path) -> Option<u64>;
     fn create_dir(&self, path: &Path) -> Result<()>;
     fn create_writable_dir(&self, path: &Path) -> Result<()>;
     fn remove_dir(&self, path: &Path) -> Result<()>;

--- a/src/platform/file_system_mock.rs
+++ b/src/platform/file_system_mock.rs
@@ -202,6 +202,10 @@ impl FileSystem for SystemMock {
         self.file_system.borrow().get_path_size(path)
     }
 
+    fn get_available_space(&self, _path: &Path) -> Option<u64> {
+        None
+    }
+
     fn create_dir(&self, path: &Path) -> Result<()> {
         self.file_system.borrow_mut().add_dir(path);
         Ok(())

--- a/src/platform/os_file_system.rs
+++ b/src/platform/os_file_system.rs
@@ -31,6 +31,17 @@ impl FileSystem for OsSystem {
             .unwrap_or_default()
     }
 
+    fn get_available_space(&self, path: &Path) -> Option<u64> {
+        let path = path.canonicalize().ok()?;
+
+        sysinfo::Disks::new_with_refreshed_list()
+            .list()
+            .iter()
+            .filter(|disk| path.starts_with(disk.mount_point()))
+            .max_by_key(|disk| disk.mount_point().as_os_str().len())
+            .map(|disk| disk.available_space())
+    }
+
     fn create_dir(&self, path: &Path) -> Result<()> {
         fs::create_dir_all(path).map_err(|e| Error::from_fs(FsOperation::CreateDir, path, e))
     }


### PR DESCRIPTION
## Summary

Running out of disk space during an image download or a disk image copy used to surface as a web or `qemu-img` failure, with no hint that the disk was the problem. Create and clone now check the free space where instances live and warn before they start.

Adds `get_available_space` to the `FileSystem` trait, backed by the sysinfo `Disks` API, and `ResourceAllocator::is_disk_space_low`, which compares it against a 5 GiB floor. Unknown free space counts as fine.

## Related Issue(s)

Closes #7

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Run `make check`.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed