### PR TITLE
perf: copy the image file instead of running qemu-img convert

### DIFF
--- a/src/actions/create_instance_action.rs
+++ b/src/actions/create_instance_action.rs
@@ -31,13 +31,11 @@ impl CreateInstanceAction {
         // Create SSH key
         SshKeyGenerator::new().generate_key(system, &Path::new(tmp_dir).join("ssh_client_key"))?;
 
-        let qemu_img = QemuImg::new(system);
-
         // Create virtual machine instance image file
-        qemu_img.convert(image_path, tmp_image)?;
+        system.copy_file(Path::new(image_path), Path::new(tmp_image))?;
 
         // Set disk capacity
-        qemu_img.resize(tmp_image, instance.disk_capacity.get_bytes() as u64)?;
+        QemuImg::new(system).resize(tmp_image, instance.disk_capacity.get_bytes() as u64)?;
 
         // Write configuration file
         instance.name = format!("{instance_name}.tmp");

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -169,10 +169,7 @@ mod tests {
             .into_owned();
         let target_image = format!("{target_dir}.tmp/machine.img");
         let system = SystemMock::new()
-            .add_command_output(
-                &format!("qemu-img convert -f qcow2 -O qcow2 {source_image} {target_image}"),
-                b"",
-            )
+            .add_file(&source_image, b"qcow2 image")
             .add_command_output(&format!("qemu-img resize {target_image} 0"), b"");
         let console_system = SystemMock::new();
         let console = &mut Console::new(&console_system);

--- a/src/error.rs
+++ b/src/error.rs
@@ -164,6 +164,14 @@ Troubleshoot:
         source: io::Error,
     },
 
+    #[error("Cannot copy file from '{}' to '{}' ({source})", from.display(), to.display())]
+    CopyFile {
+        from: PathBuf,
+        to: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
     #[error("Cannot write directory '{}'", .0.display())]
     ReadOnlyDir(PathBuf),
 

--- a/src/platform/file_system.rs
+++ b/src/platform/file_system.rs
@@ -17,5 +17,6 @@ pub trait FileSystem {
     fn write_file(&self, path: &Path, contents: &[u8]) -> Result<()>;
     fn write_secret_file(&self, path: &Path, contents: &[u8]) -> Result<()>;
     fn rename_file(&self, from: &Path, to: &Path) -> Result<()>;
+    fn copy_file(&self, from: &Path, to: &Path) -> Result<()>;
     fn remove_file(&self, path: &Path) -> Result<()>;
 }

--- a/src/platform/file_system_mock.rs
+++ b/src/platform/file_system_mock.rs
@@ -284,6 +284,17 @@ impl FileSystem for SystemMock {
         }
     }
 
+    fn copy_file(&self, from: &Path, to: &Path) -> Result<()> {
+        let mut file_system = self.file_system.borrow_mut();
+        let content = file_system.get_file(from).ok_or_else(|| Error::CopyFile {
+            from: from.to_path_buf(),
+            to: to.to_path_buf(),
+            source: io::ErrorKind::NotFound.into(),
+        })?;
+        file_system.set_file(to, &content);
+        Ok(())
+    }
+
     fn remove_file(&self, path: &Path) -> Result<()> {
         self.file_system
             .borrow_mut()
@@ -487,6 +498,34 @@ mod tests {
                 .read_file_to_string(Path::new("/data/new.txt"))
                 .unwrap(),
             "hello"
+        );
+    }
+
+    #[test]
+    fn copy_file_keeps_the_source_and_writes_the_target() {
+        let system = SystemMock::new().add_file("/data/old.txt", b"hello");
+
+        system
+            .copy_file(Path::new("/data/old.txt"), Path::new("/data/new.txt"))
+            .unwrap();
+
+        assert!(system.exists_path(Path::new("/data/old.txt")));
+        assert_eq!(
+            system
+                .read_file_to_string(Path::new("/data/new.txt"))
+                .unwrap(),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn copy_file_fails_when_source_missing() {
+        let system = SystemMock::new();
+
+        assert!(
+            system
+                .copy_file(Path::new("/data/old.txt"), Path::new("/data/new.txt"))
+                .is_err()
         );
     }
 

--- a/src/platform/os_file_system.rs
+++ b/src/platform/os_file_system.rs
@@ -120,6 +120,14 @@ impl FileSystem for OsSystem {
         })
     }
 
+    fn copy_file(&self, from: &Path, to: &Path) -> Result<()> {
+        fs::copy(from, to).map(|_| ()).map_err(|e| Error::CopyFile {
+            from: from.to_path_buf(),
+            to: to.to_path_buf(),
+            source: e,
+        })
+    }
+
     fn remove_file(&self, path: &Path) -> Result<()> {
         fs::remove_file(path).map_err(|e| Error::from_fs(FsOperation::RemoveFile, path, e))
     }

--- a/src/qemu/qemu_img.rs
+++ b/src/qemu/qemu_img.rs
@@ -62,23 +62,6 @@ impl<'a> QemuImg<'a> {
         }
     }
 
-    pub fn convert(&self, src: &str, dst: &str) -> Result<()> {
-        let mut command = self.command();
-        command
-            .arg("convert")
-            .arg("-f")
-            .arg("qcow2")
-            .arg("-O")
-            .arg("qcow2")
-            .arg(src)
-            .arg(dst);
-
-        self.system
-            .run_command(&command)
-            .map(|_| ())
-            .map_err(Self::map_error)
-    }
-
     pub fn resize(&self, image: &str, size: u64) -> Result<()> {
         let mut command = self.command();
         command.arg("resize").arg(image).arg(size.to_string());
@@ -182,19 +165,6 @@ mod tests {
             system.get_executed_commands(),
             vec!["qemu-img resize /data/machines/test/image 2048"]
         );
-    }
-
-    #[test]
-    fn test_convert_reports_the_failure_of_qemu_img() {
-        let system = SystemMock::new().add_failing_command(
-            "qemu-img convert -f qcow2 -O qcow2 /cache/image /data/machines/test/image",
-            "boom",
-        );
-
-        assert!(matches!(
-            QemuImg::new(&system).convert("/cache/image", "/data/machines/test/image"),
-            Err(Error::SystemCommandFailed(_, stderr)) if stderr == "boom"
-        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Cubic ran `qemu-img convert` to build the image file of a new instance, for both `cubic create` and `cubic clone`. The convert reads and writes every block of the source. The source is already `qcow2`, so a plain file copy does the same job and is faster.

Adds `copy_file` to the `FileSystem` trait and an `Error::CopyFile` variant. `QemuImg::convert` has no caller left, so it is removed. `qemu-img` still resizes the new image and reads the disk info.

## Related Issue(s)

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Other (performance)

## Test Plan

Run `make check` and manual tests.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed