### PR TITLE
fix: end an ssh session without waiting for a key press

### DIFF
--- a/src/util/async_caller.rs
+++ b/src/util/async_caller.rs
@@ -1,19 +1,29 @@
 pub struct AsyncCaller {
-    runtime: tokio::runtime::Runtime,
+    runtime: Option<tokio::runtime::Runtime>,
 }
 
 impl AsyncCaller {
     pub fn new() -> Self {
         Self {
-            runtime: tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap(),
+            runtime: Some(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap(),
+            ),
         }
     }
 
     pub fn call<F: Future>(&self, future: F) -> F::Output {
-        self.runtime.block_on(future)
+        self.runtime.as_ref().unwrap().block_on(future)
+    }
+}
+
+impl Drop for AsyncCaller {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            runtime.shutdown_background();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Closing an SSH session left cubic running until the user pressed a key. Dropping a tokio runtime waits for its blocking tasks to finish, and the stdin read behind `tokio::io::stdin()` can never be cancelled, so the process sat in that wait after the remote end had already closed. The async caller now shuts its runtime down on drop instead of waiting for it.

This restores the behaviour the async caller had before b29b171, which removed the explicit `shutdown_background()` call when `call` started serving two invocations per command. The same hang affected `cubic console`, which uses the same stdin relay, and it is fixed by the same change.

Tokio documents this trap on `tokio::io::stdin` and it has been open upstream for years in tokio-rs/tokio#589 and tokio-rs/tokio#2466.

## Related Issue(s)

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

`make test`, `make lint` and `make format` pass locally.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed