### PR TITLE
feat: free host disk space when files are deleted in a VM

### DIFF
--- a/docs/internals/how_it_works.rst
+++ b/docs/internals/how_it_works.rst
@@ -66,6 +66,10 @@ Cubic checks with QEMU that the accelerator works on the host and falls back to
 insist on hardware acceleration and ``--accel off`` to run in software
 emulation.
 
+Cubic attaches the instance disk with discard enabled, so files deleted inside
+the VM release their space in the host image. Cloud images mount the root
+filesystem with ``discard``, so this needs no setup inside the VM.
+
 Each instance keeps everything it owns in one directory under
 ``~/.local/share/cubic/machines/<name>/``. That directory holds the
 configuration, the disk image, the SSH key, the cloud-init seed image and,

--- a/src/actions/start_instance_action.rs
+++ b/src/actions/start_instance_action.rs
@@ -128,8 +128,8 @@ impl StartInstanceAction {
         qemu_system.set_cpus(self.instance.cpus);
         qemu_system.set_memory(self.instance.mem.get_bytes() as u64);
         qemu_system.set_console(self.instance.console_port.unwrap(), &instance_dir);
-        qemu_system.add_drive(&env.get_instance_image_file(&self.instance.name), "qcow2");
-        qemu_system.add_drive(&env.get_cloud_init_file(&self.instance.name), "raw");
+        qemu_system.add_disk(&env.get_instance_image_file(&self.instance.name));
+        qemu_system.add_iso(&env.get_cloud_init_file(&self.instance.name));
         qemu_system.set_network(
             &self.instance.hostfwd,
             self.instance.ssh_port,

--- a/src/qemu/qemu_system.rs
+++ b/src/qemu/qemu_system.rs
@@ -130,10 +130,16 @@ impl QemuSystem {
             ));
     }
 
-    pub fn add_drive(&mut self, path: &str, format: &str) {
+    pub fn add_disk(&mut self, path: &str) {
+        self.command.arg("-drive").arg(format!(
+            "if=virtio,format=qcow2,discard=unmap,detect-zeroes=unmap,file={path}"
+        ));
+    }
+
+    pub fn add_iso(&mut self, path: &str) {
         self.command
             .arg("-drive")
-            .arg(format!("if=virtio,format={format},file={path}"));
+            .arg(format!("if=virtio,format=raw,file={path}"));
     }
 
     pub fn set_qemu_args(&mut self, args: &str) {
@@ -199,6 +205,26 @@ mod tests {
                 .get_command()
                 .contains("-L /snap/cubic/current/usr/share/qemu")
         );
+    }
+
+    #[test]
+    fn test_add_disk_lets_guest_trim_free_space_in_the_image() {
+        let mut qemu = QemuSystem::from(&SystemMock::new(), Arch::AMD64).unwrap();
+        qemu.add_disk("/data/machines/test/machine.img");
+        assert!(qemu.command.get_command().contains(
+            "-drive if=virtio,format=qcow2,discard=unmap,detect-zeroes=unmap,file=/data/machines/test/machine.img"
+        ));
+    }
+
+    #[test]
+    fn test_add_iso_attaches_the_seed_without_discard() {
+        let mut qemu = QemuSystem::from(&SystemMock::new(), Arch::AMD64).unwrap();
+        qemu.add_iso("/data/machines/test/cloud-init.iso");
+        let command = qemu.command.get_command();
+        assert!(
+            command.contains("-drive if=virtio,format=raw,file=/data/machines/test/cloud-init.iso")
+        );
+        assert!(!command.contains("discard"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Deleting files in a VM never freed space on the host. The drive was attached as `if=virtio,format=qcow2,file=...`, and QEMU defaults to `discard=ignore`, so every guest TRIM was dropped and the qcow2 only grew.

Cloud images already mount the root filesystem with `discard`, so attaching the disk with `discard=unmap,detect-zeroes=unmap` is enough to make the space come back.

`add_drive` is split into `add_disk` and `add_iso` to keep the discard options on the writable disk.

## Related Issue(s)

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Unit and manual tests.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed