### PR TITLE
Add templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Cubic fits a lot of everyday workflows:
 - Supports **amd64** and **arm64** CPU architectures
 - Supports hardware acceleration with **KVM** (Linux), **Hypervisor** (macOS), **WHPX** (Windows) and **NVMM** (BSD)
 - Snapshot and restore the disk of a VM instance
+- Creates VM instances from reusable templates
 - Daemonless design which does not require root privileges
 - Written in Rust
 

--- a/docs/howto/templates.rst
+++ b/docs/howto/templates.rst
@@ -1,0 +1,77 @@
+.. _templates:
+
+Create VMs from a Template
+==========================
+
+A template is a TOML file with default values for a new virtual machine. It lets
+you recreate the same machine again and again without retyping a long command
+line, and it is easy to share with a friend or a customer.
+
+Write a Template
+----------------
+
+A template is a plain TOML file. Every field except ``version`` is optional and
+falls back to the Cubic default when it is left out:
+
+.. code-block::
+
+    version = 1              # mandatory
+
+    image = "debian:trixie"  # optional
+    user = "john"            # optional
+    cpus = 4                 # optional
+    memory = "4G"            # optional
+    disk = "100G"            # optional
+    isolate = false          # optional
+
+    ports = [                # optional
+      "8000:80",             # forward guest HTTP port to host TCP port 8000
+      "5353:53/udp"          # forward guest DNS port to host UDP port 5353
+    ]
+
+    run = [                  # optional, commands run once on the first boot
+      "sudo apt update",
+      "sudo apt full-upgrade -y",
+      "sudo apt install vim"
+    ]
+
+The fields use the same form as the command line, for example ``4G`` for memory
+and ``8000:80`` for a forwarded port.
+
+The ``run`` list holds shell commands that run once inside the guest on the first
+boot, so a template can install software and start services for you.
+
+Create a VM from a Template
+---------------------------
+
+Pass the template to ``cubic create`` or ``cubic run`` with ``--template``:
+
+.. code-block::
+
+    $ cubic create my-instance --template ./my-template.toml
+
+Because the template has no instance name, you can create as many machines from it
+as you like:
+
+.. code-block::
+
+    $ cubic create web-1 --template ./my-template.toml
+    $ cubic create web-2 --template ./my-template.toml
+
+Override Template Values
+------------------------
+
+Every command line argument overrides the matching value in the template. This is
+handy to reuse a template but change one detail, for example the image or the
+number of CPUs:
+
+.. code-block::
+
+    $ cubic create my-instance --template ./my-template.toml --image ubuntu:noble --cpus 8
+
+A template that sets ``isolate = true`` keeps the machine off the network. Use
+``--no-isolate`` to give a single machine network access anyway:
+
+.. code-block::
+
+    $ cubic create my-instance --template ./my-template.toml --no-isolate

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -59,6 +59,7 @@ Cubic
    howto/shell_completions
    howto/getting_started
    howto/snapshots
+   howto/templates
    howto/http_server
    howto/ssh_connect
    howto/console_login
@@ -105,6 +106,7 @@ Features
 * Supports hardware acceleration with KVM (Linux), Hypervisor (macOS), WHPX (Windows) and NVMM (BSD)
 * Boots each VM with EDK2 UEFI firmware, discovered automatically per architecture
 * Snapshots the disk of a VM instance and restores it later
+* Creates VM instances from reusable templates
 * No background privileged service and runs with standard user rights, no admin or root needed
 * Written in Rust
 

--- a/src/actions/load_instance_action.rs
+++ b/src/actions/load_instance_action.rs
@@ -1,9 +1,8 @@
 use crate::commands::{Context, DEFAULT_DISK_SIZE};
 use crate::error::{Error, Result};
-use crate::models::{Arch, DataSize, Instance, ResourceAllocator};
+use crate::models::{Arch, Instance, ResourceAllocator};
 use crate::qemu::QemuImg;
 use crate::view::Console;
-use std::str::FromStr;
 
 /// Load an instance and replace an unreadable config with a machine of the
 /// same defaults `cubic create` picks.
@@ -45,7 +44,7 @@ impl LoadInstanceAction {
             user: context.get_env().get_username().clone(),
             cpus,
             mem,
-            disk_capacity: DataSize::from_str(DEFAULT_DISK_SIZE).unwrap(),
+            disk_capacity: DEFAULT_DISK_SIZE,
             ssh_port: context.get_system().bind_port()?,
             ..Instance::default()
         };
@@ -64,6 +63,7 @@ mod tests {
     use crate::platform::{FileSystem, System, SystemMock};
     use std::path::Path;
     use std::rc::Rc;
+    use std::str::FromStr;
 
     const GIB: usize = 1024 * 1024 * 1024;
 
@@ -109,10 +109,7 @@ mod tests {
         let (cpus, mem) = ResourceAllocator::new(16 * GIB, 8).get_default_resources();
         assert_eq!(instance.cpus, cpus);
         assert_eq!(instance.mem, mem);
-        assert_eq!(
-            instance.disk_capacity,
-            DataSize::from_str(DEFAULT_DISK_SIZE).unwrap()
-        );
+        assert_eq!(instance.disk_capacity, DEFAULT_DISK_SIZE);
         assert_eq!(instance.user.as_str(), "cubic");
         assert!(instance.ssh_port > 0);
     }

--- a/src/cloudinit/user_data_factory.rs
+++ b/src/cloudinit/user_data_factory.rs
@@ -8,7 +8,7 @@ impl UserDataFactory {
         let execute = execute
             .map(|execute| {
                 format!(
-                    "bootcmd:\n\u{20}\u{20}- \"{}\"\n",
+                    "runcmd:\n\u{20}\u{20}- \"{}\"\n",
                     execute
                         .replace('\\', "\\\\")
                         .replace('"', "\\\"")
@@ -79,7 +79,7 @@ users:
 write_files:
   - path: /etc/ssh/sshd_config.d/10-cubic.conf
     content: "AcceptEnv *\n"
-bootcmd:
+runcmd:
   - "\"sudo apt install vim\""
 "#;
         assert_eq!(
@@ -96,12 +96,12 @@ bootcmd:
             Some("a\\b\t\"c\"\nd\re"),
         );
 
-        let expected_bootcmd = r#"bootcmd:
+        let expected_runcmd = r#"runcmd:
   - "a\\b\t\"c\"\nd\re"
 "#;
         assert!(
-            actual.ends_with(expected_bootcmd),
-            "\nActual: {actual}\nExpected suffix: {expected_bootcmd}\n"
+            actual.ends_with(expected_runcmd),
+            "\nActual: {actual}\nExpected suffix: {expected_runcmd}\n"
         )
     }
 }

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -5,14 +5,18 @@ use crate::commands::{
 };
 use crate::error::{Error, Result};
 use crate::models::{
-    DataSize, ImageName, Instance, LOW_DISK_SPACE_WARNING, PortForward, ResourceAllocator, UserName,
+    Arch, DataSize, Environment, ImageName, Instance, LOW_DISK_SPACE_WARNING, PortForward,
+    ResourceAllocator, Template, UserName,
 };
+use crate::platform::System;
 use crate::view::Console;
 use crate::view::Spinner;
 use clap::{ArgAction, Parser};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-pub const DEFAULT_DISK_SIZE: &str = "100G";
+/// The disk size of a new VM instance, 100 GiB.
+pub const DEFAULT_DISK_SIZE: DataSize = DataSize::new(100 * 1024_usize.pow(3));
 
 /// Create VM instances
 ///
@@ -39,14 +43,23 @@ pub const DEFAULT_DISK_SIZE: &str = "100G";
 ///   Create a VM instance without network access:
 ///   $ cubic create example6 --isolate ubuntu:noble
 ///
+///   Create a VM instance from a template (command line arguments override the template):
+///   $ cubic create example7 --template ./my-template.toml
+///
+///   Create a VM instance with network access from a template that isolates it:
+///   $ cubic create example8 --template ./my-template.toml --no-isolate
+///
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
 pub struct CreateCommand {
     #[clap(flatten)]
     pub instance_name: commands::InstanceArg,
+    /// Template file with default values (e.g. --template ./my-template.toml)
+    #[clap(short, long)]
+    template: Option<String>,
     /// VM image name (e.g. 'debian:trixie')
     #[clap(short, long)]
-    image: ImageName,
+    image: Option<ImageName>,
     /// Username (default: 'cubic')
     #[clap(short, long)]
     user: Option<UserName>,
@@ -56,18 +69,90 @@ pub struct CreateCommand {
     /// Memory amount of the VM instance (default: derived from host resources)
     #[clap(alias = "mem", short, long)]
     memory: Option<DataSize>,
-    /// Disk size of the VM instance
-    #[clap(short, long, default_value = DEFAULT_DISK_SIZE)]
-    disk: DataSize,
+    /// Disk size of the VM instance (default: 100G)
+    #[clap(short, long)]
+    disk: Option<DataSize>,
     /// Forward ports from guest to host (e.g. -p 8000:80 or -p 9000:90/tcp)
     #[clap(short, long)]
     port: Vec<PortForward>,
-    /// Execute a command once on the first boot (e.g. "sudo apt install ...")
+    /// Execute a command once on the first boot (repeatable, e.g. -e "sudo apt install ...")
     #[clap(short, long)]
-    execute: Option<String>,
+    execute: Vec<String>,
     /// Isolate the VM instance from network
-    #[clap(long, action = ArgAction::SetTrue)]
+    #[clap(long, action = ArgAction::SetTrue, conflicts_with = "no_isolate")]
     isolate: bool,
+    /// Connect the VM instance to the network, even if the template isolates it
+    #[clap(long, action = ArgAction::SetTrue)]
+    no_isolate: bool,
+}
+
+impl CreateCommand {
+    /// Reads the template, which provides default values that any command line
+    /// argument overrides.
+    fn read_template(&self, system: &dyn System) -> Result<Option<Template>> {
+        self.template
+            .as_deref()
+            .map(|path| Template::parse(&system.read_file_to_string(Path::new(path))?))
+            .transpose()
+    }
+
+    fn resolve_image(&self, template: Option<&Template>) -> Result<ImageName> {
+        self.image
+            .clone()
+            .or_else(|| template.and_then(|t| t.image.clone()))
+            .ok_or(Error::MissingImage)
+    }
+
+    fn build_instance(
+        &self,
+        template: Option<&Template>,
+        env: &Environment,
+        arch: Arch,
+        ssh_port: u16,
+        default_cpus: u16,
+        default_mem: DataSize,
+    ) -> Instance {
+        // A command list is joined so the commands run in order and stop at the first failure.
+        let commands = if self.execute.is_empty() {
+            template.map(|t| t.run.clone()).unwrap_or_default()
+        } else {
+            self.execute.clone()
+        };
+
+        Instance {
+            name: self.instance_name.value.to_string(),
+            arch,
+            user: self
+                .user
+                .clone()
+                .or_else(|| template.and_then(|t| t.user.clone()))
+                .unwrap_or_else(|| env.get_username().clone()),
+            cpus: self
+                .cpus
+                .or_else(|| template.and_then(|t| t.cpus))
+                .unwrap_or(default_cpus),
+            mem: self
+                .memory
+                .clone()
+                .or_else(|| template.and_then(|t| t.memory.clone()))
+                .unwrap_or(default_mem),
+            disk_capacity: self
+                .disk
+                .clone()
+                .or_else(|| template.and_then(|t| t.disk.clone()))
+                .unwrap_or(DEFAULT_DISK_SIZE),
+            ssh_port,
+            hostfwd: if self.port.is_empty() {
+                template.map(|t| t.ports.clone()).unwrap_or_default()
+            } else {
+                self.port.clone()
+            },
+            execute: (!commands.is_empty()).then(|| commands.join(" && ")),
+            isolate: !self.no_isolate
+                && (self.isolate || template.and_then(|t| t.isolate).unwrap_or(false)),
+            ..Instance::default()
+        }
+    }
 }
 
 impl Command for CreateCommand {
@@ -85,8 +170,11 @@ impl Command for CreateCommand {
             console.warn(LOW_DISK_SPACE_WARNING);
         }
 
+        let template = self.read_template(context.get_system())?;
+        let image_name = self.resolve_image(template.as_ref())?;
+
         // Fetch image
-        let image = &fetch_image_info(console, context.get_system(), env, &self.image)?;
+        let image = &fetch_image_info(console, context.get_system(), env, &image_name)?;
         fetch_image(console, context.get_system(), env, image)?;
 
         console.play(Arc::new(Mutex::new(Spinner::new(format!(
@@ -98,22 +186,14 @@ impl Command for CreateCommand {
         let (default_cpus, default_mem) =
             ResourceAllocator::read_from_host(context.get_system()).get_default_resources();
 
-        let instance = Instance {
-            name: self.instance_name.value.to_string(),
-            arch: image.arch,
-            user: self
-                .user
-                .clone()
-                .unwrap_or_else(|| context.get_env().get_username().clone()),
-            cpus: self.cpus.unwrap_or(default_cpus),
-            mem: self.memory.clone().unwrap_or(default_mem),
-            disk_capacity: self.disk.clone(),
+        let instance = self.build_instance(
+            template.as_ref(),
+            env,
+            image.arch,
             ssh_port,
-            hostfwd: self.port.clone(),
-            execute: self.execute.clone(),
-            isolate: self.isolate,
-            ..Instance::default()
-        };
+            default_cpus,
+            default_mem,
+        );
 
         console.debug(&format!(
             "Resolved instance '{}': {} vCPUs, {} memory, {} disk, ssh_port={}",
@@ -136,10 +216,11 @@ impl Command for CreateCommand {
 mod tests {
     use super::*;
     use crate::instance::InstanceStoreMock;
-    use crate::models::Environment;
     use crate::platform::SystemMock;
     use std::rc::Rc;
     use std::str::FromStr;
+
+    const GIB: usize = 1024_usize.pow(3);
 
     #[test]
     fn test_create_rejects_existing_instance_name() {
@@ -166,6 +247,127 @@ mod tests {
         assert!(matches!(
             result,
             Err(Error::InstanceAlreadyExists(ref name)) if name == "test"
+        ));
+    }
+
+    fn build_env() -> Environment {
+        Environment::new(
+            UserName::from_str("host-user").unwrap(),
+            String::new(),
+            String::new(),
+        )
+    }
+
+    fn build_instance_from(args: &[&str], template: Option<&Template>) -> Instance {
+        CreateCommand::try_parse_from(args).unwrap().build_instance(
+            template,
+            &build_env(),
+            Arch::AMD64,
+            22,
+            2,
+            DataSize::new(GIB),
+        )
+    }
+
+    fn build_template() -> Template {
+        Template::parse(
+            r#"
+version = 1
+image = "debian:trixie"
+user = "john"
+cpus = 4
+memory = "4G"
+disk = "200G"
+isolate = true
+ports = ["8000:80"]
+run = ["sudo apt update", "sudo apt install vim"]
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_template_fills_values_that_are_not_given_on_the_command_line() {
+        let template = build_template();
+        let instance = build_instance_from(&["create", "web"], Some(&template));
+
+        assert_eq!(instance.user.as_str(), "john");
+        assert_eq!(instance.cpus, 4);
+        assert_eq!(instance.mem.get_bytes(), 4 * GIB);
+        assert_eq!(instance.disk_capacity.get_bytes(), 200 * GIB);
+        assert_eq!(instance.hostfwd.len(), 1);
+        assert!(instance.isolate);
+        assert_eq!(
+            instance.execute,
+            Some("sudo apt update && sudo apt install vim".to_string())
+        );
+    }
+
+    #[test]
+    fn test_command_line_arguments_override_the_template() {
+        let template = build_template();
+        let instance = build_instance_from(
+            &[
+                "create",
+                "web",
+                "--user",
+                "janne",
+                "--cpus",
+                "8",
+                "--memory",
+                "2G",
+                "--disk",
+                "50G",
+                "--port",
+                "9000:90",
+                "--execute",
+                "echo hello",
+                "--no-isolate",
+            ],
+            Some(&template),
+        );
+
+        assert_eq!(instance.user.as_str(), "janne");
+        assert_eq!(instance.cpus, 8);
+        assert_eq!(instance.mem.get_bytes(), 2 * GIB);
+        assert_eq!(instance.disk_capacity.get_bytes(), 50 * GIB);
+        assert_eq!(instance.hostfwd.len(), 1);
+        assert_eq!(instance.hostfwd[0].to_qemu(), "tcp:127.0.0.1:9000-:90");
+        assert!(!instance.isolate);
+        assert_eq!(instance.execute, Some("echo hello".to_string()));
+    }
+
+    #[test]
+    fn test_defaults_apply_without_a_template() {
+        let instance = build_instance_from(&["create", "web"], None);
+
+        assert_eq!(instance.user.as_str(), "host-user");
+        assert_eq!(instance.cpus, 2);
+        assert_eq!(instance.mem.get_bytes(), GIB);
+        assert_eq!(instance.disk_capacity, DEFAULT_DISK_SIZE);
+        assert!(instance.hostfwd.is_empty());
+        assert_eq!(instance.execute, None);
+        assert!(!instance.isolate);
+    }
+
+    #[test]
+    fn test_resolve_image_prefers_the_command_line_and_needs_a_source() {
+        let template = build_template();
+        let resolve = |args: &[&str], template: Option<&Template>| {
+            CreateCommand::try_parse_from(args)
+                .unwrap()
+                .resolve_image(template)
+        };
+
+        let image = resolve(&["create", "web", "-i", "ubuntu:noble"], Some(&template)).unwrap();
+        assert_eq!(image.get_name(), "noble");
+
+        let image = resolve(&["create", "web"], Some(&template)).unwrap();
+        assert_eq!(image.get_name(), "trixie");
+
+        assert!(matches!(
+            resolve(&["create", "web"], None),
+            Err(Error::MissingImage)
         ));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,23 @@ pub enum Error {
     #[error("No instance name was given.\n\nProvide at least one instance name.")]
     MissingInstanceName,
 
+    // Templates
+    #[error("The template is invalid.\n\n{0}")]
+    InvalidTemplate(String),
+
+    #[error("The template has no version.\n\nAdd a version to the template: `version = 1`")]
+    MissingTemplateVersion,
+
+    #[error(
+        "Template version '{0}' is not supported by this version of cubic.\n\nPlease upgrade cubic or set a supported template version (1)."
+    )]
+    UnsupportedTemplateVersion(u32),
+
+    #[error(
+        "No image was specified.\n\nProvide an image with --image or set 'image' in the template."
+    )]
+    MissingImage,
+
     #[error(
         "Instance name '{0}' is already taken.\n\nOptions:\n  - Choose a different name\n  - Connect to existing instance: `cubic ssh {0}`"
     )]

--- a/src/models.rs
+++ b/src/models.rs
@@ -13,6 +13,7 @@ mod snapshot_name;
 mod target;
 mod target_instance_path;
 mod target_path;
+mod template;
 mod user_name;
 
 pub use arch::*;
@@ -30,4 +31,5 @@ pub use snapshot_name::*;
 pub use target::*;
 pub use target_instance_path::*;
 pub use target_path::*;
+pub use template::*;
 pub use user_name::*;

--- a/src/models/data_size.rs
+++ b/src/models/data_size.rs
@@ -7,7 +7,7 @@ pub struct DataSize {
 }
 
 impl DataSize {
-    pub fn new(bytes: usize) -> Self {
+    pub const fn new(bytes: usize) -> Self {
         Self { bytes }
     }
 

--- a/src/models/template.rs
+++ b/src/models/template.rs
@@ -1,0 +1,145 @@
+use crate::error::{Error, Result};
+use crate::models::{DataSize, ImageName, PortForward, UserName};
+use serde::{Deserialize, Deserializer, de};
+use std::fmt::Display;
+use std::str::FromStr;
+
+const SUPPORTED_TEMPLATE_VERSIONS: &[u32] = &[1];
+
+/// Default values for a new instance, loaded from a user written TOML file.
+///
+/// Typed fields (image, memory, ports, ...) are parsed from their human friendly
+/// command line form (e.g. "4G", "8000:80"), not the on-disk instance config form,
+/// so a template reads the same way a `cubic create` command line does.
+#[derive(Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Template {
+    pub version: Option<u32>,
+    #[serde(deserialize_with = "Template::deserialize_from_str_opt")]
+    pub image: Option<ImageName>,
+    #[serde(deserialize_with = "Template::deserialize_from_str_opt")]
+    pub user: Option<UserName>,
+    pub cpus: Option<u16>,
+    #[serde(deserialize_with = "Template::deserialize_from_str_opt")]
+    pub memory: Option<DataSize>,
+    #[serde(deserialize_with = "Template::deserialize_from_str_opt")]
+    pub disk: Option<DataSize>,
+    pub isolate: Option<bool>,
+    #[serde(deserialize_with = "Template::deserialize_from_str_vec")]
+    pub ports: Vec<PortForward>,
+    pub run: Vec<String>,
+}
+
+impl Template {
+    pub fn parse(content: &str) -> Result<Template> {
+        let template: Template =
+            toml::from_str(content).map_err(|error| Error::InvalidTemplate(error.to_string()))?;
+
+        let version = template.version.ok_or(Error::MissingTemplateVersion)?;
+
+        if !SUPPORTED_TEMPLATE_VERSIONS.contains(&version) {
+            return Err(Error::UnsupportedTemplateVersion(version));
+        }
+
+        Ok(template)
+    }
+
+    fn deserialize_from_str_opt<'de, D, T>(
+        deserializer: D,
+    ) -> std::result::Result<Option<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: FromStr,
+        T::Err: Display,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|value| T::from_str(&value).map_err(de::Error::custom))
+            .transpose()
+    }
+
+    fn deserialize_from_str_vec<'de, D, T>(deserializer: D) -> std::result::Result<Vec<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: FromStr,
+        T::Err: Display,
+    {
+        Vec::<String>::deserialize(deserializer)?
+            .iter()
+            .map(|value| T::from_str(value).map_err(de::Error::custom))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_full_template() {
+        let template = Template::parse(
+            r#"
+version = 1
+image = "debian:trixie"
+user = "john"
+cpus = 4
+memory = "4G"
+disk = "100G"
+isolate = true
+ports = ["8000:80", "5353:53/udp"]
+run = ["sudo apt update", "sudo apt install vim"]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(template.image.unwrap().get_name(), "trixie");
+        assert_eq!(template.user.unwrap().as_str(), "john");
+        assert_eq!(template.cpus, Some(4));
+        assert_eq!(template.memory.unwrap().get_bytes(), 4 * 1024_usize.pow(3));
+        assert_eq!(template.disk.unwrap().get_bytes(), 100 * 1024_usize.pow(3));
+        assert_eq!(template.isolate, Some(true));
+        assert_eq!(template.ports.len(), 2);
+        assert_eq!(template.run, ["sudo apt update", "sudo apt install vim"]);
+    }
+
+    /// An omitted field must fall back instead of failing the whole parse.
+    #[test]
+    fn test_parse_leaves_omitted_fields_unset() {
+        let template = Template::parse("version = 1\nimage = \"ubuntu:noble\"\n").unwrap();
+
+        assert_eq!(template.image.unwrap().get_name(), "noble");
+        assert_eq!(template.cpus, None);
+        assert!(template.run.is_empty());
+    }
+
+    #[test]
+    fn test_parse_rejects_an_unknown_field_and_an_invalid_value() {
+        for content in [
+            "version = 1\nunknown = 1\n",
+            "version = 1\nports = [\"not-a-port\"]\n",
+            "version = \"1\"\n",
+        ] {
+            assert!(matches!(
+                Template::parse(content),
+                Err(Error::InvalidTemplate(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn test_parse_rejects_missing_version() {
+        assert!(matches!(
+            Template::parse("image = \"ubuntu:noble\"\n"),
+            Err(Error::MissingTemplateVersion)
+        ));
+    }
+
+    #[test]
+    fn test_parse_rejects_unsupported_versions() {
+        for version in [0, 2, 10] {
+            assert!(matches!(
+                Template::parse(&format!("version = {version}\n")),
+                Err(Error::UnsupportedTemplateVersion(actual)) if actual == version
+            ));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds template support to `cubic create` and `cubic run`. A template is a TOML file holding default values for a new VM instance, so a setup can be written once, reused, and shared instead of retyping a long command line. It covers the image, machine size, forwarded ports and commands that run on the first boot, and every command line argument overrides the matching template value.

```toml
version = 1

image = "debian:trixie"
cpus = 4
memory = "4G"
ports = ["8000:80"]

run = [
  "sudo apt update",
  "sudo apt install -y apache2",
]
```

```
$ cubic create my-instance --template ./my-template.toml
```

This follows the design agreed in the issue thread. The template carries no instance name, so one file can create many machines. `--image` is now optional, since the template can supply it, and `-e/--execute` is repeatable to mirror the template's `run` list. A `--no-isolate` argument was added so a template that sets `isolate = true` can still be overridden from the command line, keeping the override rule true for every field.

The branch also carries a separate fix. The first boot command reached cloud-init as `bootcmd`, which cloud-init runs on every boot, so a package install repeated on each start. It is now passed as `runcmd` and runs once, matching what the flag has always documented.

## Related Issue(s)

Closes #287

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Test Plan

`make check` passes locally.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed