### PR TITLE
perf: speed up the first boot of a VM instance

### DIFF
--- a/src/cloudinit/user_data_factory.rs
+++ b/src/cloudinit/user_data_factory.rs
@@ -28,6 +28,8 @@ impl UserDataFactory {
             \u{20}\u{20}\u{20}\u{20}ssh_authorized_keys: [{pubkey}]\n\
             \u{20}\u{20}\u{20}\u{20}shell: /bin/bash\n\
             \u{20}\u{20}\u{20}\u{20}sudo: ALL=(ALL) NOPASSWD:ALL\n\
+            resize_rootfs: noblock\n\
+            ssh_genkeytypes: [ed25519]\n\
             write_files:\n\
             \u{20}\u{20}- path: /etc/ssh/sshd_config.d/10-cubic.conf\n\
             \u{20}\u{20}\u{20}\u{20}content: \"AcceptEnv *\\n\"\n\
@@ -52,6 +54,8 @@ users:
     ssh_authorized_keys: [pubkey]
     shell: /bin/bash
     sudo: ALL=(ALL) NOPASSWD:ALL
+resize_rootfs: noblock
+ssh_genkeytypes: [ed25519]
 write_files:
   - path: /etc/ssh/sshd_config.d/10-cubic.conf
     content: "AcceptEnv *\n"
@@ -76,6 +80,8 @@ users:
     ssh_authorized_keys: [pubkey]
     shell: /bin/bash
     sudo: ALL=(ALL) NOPASSWD:ALL
+resize_rootfs: noblock
+ssh_genkeytypes: [ed25519]
 write_files:
   - path: /etc/ssh/sshd_config.d/10-cubic.conf
     content: "AcceptEnv *\n"


### PR DESCRIPTION
## Summary

Cloud init generated an RSA, an ECDSA and an ed25519 host key on the first boot of every VM instance, and sshd could not start until all three existed. The seed now asks for an ed25519 key alone, which is the only key cubic ever uses, because it pins whatever key the guest offers on the first connect. The root filesystem also grows in the background now instead of blocking the cloud init network stage, since cubic always resizes the disk on create and that work always has something to do.

Together this takes about two and a half seconds off the time until a new VM instance answers on SSH.

This only affects instances created after the change. The seed image is written once and never refreshed, so existing instances keep their current configuration.

## Related Issue(s)

None

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Other (performance)

## Test Plan

Measured on ubuntu:noble with 2 vCPUs, 1G of memory and KVM, timing from `cubic start` until the guest greets on the forwarded SSH port, three runs per configuration.

| | before | after |
| --- | --- | --- |
| time to SSH greeting, median | 20.97s | 18.48s |
| config-ssh | 1.442s | 0.023s |
| config-resizefs | 0.622s | 0.004s |

Per module numbers come from `cloud-init analyze blame` in the guest.

Verified on a fresh instance created with `-e "touch /tmp/first-boot-ran"` that `cloud-init status` reports `done`, that the first boot command ran once, that `/etc/ssh/` holds the ed25519 host key alone, that the default user has passwordless sudo, and that the root filesystem still reached 96G even though the resize no longer blocks.

Two alternatives were measured and rejected because they made no difference. Giving the root disk an explicit `bootindex` and attaching the seed read only did not change the firmware time. Adding a writable UEFI variable store did not change it either. The remaining four seconds before the kernel starts are firmware, shim and GRUB, and only a direct kernel boot removes them.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed