### PR TITLE
docs: reformulate the feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 Cubic spins up Linux virtual machines on Linux, macOS and Windows with a single
 command.
 
-Every distribution comes as a prebuilt cloud image and is ready to use within
+Every distribution comes as an official image and is ready to use within
 seconds, so you skip the long installation. Cubic keeps things simple and secure
 by acting as lightweight glue over proven tools. No privileged system service is
-required and every VM runs as your normal user, so you never need admin or root
-rights.
-Cubic is built on top of `QEMU`, `EDK2`, official cloud images and `cloud-init`.
+required and every VM runs as your normal user.
+Cubic is built on top of `QEMU`, `EDK2`, official Linux distribution images and
+`cloud-init`.
 
 ![Cubic Demo](docs/cubic.gif)
 
@@ -24,7 +24,7 @@ One command takes you from nothing to a shell inside a fresh Linux VM. The image
 are official and verified, downloaded straight from each distribution. Every
 machine is a real VM, so you get stronger isolation than containers can offer.
 The same workflow runs on Linux, macOS and Windows across amd64 and arm64.
-No privileged system service is required and you never need admin or root rights.
+No privileged system service is required and every VM runs as your normal user.
 
 Cubic fits a lot of everyday workflows:
 
@@ -38,23 +38,35 @@ Cubic fits a lot of everyday workflows:
 
 # 🔥 Features
 
-- Simple command-line interface
-- Supports the following guest OS:
-  - **Alma Linux**
-  - **Arch Linux**
-  - **Debian**
-  - **Fedora**
-  - **Gentoo**
-  - **OpenSUSE**
-  - **Rocky Linux**
-  - **Ubuntu**
-- Supports the following host OS: **Linux**, **macOS**, **Windows**
-- Supports **amd64** and **arm64** CPU architectures
-- Supports hardware acceleration with **KVM** (Linux), **Hypervisor** (macOS), **WHPX** (Windows) and **NVMM** (BSD)
-- Snapshot and restore the disk of a VM instance
-- Creates VM instances from reusable templates
-- Daemonless design which does not require root privileges
+**Fast and simple**
+
+- Creates a VM and opens a shell in one command
+- Boots official Linux distribution images in seconds
 - Written in Rust
+
+**Runs anywhere**
+
+- Runs on **Linux**, **macOS** and **Windows** hosts
+- Ships **Alma Linux**, **Arch Linux**, **Debian**, **Fedora**, **Gentoo**, **OpenSUSE**, **Rocky Linux** and **Ubuntu**
+- Runs **amd64** and **arm64** guests
+- Accelerates every VM with **KVM** (Linux), **Hypervisor** (macOS) and **WHPX** (Windows)
+
+**Everyday work**
+
+- Forwards ports from a VM to the host
+- Copies files between host and VM and between two VMs
+- Executes single commands in a VM
+- Creates VM instances from reusable templates
+- Snapshots a VM disk and restores it later
+- Clones and renames VM instances
+- Isolates a VM from the network with one flag
+
+**Safe by default**
+
+- Runs every VM as a normal user process without a privileged system service
+- Verifies every image against the checksum of the distribution
+- Protects every VM with its own SSH key and a locked password
+- Encrypts the QEMU control channels with mutual TLS
 
 # 🚀 Quick Start
 
@@ -137,12 +149,11 @@ $ cubic --help
 Cubic runs Linux virtual machines on Linux, macOS and Windows with a single
 command.
 
-Every distribution comes as a prebuilt cloud image and is ready to use within
+Every distribution comes as an official image and is ready to use within
 seconds, so you skip the long installation. Cubic keeps things simple and secure
 by acting as lightweight glue over proven tools. No privileged system service is
-required and every VM runs as your normal user, so you never need admin or root
-rights. Cubic is built on top of QEMU, EDK2, official cloud images and
-cloud-init.
+required and every VM runs as your normal user. Cubic is built on top of QEMU,
+EDK2, official Linux distribution images and cloud-init.
 
 Examples:
 
@@ -237,7 +248,7 @@ drives to run every VM.
 | getrandom | Secure randomness for SSH key generation |
 | regex | Parse image and instance names and scrape image version listings |
 | rcgen | Generate the per-instance self-signed certificates for QEMU mTLS |
-| reqwest | Download cloud images over HTTPS |
+| reqwest | Download official Linux distribution images over HTTPS |
 | russh | Pure-Rust SSH client to connect into VMs |
 | russh-sftp | SFTP file transfer over the SSH connection |
 | rustls | TLS for the QEMU mTLS control channel |

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cubic - Linux VMs in one command</title>
-  <meta name="description" content="Cubic spins up Linux virtual machines on Linux, macOS and Windows with a single command. Prebuilt cloud images, no root required, built on QEMU.">
+  <meta name="description" content="Cubic spins up Linux virtual machines on Linux, macOS and Windows with a single command. Official Linux distribution images, no privileged system service, built on QEMU.">
   <link rel="icon" href="logo-mark.svg" type="image/svg+xml">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Cubic - Linux VMs in one command">
-  <meta property="og:description" content="Cubic spins up Linux virtual machines on Linux, macOS and Windows with a single command. Prebuilt cloud images, no root required, built on QEMU.">
+  <meta property="og:description" content="Cubic spins up Linux virtual machines on Linux, macOS and Windows with a single command. Official Linux distribution images, no privileged system service, built on QEMU.">
   <meta property="og:url" content="https://cubic-vm.github.io/cubic/">
   <meta property="og:image" content="https://cubic-vm.github.io/cubic/cubic.gif">
   <meta name="twitter:card" content="summary_large_image">
@@ -228,12 +228,12 @@
         a single command.
       </p>
       <p class="intro">
-        Every distribution comes as a prebuilt cloud image and is ready to use
+        Every distribution comes as an official image and is ready to use
         within seconds, so you skip the long installation. Cubic keeps things
         simple and secure by acting as lightweight glue over proven tools. No
         privileged system service is required and every VM runs as your normal
-        user, so you never need admin or root rights. Cubic is built on top of
-        QEMU, EDK2, official cloud images and cloud-init.
+        user. Cubic is built on top of QEMU, EDK2, official Linux distribution
+        images and cloud-init.
       </p>
       <div class="cta">
         <a class="btn btn-primary" href="https://github.com/cubic-vm/cubic" target="_blank" rel="noopener">GitHub</a>

--- a/docs/internals/how_it_works.rst
+++ b/docs/internals/how_it_works.rst
@@ -1,14 +1,14 @@
 How Cubic Works
 ===============
 
-Cubic is intentionally simple. It has no background daemon, requires no root
-privileges, and builds on four established tools: official cloud images,
-cloud-init, QEMU, and EDK2 UEFI firmware.
+Cubic is intentionally simple. It has no background service, needs no extra
+privileges, and builds on four established tools: official Linux distribution
+images, cloud-init, QEMU, and EDK2 UEFI firmware.
 
 What Happens When You Run Cubic
 --------------------------------
 
-1. **Download** — Cubic fetches the official cloud image for the chosen
+1. **Download** — Cubic fetches the official image for the chosen
    distribution directly from the vendor's mirror. The image is
    checksum-verified and cached locally under ``~/.cache/cubic/images/`` so
    subsequent instances reuse it without re-downloading.
@@ -22,11 +22,11 @@ What Happens When You Run Cubic
    subsequent boots cloud-init detects that provisioning is complete and does
    not run again.
 
-4. **Run** — QEMU launches the VM directly from the CLI. No daemon is involved
-   — Cubic is a process that starts QEMU and exits.
+4. **Run** — QEMU launches the VM directly from the CLI. No background service
+   is involved — Cubic is a process that starts QEMU and exits.
 
-Cloud Images
-------------
+Distribution Images
+-------------------
 
 Cubic always uses official, unmodified images downloaded directly from the
 vendor. Images are fetched from each distribution's own mirror (Ubuntu, Debian,
@@ -59,7 +59,6 @@ line and executes it directly. Every platform has one hardware accelerator:
 * **KVM** on Linux
 * **HVF** (Hypervisor Framework) on macOS
 * **WHPX** on Windows
-* **NVMM** on the BSDs
 
 Cubic checks with QEMU that the accelerator works on the host and falls back to
 **TCG** software emulation when it does not. Use ``cubic start --accel on`` to
@@ -67,7 +66,7 @@ insist on hardware acceleration and ``--accel off`` to run in software
 emulation.
 
 Cubic attaches the instance disk with discard enabled, so files deleted inside
-the VM release their space in the host image. Cloud images mount the root
+the VM release their space in the host image. Official images mount the root
 filesystem with ``discard``, so this needs no setup inside the VM.
 
 Each instance keeps everything it owns in one directory under
@@ -79,21 +78,22 @@ from each other and from the shared image cache.
 UEFI Firmware (EDK2)
 --------------------
 
-Cloud images boot through UEFI, so Cubic boots every VM with `EDK2
+Official images boot through UEFI, so Cubic boots every VM with `EDK2
 <https://github.com/tianocore/edk2>`_ UEFI firmware. Cubic finds the firmware
 automatically in the host's QEMU installation and picks the right build for the
 guest architecture. When the firmware lives somewhere unusual you can point Cubic
 at it with the ``CUBIC_QEMU_FW_AMD64`` and ``CUBIC_QEMU_FW_ARM64`` environment
 variables. See :ref:`qemu detection` for details.
 
-Daemonless and Rootless Security
----------------------------------
+Security Without a Privileged Service
+-------------------------------------
 
-Most VM managers require a background daemon running as root or a privileged
-helper. Cubic does not. Every ``cubic`` invocation
-is a short-lived CLI process that starts or stops a QEMU process owned by the
-current user and then exits.
+Most VM managers require a background service that runs with system wide
+privileges. Cubic does not. Every ``cubic`` invocation is a short-lived CLI
+process that starts or stops a QEMU process owned by the current user and then
+exits.
 
 Because QEMU runs in the user's context with no elevated privileges, a
-compromised guest VM cannot escalate to root on the host. The security boundary
-is enforced by the operating system's normal user isolation.
+compromised guest VM cannot gain system wide privileges on the host. The
+security boundary is enforced by the operating system's normal user
+isolation.

--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -15,24 +15,24 @@ Cubic is designed with three security goals in mind:
    over any network the host is connected to.
 
 To meet these goals Cubic keeps the amount of trusted code small. It runs
-without a background service, it never asks for root rights, and it
+without a background service, it never asks for extra privileges, and it
 authenticates every connection that reaches a virtual machine.
 
-Daemonless and Rootless Design
-------------------------------
+No Privileged System Service
+----------------------------
 
-Many virtual machine managers rely on a background service that runs as root.
-Cubic does not. Each time you run a cubic command it starts a short lived
-process that launches or stops a QEMU process owned by your own user account,
-and then it exits.
+Many virtual machine managers rely on a background service that runs with
+system wide privileges. Cubic does not. Each time you run a cubic command it
+starts a short lived process that launches or stops a QEMU process owned by your
+own user account, and then it exits.
 
 Because QEMU runs as your normal user with no extra rights, a guest that breaks
-out of its virtual machine cannot gain root access on the host. Any such escape
-stays inside your own user account, where the operating system keeps it isolated
-from other users in the usual way.
+out of its virtual machine cannot gain system wide privileges on the host. Any
+such escape stays inside your own user account, where the operating system keeps
+it isolated from other users in the usual way.
 
-Verified Cloud Images
----------------------
+Verified Distribution Images
+----------------------------
 
 Cubic only uses official images that come straight from each distribution.
 Before an image is used, Cubic compares it against the checksum that the vendor
@@ -67,8 +67,9 @@ separation comes from the authentication on each connection, which the sections
 below describe.
 
 By default a guest still has outbound access so it can install packages and
-reach the internet. Starting a machine with ``--isolate`` cuts off this outbound
-access for workloads that should stay fully contained.
+reach the internet. Creating a machine with ``--isolate`` cuts off this outbound
+access for workloads that should stay fully contained. You can also turn it on
+and off later with ``cubic modify --isolate`` and ``cubic modify --no-isolate``.
 
 Port Forwarding
 ---------------
@@ -143,15 +144,8 @@ Keeping Instances Apart
 Everything that belongs to a virtual machine, including its SSH private key, its
 TLS certificates, its disk images and its cloud-init seed image, is stored under
 your own data directory, for example ``~/.local/share/cubic/machines/<name>/``
-on Linux. Reaching a running machine therefore comes down to two things: the
-file permissions on that directory, and holding the SSH key or the TLS client
+on Linux. Reaching a running machine means holding the SSH key or the TLS client
 certificate that is kept inside it.
-
-Cubic currently relies on the file permissions that the operating system applies
-by default. Restricting the private keys and certificates so that only their
-owner can read them, and the instance directories so that only their owner can
-enter them, would make this protection independent of how each user's system is
-configured.
 
 Security Issues
 ---------------

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -94,21 +94,41 @@ cat >> docs/index.rst << 'EOF'
 
 Cubic spins up Linux virtual machines on Linux, macOS and Windows with a single command.
 
-Every distribution comes as a prebuilt cloud image and is ready to use within seconds, so you skip the long installation. Cubic keeps things simple and secure by acting as lightweight glue over proven tools. No privileged system service is required and every VM runs as your normal user, so you never need admin or root rights.
-Cubic is built on top of ``QEMU``, ``EDK2``, official cloud images and ``cloud-init``.
+Every distribution comes as an official image and is ready to use within seconds, so you skip the long installation. Cubic keeps things simple and secure by acting as lightweight glue over proven tools. No privileged system service is required and every VM runs as your normal user.
+Cubic is built on top of ``QEMU``, ``EDK2``, official Linux distribution images and ``cloud-init``.
 
 Features
 ---------
-* Simple command-line interface
-* Supports Alma Linux, Arch Linux, Debian, Fedora, Gentoo, OpenSUSE, Rocky Linux and Ubuntu guest images
-* Uses official, checksum-verified cloud images downloaded straight from each distribution
-* Supports Linux, macOS and Windows hosts with amd64 and arm64 architecture
-* Supports hardware acceleration with KVM (Linux), Hypervisor (macOS), WHPX (Windows) and NVMM (BSD)
-* Boots each VM with EDK2 UEFI firmware, discovered automatically per architecture
-* Snapshots the disk of a VM instance and restores it later
-* Creates VM instances from reusable templates
-* No background privileged service and runs with standard user rights, no admin or root needed
+
+**Fast and simple**
+
+* Creates a VM and opens a shell in one command
+* Boots official Linux distribution images in seconds
 * Written in Rust
+
+**Runs anywhere**
+
+* Runs on **Linux**, **macOS** and **Windows** hosts
+* Ships **Alma Linux**, **Arch Linux**, **Debian**, **Fedora**, **Gentoo**, **OpenSUSE**, **Rocky Linux** and **Ubuntu**
+* Runs **amd64** and **arm64** guests
+* Accelerates every VM with **KVM** (Linux), **Hypervisor** (macOS) and **WHPX** (Windows)
+
+**Everyday work**
+
+* Forwards ports from a VM to the host
+* Copies files between host and VM and between two VMs
+* Executes single commands in a VM
+* Creates VM instances from reusable templates
+* Snapshots a VM disk and restores it later
+* Clones and renames VM instances
+* Isolates a VM from the network with one flag
+
+**Safe by default**
+
+* Runs every VM as a normal user process without a privileged system service
+* Verifies every image against the checksum of the distribution
+* Protects every VM with its own SSH key and a locked password
+* Encrypts the QEMU control channels with mutual TLS
 
 Source Code
 ===========

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,12 +10,11 @@ description: |
   Cubic spins up Linux virtual machines on Linux, macOS and Windows with a
   single command.
 
-  Every distribution comes as a prebuilt cloud image and is ready to use within
+  Every distribution comes as an official image and is ready to use within
   seconds, so you skip the long installation. Cubic keeps things simple and
   secure by acting as lightweight glue over proven tools. No privileged system
-  service is required and every VM runs as your normal user, so you never need
-  admin or root rights. Cubic is built on top of QEMU, EDK2, official cloud
-  images and cloud-init.
+  service is required and every VM runs as your normal user. Cubic is built on
+  top of QEMU, EDK2, official Linux distribution images and cloud-init.
 base: core24
 platforms:
   amd64:

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -46,12 +46,11 @@ const ABOUT: &str = "\
 Cubic runs Linux virtual machines on Linux, macOS and Windows with a single
 command.
 
-Every distribution comes as a prebuilt cloud image and is ready to use within
+Every distribution comes as an official image and is ready to use within
 seconds, so you skip the long installation. Cubic keeps things simple and secure
 by acting as lightweight glue over proven tools. No privileged system service is
-required and every VM runs as your normal user, so you never need admin or root
-rights. Cubic is built on top of QEMU, EDK2, official cloud images and
-cloud-init.
+required and every VM runs as your normal user. Cubic is built on top of QEMU,
+EDK2, official Linux distribution images and cloud-init.
 
 Examples:
 


### PR DESCRIPTION
## Summary

Rewrites the feature list in the README and on the documentation home page so it ranks what matters. The old list was flat and unordered, led with a generic claim any CLI tool could make, and spent four lines on the guest distribution names before reaching anything distinctive.

The features are now grouped into fast and simple, runs anywhere, everyday work and safe by default, in that order, so a reader who scans for five seconds comes away with speed and simplicity first.

The list also shows what Cubic already does but never advertised. The whole security story is new to the README: images verified against the checksum published by each distribution, a per VM SSH key with a locked guest password, and the QEMU monitor and console protected with mutual TLS. Port forwarding, network isolation, file copy and single command execution are new to the list as well.

Wording is aligned across every user facing surface, so the README, the `--help` output, the landing page, the documentation home and the Snap Store description all say the same thing. The list says official Linux distribution images so nobody reads it as needing a cloud, and privileged system service so the wording fits Linux, macOS and Windows equally.

The internals pages follow the same wording, the isolate flag is documented on the commands that actually offer it, and the instance section focuses on what protects a running machine.

The features list on the documentation home page lives in `scripts/generate-docs.sh`, since `docs/index.rst` is generated and gitignored.

## Related Issue(s)

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Test Plan

- `make format`, `make lint`, `make yamllint`, `make shellcheck` and `make test` pass locally. 492 tests, 0 failures.
- `sphinx-build docs` builds clean. The only warning is the pre-existing one about `docs/reference/index.rst`.
- Regenerated `docs/index.rst` with `scripts/generate-docs.sh` and confirmed it matches the intended content, so the generator is the source of truth.
- Confirmed the `--help` block in the README matches real `cargo run -- --help` output byte for byte.
- Confirmed the README list and the documentation home list are identical, bullet for bullet.
- Checked every feature claim against the source, including the checksum verification in `src/image/image_fetcher.rs`, the per instance key in `src/ssh/ssh_key_generator.rs`, the mutual TLS in `src/qemu/qemu_system.rs`, and the isolate flag in `src/commands/create_command.rs` and `src/commands/modify_command.rs`.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed