### PR TITLE
feat: add image tags and a bare distro shortcut

### DIFF
--- a/docs/howto/environment_variables.rst
+++ b/docs/howto/environment_variables.rst
@@ -17,7 +17,7 @@ Create the Virtual Machine
 
 .. code-block::
 
-    $ cubic create builder --image ubuntu:noble
+    $ cubic create builder --image ubuntu
 
 Start the Virtual Machine
 --------------------------

--- a/docs/howto/getting_started.rst
+++ b/docs/howto/getting_started.rst
@@ -13,21 +13,34 @@ You can list all supported distributions with:
 .. code-block::
 
     $ cubic images
-    Name                       Arch         Size   Cached
-    almalinux:9                amd64   554.8 MiB       no
-    archlinux:latest           amd64   530.6 MiB       no
-    debian:{12, bookworm}      amd64   426.8 MiB       no
-    fedora:43                  amd64   556.3 MiB       no
-    gentoo:latest              amd64     1.7 GiB       no
-    opensuse:15.6              amd64   690.1 MiB       no
-    rockylinux:10              amd64   519.8 MiB       no
-    ubuntu:{22.04, jammy}      amd64   295.6 MiB       no
+    Name                Tags                       Arch         Size   Cached
+    almalinux:10        stable, latest             amd64   547.0 MiB       no
+    archlinux:rolling   stable, latest             amd64   530.8 MiB       no
+    debian:13           trixie, stable, latest     amd64   413.6 MiB       no
+    fedora:44           stable, latest             amd64   556.7 MiB       no
+    gentoo:rolling      stable, latest             amd64     1.6 GiB       no
+    opensuse:15.6       stable, latest             amd64   694.9 MiB       no
+    rockylinux:10       stable, latest             amd64   519.8 MiB       no
+    ubuntu:26.04        resolute, stable, latest   amd64   407.8 MiB       no
     [...]
 
 The list above is shortened to one release per distribution.
 Run the command to see every image.
 By default Cubic only lists images for the architecture of your host.
 Add ``--all`` to see the other architectures too.
+
+Use the name of a row or swap its version for one of its tags, so
+``ubuntu:26.04``, ``ubuntu:resolute`` and ``ubuntu:latest`` are the same image.
+Every distribution carries the same two tags.
+The tag ``latest`` is the newest release.
+The tag ``stable`` is the newest long term release, so the last LTS for Ubuntu
+and the current stable for Debian.
+A rolling release such as ``archlinux:rolling`` has no version and uses the same
+image for both.
+A plain distribution name is a shortcut for ``stable``, so ``--image ubuntu``
+gives you the last LTS.
+Both tags keep working release after release, so you never have to edit a
+version into your scripts.
 
 Create the Virtual Machine
 --------------------------
@@ -36,7 +49,7 @@ In the next step you can create the virtual machine with a single command:
 
 .. code-block::
 
-    $ cubic create example --image debian:bookworm
+    $ cubic create example --image debian
 
 List all Virtual Machines
 -------------------------
@@ -62,7 +75,7 @@ For example to create a virtual machine with 4 CPU cores, 4 GiB of memory and 10
 
 .. code-block::
 
-    $ cubic create example --image debian:bookworm --cpus 4 --memory 4G --disk 10G
+    $ cubic create example --image debian --cpus 4 --memory 4G --disk 10G
 
 
 Start the virtual machine

--- a/docs/howto/templates.rst
+++ b/docs/howto/templates.rst
@@ -17,7 +17,7 @@ falls back to the Cubic default when it is left out:
 
     version = 1              # mandatory
 
-    image = "debian:trixie"  # optional
+    image = "debian"         # optional
     user = "john"            # optional
     cpus = 4                 # optional
     memory = "4G"            # optional
@@ -67,7 +67,7 @@ number of CPUs:
 
 .. code-block::
 
-    $ cubic create my-instance --template ./my-template.toml --image ubuntu:noble --cpus 8
+    $ cubic create my-instance --template ./my-template.toml --image ubuntu --cpus 8
 
 A template that sets ``isolate = true`` keeps the machine off the network. Use
 ``--no-isolate`` to give a single machine network access anyway:

--- a/docs/internals/how_it_works.rst
+++ b/docs/internals/how_it_works.rst
@@ -9,7 +9,7 @@ What Happens When You Run Cubic
 --------------------------------
 
 1. **Download** — Cubic fetches the official image for the chosen
-   distribution directly from the vendor's mirror. The image is
+   distribution directly from the distro's mirror. The image is
    checksum-verified and cached locally under ``~/.cache/cubic/images/`` so
    subsequent instances reuse it without re-downloading.
 
@@ -29,7 +29,7 @@ Distribution Images
 -------------------
 
 Cubic always uses official, unmodified images downloaded directly from the
-vendor. Images are fetched from each distribution's own mirror (Ubuntu, Debian,
+distro. Images are fetched from each distribution's own mirror (Ubuntu, Debian,
 Fedora, Arch Linux, and others) and checksum-verified before use. The cached
 image under ``~/.cache/cubic/images/`` is shared across instances of the same
 distribution and version so it is only downloaded once.

--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -35,7 +35,7 @@ Verified Distribution Images
 ----------------------------
 
 Cubic only uses official images that come straight from each distribution.
-Before an image is used, Cubic compares it against the checksum that the vendor
+Before an image is used, Cubic compares it against the checksum that the distro
 publishes next to it, using either SHA256 or SHA512. If the value does not
 match, Cubic rejects the download and stops with an ``InvalidChecksum`` error.
 
@@ -44,7 +44,7 @@ machine. The verified image is cached under ``~/.cache/cubic/images/`` and
 shared by every virtual machine that uses the same distribution and version, so
 it only needs to be fetched and checked once.
 
-In the future Cubic could go one step further and verify a vendor signature over
+In the future Cubic could go one step further and verify a distro signature over
 the checksum file. That would remove the need to trust the connection to the
 mirror at all.
 

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -55,12 +55,12 @@ EDK2, official Linux distribution images and cloud-init.
 Examples:
 
   Create a new VM instance with:
-  $ cubic create example --image ubuntu:noble
+  $ cubic create example --image ubuntu
   Open a shell in the VM instance:
   $ cubic ssh example
 
   Alternatively, use `run` to execute the above commands in a single command:
-  $ cubic run example --image ubuntu:noble
+  $ cubic run example --image ubuntu
 
   Show all supported VM images:
   $ cubic images

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -29,25 +29,29 @@ pub const DEFAULT_DISK_SIZE: DataSize = DataSize::new(100 * 1024_usize.pow(3));
 ///   $ cubic create example1 --cpus 8 --memory 10G --disk 200G -i debian:trixie
 ///
 ///   Create a VM instance and forward the instance's HTTP port to the host port 8000:
-///   $ cubic create example2 --port 8000:80 -i ubuntu:noble
+///   $ cubic create example2 --port 8000:80 -i ubuntu
 ///
 ///   Create a VM instance and forward the instance's DNS port to the host port 5353:
-///   $ cubic create example3 --port 5353:53/udp -i ubuntu:noble
+///   $ cubic create example3 --port 5353:53/udp -i ubuntu
 ///
 ///   Create a VM instance with multiple port forwarding rules:
-///   $ cubic create example4 -p 8000:80/tcp -p 5353:53/udp -i ubuntu:noble
+///   $ cubic create example4 -p 8000:80/tcp -p 5353:53/udp -i ubuntu:latest
 ///
 ///   Create a VM instance and install Vim:
-///   $ cubic create example5 -e "sudo apt install -y vim" -i ubuntu:noble
+///   $ cubic create example5 -e "sudo apt install -y vim" -i ubuntu
 ///
 ///   Create a VM instance without network access:
-///   $ cubic create example6 --isolate ubuntu:noble
+///   $ cubic create example6 --isolate ubuntu
 ///
 ///   Create a VM instance from a template (command line arguments override the template):
 ///   $ cubic create example7 --template ./my-template.toml
 ///
 ///   Create a VM instance with network access from a template that isolates it:
 ///   $ cubic create example8 --template ./my-template.toml --no-isolate
+///
+///   Every distribution has the tags latest and stable. The tag latest is the
+///   newest release and the tag stable is the newest long term release. A plain
+///   name is a shortcut for stable, so --image ubuntu gives you the last LTS.
 ///
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
@@ -57,7 +61,7 @@ pub struct CreateCommand {
     /// Template file with default values (e.g. --template ./my-template.toml)
     #[clap(short, long)]
     template: Option<String>,
-    /// VM image name (e.g. 'debian:trixie')
+    /// VM image name (e.g. 'debian:trixie', 'debian:latest' or 'debian')
     #[clap(short, long)]
     image: Option<ImageName>,
     /// Username (default: 'cubic')

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -29,7 +29,7 @@ pub fn fetch_image_info(
 ) -> Result<Image> {
     console.play(Arc::new(Mutex::new(Spinner::new(format!(
         "Looking up image {}:{}",
-        image.get_vendor(),
+        image.get_distro(),
         image.get_name()
     )))));
     let image = ImageFactory::new(system, env).find_image(console, image);
@@ -72,7 +72,7 @@ mod tests {
             String::new(),
         );
         let image = Image {
-            vendor: "debian".to_string(),
+            distro: "debian".to_string(),
             names: vec!["12".to_string(), "bookworm".to_string()],
             arch: Arch::AMD64,
             image_url: String::new(),

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -73,7 +73,9 @@ mod tests {
         );
         let image = Image {
             distro: "debian".to_string(),
-            names: vec!["12".to_string(), "bookworm".to_string()],
+            version: "12".to_string(),
+            codename: Some("bookworm".to_string()),
+            tags: Vec::new(),
             arch: Arch::AMD64,
             image_url: String::new(),
             checksum_url: String::new(),

--- a/src/commands/list_image_command.rs
+++ b/src/commands/list_image_command.rs
@@ -10,16 +10,23 @@ use clap::Parser;
 /// Examples:
 ///
 ///   $ cubic images
-///   Name                Arch         Size   Cached
-///   archlinux:rolling   amd64   530.8 MiB       no
-///   debian:12           amd64   428.7 MiB       no
-///   debian:13           amd64   413.6 MiB      yes
-///   fedora:43           amd64   556.3 MiB       no
-///   fedora:44           amd64   556.7 MiB       no
+///   Name                Tags                       Arch         Size   Cached
+///   archlinux:rolling   stable, latest             amd64   530.8 MiB       no
+///   debian:12           bookworm                   amd64   428.7 MiB       no
+///   debian:13           trixie, stable, latest     amd64   413.6 MiB      yes
+///   fedora:43                                      amd64   556.3 MiB       no
+///   fedora:44           stable, latest             amd64   556.7 MiB       no
 ///   [...]
-///   ubuntu:25.10        amd64   394.2 MiB       no
-///   ubuntu:26.04        amd64   407.8 MiB      yes
+///   ubuntu:25.10        questing                   amd64   394.2 MiB       no
+///   ubuntu:26.04        resolute, stable, latest   amd64   407.8 MiB      yes
 ///   [...]
+///
+///   Use the name of a row or swap its version for one of its tags, so
+///   ubuntu:26.04, ubuntu:resolute and ubuntu:latest are the same image.
+///   Every distribution carries two extra tags. The tag latest is the newest
+///   release and the tag stable is the newest long term release, which is the
+///   last LTS for Ubuntu and the current stable for Debian. A rolling release
+///   such as archlinux:rolling has no version and uses the same image for both.
 ///
 ///
 #[derive(Parser)]
@@ -36,6 +43,7 @@ impl Command for ListImageCommand {
         let mut view = TableView::new();
         view.add_row()
             .add("Name", Alignment::Left)
+            .add("Tags", Alignment::Left)
             .add("Arch", Alignment::Left)
             .add("Size", Alignment::Right)
             .add("Cached", Alignment::Right);
@@ -52,6 +60,7 @@ impl Command for ListImageCommand {
 
             view.add_row()
                 .add(&image.get_image_name(), Alignment::Left)
+                .add(&image.get_tags(), Alignment::Left)
                 .add(&image.arch.to_string(), Alignment::Left)
                 .add(&size, Alignment::Right)
                 .add(

--- a/src/commands/list_image_command.rs
+++ b/src/commands/list_image_command.rs
@@ -10,24 +10,15 @@ use clap::Parser;
 /// Examples:
 ///
 ///   $ cubic images
-///   Name                       Arch         Size   Cached
-///   archlinux:latest           amd64   518.7 MiB       no
-///   debian:{12, bookworm}      amd64   424.2 MiB       no
-///   debian:{11, bullseye}      amd64   343.8 MiB       no
-///   debian:{10, buster}        amd64   301.7 MiB       no
-///   debian:{13, trixie}        amd64   412.0 MiB      yes
-///   fedora:41                  amd64   468.9 MiB       no
-///   fedora:42                  amd64   507.6 MiB       no
-///   fedora:43                  amd64   556.3 MiB       no
-///   opensuse:15.5              amd64   643.1 MiB       no
+///   Name                Arch         Size   Cached
+///   archlinux:rolling   amd64   530.8 MiB       no
+///   debian:12           amd64   428.7 MiB       no
+///   debian:13           amd64   413.6 MiB      yes
+///   fedora:43           amd64   556.3 MiB       no
+///   fedora:44           amd64   556.7 MiB       no
 ///   [...]
-///   opensuse:15.6              amd64   682.7 MiB       no
-///   [...]
-///   rockylinux:10              amd64   548.8 MiB       no
-///   rockylinux:8               amd64     1.9 GiB       no
-///   rockylinux:9               amd64   618.8 MiB       no
-///   [...]
-///   ubuntu:{24.04, noble}      amd64   250.4 MiB      yes
+///   ubuntu:25.10        amd64   394.2 MiB       no
+///   ubuntu:26.04        amd64   407.8 MiB      yes
 ///   [...]
 ///
 ///
@@ -60,7 +51,7 @@ impl Command for ListImageCommand {
                 .unwrap_or_default();
 
             view.add_row()
-                .add(&image.get_image_names(), Alignment::Left)
+                .add(&image.get_image_name(), Alignment::Left)
                 .add(&image.arch.to_string(), Alignment::Left)
                 .add(&size, Alignment::Right)
                 .add(

--- a/src/commands/run_command.rs
+++ b/src/commands/run_command.rs
@@ -14,19 +14,23 @@ use clap::{self, Parser};
 ///   $ cubic run example1 --cpus 8 --memory 10G --disk 200G -i debian:trixie
 ///
 ///   Run a VM instance and forward the instance's HTTP port to the host port 8000:
-///   $ cubic run example2 --port 8000:80 -i ubuntu:noble
+///   $ cubic run example2 --port 8000:80 -i ubuntu
 ///
 ///   Run a VM instance and forward the instance's DNS port to the host port 5353:
-///   $ cubic run example3 --port 5353:53/udp -i ubuntu:noble
+///   $ cubic run example3 --port 5353:53/udp -i ubuntu
 ///
 ///   Run a VM instance with multiple port forwarding rules:
-///   $ cubic run example4 -p 8000:80/tcp -p 5353:53/udp -i ubuntu:noble
+///   $ cubic run example4 -p 8000:80/tcp -p 5353:53/udp -i ubuntu:latest
 ///
 ///   Run a VM instance and install Vim:
-///   $ cubic run example5 -e "sudo apt install -y vim" -i ubuntu:noble
+///   $ cubic run example5 -e "sudo apt install -y vim" -i ubuntu
 ///
 ///   Run a VM instance without network access:
-///   $ cubic run example6 --isolate ubuntu:noble
+///   $ cubic run example6 --isolate ubuntu
+///
+///   Every distribution has the tags latest and stable. The tag latest is the
+///   newest release and the tag stable is the newest long term release. A plain
+///   name is a shortcut for stable, so --image ubuntu gives you the last LTS.
 ///
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -37,10 +37,12 @@ use clap::Parser;
 ///   SSH:          ssh -i .../trixie/ssh_client_key -p 54315 cubic@localhost
 ///
 ///   Show information of a VM image
-///   $ cubic show ubuntu:noble
-///   Name:         ubuntu:{24.04, noble}
+///   A plain name is an instance, so an image needs a name or a tag
+///   $ cubic show ubuntu:latest
+///   Name:         ubuntu:26.04
+///   Tags:         resolute, stable, latest
 ///   Architecture: amd64
-///   Size:         512.0 MiB
+///   Size:         407.8 MiB
 ///   Cached:       yes
 ///
 ///   Show all image information, adding checksum, file path and URLs
@@ -56,7 +58,10 @@ use clap::Parser;
 #[clap(verbatim_doc_comment)]
 pub struct ShowCommand {
     /// Name of the virtual machine image or instance
-    name: Either<ImageName, InstanceName>,
+    ///
+    /// A plain name is an instance. An image needs a name or a tag,
+    /// for example ubuntu:latest.
+    name: Either<InstanceName, ImageName>,
 
     #[clap(flatten)]
     all: commands::AllInfoArg,
@@ -65,13 +70,13 @@ pub struct ShowCommand {
 impl Command for ShowCommand {
     fn run(&self, console: &mut Console<'_>, context: &commands::Context) -> Result<()> {
         match &self.name {
-            Either::Left(name) => commands::ShowImageCommand {
-                name: name.clone(),
+            Either::Left(instance) => commands::ShowInstanceCommand {
+                instance: instance.clone().into(),
                 all: self.all.value.into(),
             }
             .run(console, context),
-            Either::Right(instance) => commands::ShowInstanceCommand {
-                instance: instance.clone().into(),
+            Either::Right(name) => commands::ShowImageCommand {
+                name: name.clone(),
                 all: self.all.value.into(),
             }
             .run(console, context),

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -23,6 +23,7 @@ impl Command for ShowImageCommand {
 
         let mut view = MapView::new();
         view.add("Name", &image.get_image_name());
+        view.add("Tags", &image.get_tags());
         view.add("Architecture", &image.arch.to_string());
         if let Some(size) = image.size {
             view.add("Size", &DataSize::new(size as usize).to_size());

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -22,7 +22,7 @@ impl Command for ShowImageCommand {
         let image = fetch_image_info(console, context.get_system(), env, &self.name)?;
 
         let mut view = MapView::new();
-        view.add("Name", &image.get_image_names());
+        view.add("Name", &image.get_image_name());
         view.add("Architecture", &image.arch.to_string());
         if let Some(size) = image.size {
             view.add("Size", &DataSize::new(size as usize).to_size());

--- a/src/image/almalinux_image_provider.rs
+++ b/src/image/almalinux_image_provider.rs
@@ -22,10 +22,6 @@ impl ImageProvider for AlmaLinuxImageProvider {
         format!("{name}/cloud/{arch_name}/images/",)
     }
 
-    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
-        vec![name.to_string()]
-    }
-
     fn get_image_file_pattern(&self, name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
         format!("AlmaLinux-{name}-GenericCloud-latest.{arch_name}.qcow2")

--- a/src/image/almalinux_image_provider.rs
+++ b/src/image/almalinux_image_provider.rs
@@ -5,7 +5,7 @@ use crate::util;
 pub struct AlmaLinuxImageProvider {}
 
 impl ImageProvider for AlmaLinuxImageProvider {
-    fn get_vendor(&self) -> &str {
+    fn get_distro(&self) -> &str {
         "almalinux"
     }
 

--- a/src/image/archlinux_image_provider.rs
+++ b/src/image/archlinux_image_provider.rs
@@ -4,7 +4,7 @@ use crate::models::{Arch, HashAlg};
 pub struct ArchLinuxImageProvider {}
 
 impl ImageProvider for ArchLinuxImageProvider {
-    fn get_vendor(&self) -> &str {
+    fn get_distro(&self) -> &str {
         "archlinux"
     }
 

--- a/src/image/archlinux_image_provider.rs
+++ b/src/image/archlinux_image_provider.rs
@@ -1,5 +1,5 @@
 use crate::image::ImageProvider;
-use crate::models::{Arch, HashAlg};
+use crate::models::{Arch, HashAlg, Image};
 
 pub struct ArchLinuxImageProvider {}
 
@@ -20,8 +20,8 @@ impl ImageProvider for ArchLinuxImageProvider {
         "latest/".to_string()
     }
 
-    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
-        vec![name.to_string()]
+    fn get_version(&self, _image_file: &str, _name: &str) -> String {
+        Image::ROLLING.to_string()
     }
 
     fn get_image_file_pattern(&self, _name: &str, arch: Arch) -> String {

--- a/src/image/debian_image_provider.rs
+++ b/src/image/debian_image_provider.rs
@@ -4,14 +4,6 @@ use crate::util;
 
 pub struct DebianImageProvider {}
 
-impl DebianImageProvider {
-    fn get_version_from_content(&self, content: &str) -> Option<String> {
-        util::find_and_extract(r"debian-([^-]+)-generic-[^.]+.qcow2", content)
-            .into_iter()
-            .next()
-    }
-}
-
 impl ImageProvider for DebianImageProvider {
     fn get_distro(&self) -> &str {
         "debian"
@@ -29,13 +21,15 @@ impl ImageProvider for DebianImageProvider {
         format!("{name}/latest/")
     }
 
-    fn get_image_names(&self, image_file: &str, name: &str) -> Vec<String> {
-        let mut names = Vec::new();
-        if let Some(version) = self.get_version_from_content(image_file) {
-            names.push(version);
-        }
-        names.push(name.to_string());
-        names
+    fn get_version(&self, image_file: &str, name: &str) -> String {
+        util::find_and_extract(r"debian-([^-]+)-generic-[^.]+.qcow2", image_file)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| name.to_string())
+    }
+
+    fn get_codename(&self, name: &str) -> Option<String> {
+        Some(name.to_string())
     }
 
     fn get_image_file_pattern(&self, _name: &str, arch: Arch) -> String {
@@ -70,10 +64,16 @@ mod tests {
     }
 
     #[test]
-    fn test_get_image_names_extracts_version() {
+    fn test_get_version_and_codename() {
+        let provider = DebianImageProvider {};
+
         assert_eq!(
-            DebianImageProvider {}.get_image_names("debian-12-generic-amd64.qcow2", "bookworm"),
-            ["12", "bookworm"]
+            provider.get_version("debian-12-generic-amd64.qcow2", "bookworm"),
+            "12"
+        );
+        assert_eq!(
+            provider.get_codename("bookworm"),
+            Some("bookworm".to_string())
         );
     }
 

--- a/src/image/debian_image_provider.rs
+++ b/src/image/debian_image_provider.rs
@@ -13,7 +13,7 @@ impl DebianImageProvider {
 }
 
 impl ImageProvider for DebianImageProvider {
-    fn get_vendor(&self) -> &str {
+    fn get_distro(&self) -> &str {
         "debian"
     }
 

--- a/src/image/fedora_image_provider.rs
+++ b/src/image/fedora_image_provider.rs
@@ -5,7 +5,7 @@ use crate::util;
 pub struct FedoraImageProvider {}
 
 impl ImageProvider for FedoraImageProvider {
-    fn get_vendor(&self) -> &str {
+    fn get_distro(&self) -> &str {
         "fedora"
     }
 

--- a/src/image/fedora_image_provider.rs
+++ b/src/image/fedora_image_provider.rs
@@ -25,10 +25,6 @@ impl ImageProvider for FedoraImageProvider {
         format!("{name}/Cloud/{arch_name}/images/",)
     }
 
-    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
-        vec![name.to_string()]
-    }
-
     fn get_image_file_pattern(&self, name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
         format!("Fedora-Cloud-Base-Generic-{name}-.*.{arch_name}.qcow2")

--- a/src/image/gentoo_image_provider.rs
+++ b/src/image/gentoo_image_provider.rs
@@ -4,7 +4,7 @@ use crate::models::{Arch, HashAlg};
 pub struct GentooImageProvider {}
 
 impl ImageProvider for GentooImageProvider {
-    fn get_vendor(&self) -> &str {
+    fn get_distro(&self) -> &str {
         "gentoo"
     }
 
@@ -45,7 +45,7 @@ mod tests {
     use regex::Regex;
 
     #[test]
-    fn test_get_image_dir_path_uses_vendor_arch() {
+    fn test_get_image_dir_path_uses_distro_arch() {
         assert_eq!(
             GentooImageProvider {}.get_image_dir_path("latest", Arch::AMD64),
             "amd64/autobuilds/current-di-amd64-cloudinit/"

--- a/src/image/gentoo_image_provider.rs
+++ b/src/image/gentoo_image_provider.rs
@@ -1,5 +1,5 @@
 use crate::image::ImageProvider;
-use crate::models::{Arch, HashAlg};
+use crate::models::{Arch, HashAlg, Image};
 
 pub struct GentooImageProvider {}
 
@@ -21,8 +21,8 @@ impl ImageProvider for GentooImageProvider {
         format!("{arch_name}/autobuilds/current-di-{arch_name}-cloudinit/")
     }
 
-    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
-        vec![name.to_string()]
+    fn get_version(&self, _image_file: &str, _name: &str) -> String {
+        Image::ROLLING.to_string()
     }
 
     fn get_image_file_pattern(&self, _name: &str, arch: Arch) -> String {

--- a/src/image/image_cache.rs
+++ b/src/image/image_cache.rs
@@ -100,7 +100,8 @@ mod tests {
 
 [[images]]
 distro = "testdistro"
-names = ["testversion", "testcodename"]
+version = "testversion"
+codename = "testcodename"
 arch = "AMD64"
 image_url = "imageurl"
 checksum_url = "checksumurl"
@@ -108,7 +109,8 @@ hash_alg = "Sha256"
 
 [[images]]
 distro = "testdistro2"
-names = ["testversion2", "testcodename2"]
+version = "testversion2"
+codename = "testcodename2"
 arch = "ARM64"
 image_url = "imageurl2"
 checksum_url = "checksumurl2"
@@ -121,13 +123,15 @@ hash_alg = "Sha512"
         assert_eq!(cache.timestamp, 5000);
         assert_eq!(cache.images.len(), 2);
         assert_eq!(cache.images[0].distro, "testdistro");
-        assert_eq!(cache.images[0].names, ["testversion", "testcodename"]);
+        assert_eq!(cache.images[0].get_version(), "testversion");
+        assert_eq!(cache.images[0].get_name(), "testcodename");
         assert_eq!(cache.images[0].arch, Arch::AMD64);
         assert_eq!(cache.images[0].image_url, "imageurl");
         assert_eq!(cache.images[0].checksum_url, "checksumurl");
         assert_eq!(cache.images[0].hash_alg, HashAlg::Sha256);
         assert_eq!(cache.images[1].distro, "testdistro2");
-        assert_eq!(cache.images[1].names, ["testversion2", "testcodename2"]);
+        assert_eq!(cache.images[1].get_version(), "testversion2");
+        assert_eq!(cache.images[1].get_name(), "testcodename2");
         assert_eq!(cache.images[1].arch, Arch::ARM64);
         assert_eq!(cache.images[1].image_url, "imageurl2");
         assert_eq!(cache.images[1].checksum_url, "checksumurl2");
@@ -141,7 +145,9 @@ hash_alg = "Sha512"
         ImageCache {
             images: vec![Image {
                 distro: "testdistro".to_string(),
-                names: vec!["testversion".to_string(), "testcodename".to_string()],
+                version: "testversion".to_string(),
+                codename: Some("testcodename".to_string()),
+                tags: Vec::new(),
                 arch: Arch::AMD64,
                 image_url: "imageurl".to_string(),
                 checksum_url: "checksumurl".to_string(),
@@ -159,7 +165,8 @@ hash_alg = "Sha512"
 
 [[images]]
 distro = "testdistro"
-names = ["testversion", "testcodename"]
+version = "testversion"
+codename = "testcodename"
 arch = "AMD64"
 image_url = "imageurl"
 checksum_url = "checksumurl"
@@ -173,7 +180,9 @@ hash_alg = "Sha256"
         let system = crate::platform::SystemMock::new();
         let cache = ImageCache::new(vec![Image {
             distro: "testdistro".to_string(),
-            names: vec!["testversion".to_string()],
+            version: "testversion".to_string(),
+            codename: Some("testcodename".to_string()),
+            tags: Vec::new(),
             arch: Arch::AMD64,
             image_url: "imageurl".to_string(),
             checksum_url: "checksumurl".to_string(),

--- a/src/image/image_cache.rs
+++ b/src/image/image_cache.rs
@@ -99,7 +99,7 @@ mod tests {
             r#"timestamp = 5000
 
 [[images]]
-vendor = "testvendor"
+distro = "testdistro"
 names = ["testversion", "testcodename"]
 arch = "AMD64"
 image_url = "imageurl"
@@ -107,7 +107,7 @@ checksum_url = "checksumurl"
 hash_alg = "Sha256"
 
 [[images]]
-vendor = "testvendor2"
+distro = "testdistro2"
 names = ["testversion2", "testcodename2"]
 arch = "ARM64"
 image_url = "imageurl2"
@@ -120,13 +120,13 @@ hash_alg = "Sha512"
         let cache = ImageCache::deserialize(reader).unwrap();
         assert_eq!(cache.timestamp, 5000);
         assert_eq!(cache.images.len(), 2);
-        assert_eq!(cache.images[0].vendor, "testvendor");
+        assert_eq!(cache.images[0].distro, "testdistro");
         assert_eq!(cache.images[0].names, ["testversion", "testcodename"]);
         assert_eq!(cache.images[0].arch, Arch::AMD64);
         assert_eq!(cache.images[0].image_url, "imageurl");
         assert_eq!(cache.images[0].checksum_url, "checksumurl");
         assert_eq!(cache.images[0].hash_alg, HashAlg::Sha256);
-        assert_eq!(cache.images[1].vendor, "testvendor2");
+        assert_eq!(cache.images[1].distro, "testdistro2");
         assert_eq!(cache.images[1].names, ["testversion2", "testcodename2"]);
         assert_eq!(cache.images[1].arch, Arch::ARM64);
         assert_eq!(cache.images[1].image_url, "imageurl2");
@@ -140,7 +140,7 @@ hash_alg = "Sha512"
 
         ImageCache {
             images: vec![Image {
-                vendor: "testvendor".to_string(),
+                distro: "testdistro".to_string(),
                 names: vec!["testversion".to_string(), "testcodename".to_string()],
                 arch: Arch::AMD64,
                 image_url: "imageurl".to_string(),
@@ -158,7 +158,7 @@ hash_alg = "Sha512"
             r#"timestamp = 1000
 
 [[images]]
-vendor = "testvendor"
+distro = "testdistro"
 names = ["testversion", "testcodename"]
 arch = "AMD64"
 image_url = "imageurl"
@@ -172,7 +172,7 @@ hash_alg = "Sha256"
     fn test_write_to_file_then_read_from_file_round_trips() {
         let system = crate::platform::SystemMock::new();
         let cache = ImageCache::new(vec![Image {
-            vendor: "testvendor".to_string(),
+            distro: "testdistro".to_string(),
             names: vec!["testversion".to_string()],
             arch: Arch::AMD64,
             image_url: "imageurl".to_string(),

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -88,7 +88,7 @@ impl<'a> ImageFactory<'a> {
                         .unwrap_or(true)
                     {
                         Some(Image {
-                            vendor: image_provider.get_vendor().to_string(),
+                            distro: image_provider.get_distro().to_string(),
                             names,
                             arch,
                             image_url,
@@ -146,7 +146,7 @@ impl<'a> ImageFactory<'a> {
     ) -> Vec<Image> {
         let mut images = IMAGE_PROVIDERS
             .iter()
-            .filter(|p| filter.is_none() || filter.as_ref().unwrap().get_vendor() == p.get_vendor())
+            .filter(|p| filter.is_none() || filter.as_ref().unwrap().get_distro() == p.get_distro())
             .flat_map(|provider| {
                 Self::get_images_from_provider(console, web, *provider, filter.clone())
             })
@@ -159,7 +159,7 @@ impl<'a> ImageFactory<'a> {
         images
             .iter()
             .find(|image| {
-                image.vendor == filter.get_vendor()
+                image.distro == filter.get_distro()
                     && image.arch == filter.get_arch()
                     && image.names.contains(&filter.get_name().to_string())
             })
@@ -236,9 +236,9 @@ mod tests {
     use crate::models::HashAlg;
     use std::str::FromStr;
 
-    fn build_image(vendor: &str, names: &[&str], arch: Arch) -> Image {
+    fn build_image(distro: &str, names: &[&str], arch: Arch) -> Image {
         Image {
-            vendor: vendor.to_string(),
+            distro: distro.to_string(),
             names: names.iter().map(|n| n.to_string()).collect(),
             arch,
             image_url: "image_url".to_string(),
@@ -249,7 +249,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_matching_image_matches_vendor_arch_and_name() {
+    fn test_find_matching_image_matches_distro_arch_and_name() {
         let images = vec![
             build_image("almalinux", &["9"], Arch::AMD64),
             build_image("debian", &["12", "bookworm"], Arch::AMD64),
@@ -262,7 +262,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_matching_image_returns_none_on_vendor_mismatch() {
+    fn test_find_matching_image_returns_none_on_distro_mismatch() {
         let images = vec![build_image("debian", &["12", "bookworm"], Arch::AMD64)];
         let filter = ImageName::from_str("ubuntu:bookworm:amd64").unwrap();
 

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -99,6 +99,38 @@ impl<'a> ImageFactory<'a> {
         }
     }
 
+    /// Derive the stable and latest tag of every distro and arch. Tags follow
+    /// from the version list, so they are never stored and never go stale.
+    fn tag_images(mut images: Vec<Image>) -> Vec<Image> {
+        images.sort();
+
+        for image_provider in IMAGE_PROVIDERS {
+            for arch in [Arch::AMD64, Arch::ARM64] {
+                let is_in_group = |image: &Image| {
+                    image.distro == image_provider.get_distro() && image.arch == arch
+                };
+                let versions = images
+                    .iter()
+                    .filter(|image| is_in_group(image))
+                    .map(|image| image.get_version().to_string())
+                    .collect::<Vec<_>>();
+                let latest = versions.last().cloned();
+                let stable = image_provider.find_stable_version(&versions);
+
+                for image in images.iter_mut().filter(|image| is_in_group(image)) {
+                    if stable.as_deref() == Some(image.get_version()) {
+                        image.tags.push(Image::STABLE_TAG.into());
+                    }
+                    if latest.as_deref() == Some(image.get_version()) {
+                        image.tags.push(Image::LATEST_TAG.into());
+                    }
+                }
+            }
+        }
+
+        images
+    }
+
     fn get_images_from_provider(
         console: &mut Console<'_>,
         web: &mut WebClient,
@@ -190,6 +222,8 @@ impl<'a> ImageFactory<'a> {
             }
         };
 
+        let images = Self::tag_images(images);
+
         Ok(match &filter {
             Some(name) => Self::find_matching_image(&images, name)
                 .into_iter()
@@ -231,6 +265,53 @@ mod tests {
             hash_alg: HashAlg::Sha256,
             size: None,
         }
+    }
+
+    #[test]
+    fn test_tag_images_tags_the_newest_and_the_newest_lts() {
+        let images = vec![
+            build_image("ubuntu", "24.04", Some("noble"), Arch::AMD64),
+            build_image("ubuntu", "25.10", Some("questing"), Arch::AMD64),
+            build_image("ubuntu", "25.04", Some("plucky"), Arch::AMD64),
+        ];
+
+        let images = ImageFactory::tag_images(images);
+
+        assert_eq!(images[0].get_tags(), "noble, stable");
+        assert_eq!(images[1].get_tags(), "plucky");
+        assert_eq!(images[2].get_tags(), "questing, latest");
+    }
+
+    #[test]
+    fn test_tag_images_tags_each_arch_on_its_own() {
+        let images = vec![
+            build_image("ubuntu", "24.04", Some("noble"), Arch::AMD64),
+            build_image("ubuntu", "26.04", Some("resolute"), Arch::AMD64),
+            build_image("ubuntu", "24.04", Some("noble"), Arch::ARM64),
+        ];
+
+        let images = ImageFactory::tag_images(images);
+        let find_tags = |version: &str, arch: Arch| {
+            images
+                .iter()
+                .find(|image| image.get_version() == version && image.arch == arch)
+                .map(|image| image.get_tags())
+                .unwrap()
+        };
+
+        assert_eq!(find_tags("24.04", Arch::AMD64), "noble");
+        assert_eq!(find_tags("26.04", Arch::AMD64), "resolute, stable, latest");
+        assert_eq!(find_tags("24.04", Arch::ARM64), "noble, stable, latest");
+    }
+
+    #[test]
+    fn test_tag_images_tags_a_rolling_release() {
+        let images = vec![build_image("archlinux", Image::ROLLING, None, Arch::AMD64)];
+
+        let images = ImageFactory::tag_images(images);
+
+        assert_eq!(images[0].get_image_name(), "archlinux:rolling");
+        assert_eq!(images[0].get_tags(), "stable, latest");
     }
 
     #[test]

--- a/src/image/image_factory.rs
+++ b/src/image/image_factory.rs
@@ -47,7 +47,6 @@ impl<'a> ImageFactory<'a> {
         image_provider: &dyn image::ImageProvider,
         name: &str,
         arch: Arch,
-        filter: Option<ImageName>,
     ) -> Option<Image> {
         let image_dir_url = format!(
             "{}{}",
@@ -78,30 +77,22 @@ impl<'a> ImageFactory<'a> {
 
         if let Some(image_file) = image_file {
             let image_url = format!("{image_dir_url}{image_file}");
-            let names = image_provider.get_image_names(image_file, name);
             web.get_file_size(&image_url)
                 .ok()
                 .and_then(|size| size)
-                .and_then(|size| {
-                    if filter
-                        .map(|name| names.contains(&name.get_name().to_string()))
-                        .unwrap_or(true)
-                    {
-                        Some(Image {
-                            distro: image_provider.get_distro().to_string(),
-                            names,
-                            arch,
-                            image_url,
-                            checksum_url: format!(
-                                "{image_dir_url}{}",
-                                image_provider.get_checksum_file(image_file, name, arch)
-                            ),
-                            hash_alg: image_provider.get_checksum_alg(),
-                            size: Some(size),
-                        })
-                    } else {
-                        None
-                    }
+                .map(|size| Image {
+                    distro: image_provider.get_distro().to_string(),
+                    version: image_provider.get_version(image_file, name),
+                    codename: image_provider.get_codename(name),
+                    tags: Vec::new(),
+                    arch,
+                    image_url,
+                    checksum_url: format!(
+                        "{image_dir_url}{}",
+                        image_provider.get_checksum_file(image_file, name, arch)
+                    ),
+                    hash_alg: image_provider.get_checksum_alg(),
+                    size: Some(size),
                 })
         } else {
             None
@@ -129,7 +120,6 @@ impl<'a> ImageFactory<'a> {
                                     image_provider,
                                     &name,
                                     arch,
-                                    filter.clone(),
                                 )
                             })
                             .collect::<Vec<_>>()
@@ -144,15 +134,13 @@ impl<'a> ImageFactory<'a> {
         web: &mut WebClient,
         filter: Option<ImageName>,
     ) -> Vec<Image> {
-        let mut images = IMAGE_PROVIDERS
+        IMAGE_PROVIDERS
             .iter()
             .filter(|p| filter.is_none() || filter.as_ref().unwrap().get_distro() == p.get_distro())
             .flat_map(|provider| {
                 Self::get_images_from_provider(console, web, *provider, filter.clone())
             })
-            .collect::<Vec<_>>();
-        images.sort();
-        images
+            .collect()
     }
 
     fn find_matching_image(images: &[Image], filter: &ImageName) -> Option<Image> {
@@ -161,7 +149,7 @@ impl<'a> ImageFactory<'a> {
             .find(|image| {
                 image.distro == filter.get_distro()
                     && image.arch == filter.get_arch()
-                    && image.names.contains(&filter.get_name().to_string())
+                    && image.has_name(filter.get_name())
             })
             .cloned()
     }
@@ -176,34 +164,22 @@ impl<'a> ImageFactory<'a> {
             ImageCache::read_from_file(self.system, Path::new(&self.env.get_image_cache_file()));
 
         // Use cache if valid
-        if let Some(cache) = &cache
+        let images = if let Some(cache) = &cache
             && cache.is_valid()
         {
             console.debug("Using cached image list");
-            return Ok(match &filter {
-                Some(name) => Self::find_matching_image(&cache.images, name)
-                    .into_iter()
-                    .collect(),
-                None => cache.images.clone(),
-            });
-        }
+            cache.images.clone()
+        } else {
+            // Fetch image info
+            console.debug("Image cache missing or stale, fetching image list from providers");
+            let images = Self::get_images(console, &mut WebClient::new()?, filter.clone());
 
-        // Fetch image info
-        console.debug("Image cache missing or stale, fetching image list from providers");
-        let images = Self::get_images(console, &mut WebClient::new()?, filter.clone());
-
-        // Return cache if fetching failed
-        Ok(
+            // Return cache if fetching failed
             if images.is_empty()
                 && let Some(cache) = &cache
             {
                 console.debug("Fetching image list failed, falling back to stale cache");
-                match &filter {
-                    Some(name) => Self::find_matching_image(&cache.images, name)
-                        .into_iter()
-                        .collect(),
-                    None => cache.images.clone(),
-                }
+                cache.images.clone()
             } else {
                 // Write cache
                 if filter.is_none() {
@@ -211,8 +187,15 @@ impl<'a> ImageFactory<'a> {
                         .write_to_file(self.system, Path::new(&self.env.get_image_cache_file()));
                 }
                 images
-            },
-        )
+            }
+        };
+
+        Ok(match &filter {
+            Some(name) => Self::find_matching_image(&images, name)
+                .into_iter()
+                .collect(),
+            None => images,
+        })
     }
 
     pub fn get_all_images(&self, console: &mut Console<'_>) -> Result<Vec<Image>> {
@@ -236,10 +219,12 @@ mod tests {
     use crate::models::HashAlg;
     use std::str::FromStr;
 
-    fn build_image(distro: &str, names: &[&str], arch: Arch) -> Image {
+    fn build_image(distro: &str, version: &str, codename: Option<&str>, arch: Arch) -> Image {
         Image {
             distro: distro.to_string(),
-            names: names.iter().map(|n| n.to_string()).collect(),
+            version: version.to_string(),
+            codename: codename.map(str::to_string),
+            tags: Vec::new(),
             arch,
             image_url: "image_url".to_string(),
             checksum_url: "checksum_url".to_string(),
@@ -251,8 +236,8 @@ mod tests {
     #[test]
     fn test_find_matching_image_matches_distro_arch_and_name() {
         let images = vec![
-            build_image("almalinux", &["9"], Arch::AMD64),
-            build_image("debian", &["12", "bookworm"], Arch::AMD64),
+            build_image("almalinux", "9", None, Arch::AMD64),
+            build_image("debian", "12", Some("bookworm"), Arch::AMD64),
         ];
         let filter = ImageName::from_str("debian:bookworm:amd64").unwrap();
 
@@ -262,48 +247,28 @@ mod tests {
     }
 
     #[test]
-    fn test_find_matching_image_returns_none_on_distro_mismatch() {
-        let images = vec![build_image("debian", &["12", "bookworm"], Arch::AMD64)];
-        let filter = ImageName::from_str("ubuntu:bookworm:amd64").unwrap();
+    fn test_find_matching_image_returns_none_on_a_mismatch() {
+        let images = vec![build_image("debian", "12", Some("bookworm"), Arch::AMD64)];
 
-        assert_eq!(ImageFactory::find_matching_image(&images, &filter), None);
+        for name in [
+            "ubuntu:bookworm:amd64",
+            "debian:bookworm:arm64",
+            "debian:bullseye:amd64",
+        ] {
+            let filter = ImageName::from_str(name).unwrap();
+
+            assert_eq!(ImageFactory::find_matching_image(&images, &filter), None);
+        }
     }
 
     #[test]
-    fn test_find_matching_image_returns_none_on_arch_mismatch() {
-        let images = vec![build_image("debian", &["12", "bookworm"], Arch::AMD64)];
+    fn test_filter_arch_keeps_the_filtered_arch_only() {
         let filter = ImageName::from_str("debian:bookworm:arm64").unwrap();
 
-        assert_eq!(ImageFactory::find_matching_image(&images, &filter), None);
-    }
-
-    #[test]
-    fn test_find_matching_image_returns_none_on_name_mismatch() {
-        let images = vec![build_image("debian", &["12", "bookworm"], Arch::AMD64)];
-        let filter = ImageName::from_str("debian:bullseye:amd64").unwrap();
-
-        assert_eq!(ImageFactory::find_matching_image(&images, &filter), None);
-    }
-
-    #[test]
-    fn test_find_matching_image_returns_none_for_empty_images() {
-        let filter = ImageName::from_str("debian:bookworm:amd64").unwrap();
-
-        assert_eq!(ImageFactory::find_matching_image(&[], &filter), None);
-    }
-
-    #[test]
-    fn test_filter_arch_without_filter_keeps_all_arches() {
         assert_eq!(
             ImageFactory::filter_arch(None),
             vec![Arch::AMD64, Arch::ARM64]
         );
-    }
-
-    #[test]
-    fn test_filter_arch_keeps_only_filtered_arch() {
-        let filter = ImageName::from_str("debian:bookworm:arm64").unwrap();
-
         assert_eq!(ImageFactory::filter_arch(Some(filter)), vec![Arch::ARM64]);
     }
 }

--- a/src/image/image_provider.rs
+++ b/src/image/image_provider.rs
@@ -1,7 +1,7 @@
 use crate::models::{Arch, HashAlg};
 
 pub trait ImageProvider {
-    fn get_vendor(&self) -> &str;
+    fn get_distro(&self) -> &str;
 
     fn get_base_url(&self) -> &str;
     fn find_image_names(&self, content: &str) -> Vec<String>;

--- a/src/image/image_provider.rs
+++ b/src/image/image_provider.rs
@@ -21,4 +21,10 @@ pub trait ImageProvider {
     fn get_codename(&self, _name: &str) -> Option<String> {
         None
     }
+
+    /// Newest long term release, picked from versions sorted oldest first.
+    /// Distributions without long term releases keep the newest version.
+    fn find_stable_version(&self, versions: &[String]) -> Option<String> {
+        versions.last().cloned()
+    }
 }

--- a/src/image/image_provider.rs
+++ b/src/image/image_provider.rs
@@ -7,9 +7,18 @@ pub trait ImageProvider {
     fn find_image_names(&self, content: &str) -> Vec<String>;
 
     fn get_image_dir_path(&self, name: &str, arch: Arch) -> String;
-    fn get_image_names(&self, image_file: &str, name: &str) -> Vec<String>;
     fn get_image_file_pattern(&self, name: &str, arch: Arch) -> String;
 
     fn get_checksum_file(&self, image_file: &str, name: &str, arch: Arch) -> String;
     fn get_checksum_alg(&self) -> HashAlg;
+
+    /// Release version, by default the name of the release directory
+    fn get_version(&self, _image_file: &str, name: &str) -> String {
+        name.to_string()
+    }
+
+    /// Release codename, for the distributions that have one
+    fn get_codename(&self, _name: &str) -> Option<String> {
+        None
+    }
 }

--- a/src/image/image_store.rs
+++ b/src/image/image_store.rs
@@ -33,7 +33,9 @@ mod tests {
     fn build_image(arch: Arch) -> Image {
         Image {
             distro: "debian".to_string(),
-            names: vec!["12".to_string(), "bookworm".to_string()],
+            version: "12".to_string(),
+            codename: Some("bookworm".to_string()),
+            tags: Vec::new(),
             arch,
             image_url: String::new(),
             checksum_url: String::new(),

--- a/src/image/image_store.rs
+++ b/src/image/image_store.rs
@@ -32,7 +32,7 @@ mod tests {
 
     fn build_image(arch: Arch) -> Image {
         Image {
-            vendor: "debian".to_string(),
+            distro: "debian".to_string(),
             names: vec!["12".to_string(), "bookworm".to_string()],
             arch,
             image_url: String::new(),

--- a/src/image/opensuse_image_provider.rs
+++ b/src/image/opensuse_image_provider.rs
@@ -5,7 +5,7 @@ use crate::util;
 pub struct OpenSuseImageProvider {}
 
 impl ImageProvider for OpenSuseImageProvider {
-    fn get_vendor(&self) -> &str {
+    fn get_distro(&self) -> &str {
         "opensuse"
     }
 

--- a/src/image/opensuse_image_provider.rs
+++ b/src/image/opensuse_image_provider.rs
@@ -21,10 +21,6 @@ impl ImageProvider for OpenSuseImageProvider {
         format!("Leap_{name}/images/",)
     }
 
-    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
-        vec![name.to_string()]
-    }
-
     fn get_image_file_pattern(&self, name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
         format!("openSUSE-Leap-{name}.{arch_name}-NoCloud.qcow2")

--- a/src/image/rockylinux_image_provider.rs
+++ b/src/image/rockylinux_image_provider.rs
@@ -22,10 +22,6 @@ impl ImageProvider for RockyLinuxImageProvider {
         format!("{name}/images/{arch_name}/",)
     }
 
-    fn get_image_names(&self, _image_file: &str, name: &str) -> Vec<String> {
-        vec![name.to_string()]
-    }
-
     fn get_image_file_pattern(&self, name: &str, arch: Arch) -> String {
         let arch_name = arch.as_canonical_str();
         format!("Rocky-{name}-GenericCloud-Base.latest.{arch_name}.qcow2")

--- a/src/image/rockylinux_image_provider.rs
+++ b/src/image/rockylinux_image_provider.rs
@@ -5,7 +5,7 @@ use crate::util;
 pub struct RockyLinuxImageProvider {}
 
 impl ImageProvider for RockyLinuxImageProvider {
-    fn get_vendor(&self) -> &str {
+    fn get_distro(&self) -> &str {
         "rockylinux"
     }
 

--- a/src/image/ubuntu_image_provider.rs
+++ b/src/image/ubuntu_image_provider.rs
@@ -4,6 +4,15 @@ use crate::util;
 
 pub struct UbuntuImageProvider {}
 
+impl UbuntuImageProvider {
+    /// Ubuntu releases a long term version every even year in April
+    fn is_long_term_version(&self, version: &str) -> bool {
+        version.split_once('.').is_some_and(|(year, month)| {
+            month == "04" && year.parse::<u32>().is_ok_and(|year| year % 2 == 0)
+        })
+    }
+}
+
 impl ImageProvider for UbuntuImageProvider {
     fn get_distro(&self) -> &str {
         "ubuntu"
@@ -44,6 +53,15 @@ impl ImageProvider for UbuntuImageProvider {
     fn get_checksum_alg(&self) -> HashAlg {
         HashAlg::Sha256
     }
+
+    fn find_stable_version(&self, versions: &[String]) -> Option<String> {
+        versions
+            .iter()
+            .rev()
+            .find(|version| self.is_long_term_version(version))
+            .cloned()
+            .or_else(|| versions.last().cloned())
+    }
 }
 
 #[cfg(test)]
@@ -71,6 +89,24 @@ mod tests {
             "24.04"
         );
         assert_eq!(provider.get_codename("noble"), Some("noble".to_string()));
+    }
+
+    #[test]
+    fn test_find_stable_version_picks_the_newest_lts() {
+        let provider = UbuntuImageProvider {};
+
+        assert_eq!(
+            provider.find_stable_version(
+                &["24.04", "24.10", "25.04", "25.10", "26.04"]
+                    .map(String::from)
+                    .to_vec()
+            ),
+            Some("26.04".to_string())
+        );
+        assert_eq!(
+            provider.find_stable_version(&["25.04", "25.10"].map(String::from).to_vec()),
+            Some("25.10".to_string())
+        );
     }
 
     #[test]

--- a/src/image/ubuntu_image_provider.rs
+++ b/src/image/ubuntu_image_provider.rs
@@ -4,14 +4,6 @@ use crate::util;
 
 pub struct UbuntuImageProvider {}
 
-impl UbuntuImageProvider {
-    fn get_version_from_content(&self, content: &str) -> Option<String> {
-        util::find_and_extract(r"ubuntu-([^-]+)-minimal-cloudimg-[^.]+.img", content)
-            .into_iter()
-            .next()
-    }
-}
-
 impl ImageProvider for UbuntuImageProvider {
     fn get_distro(&self) -> &str {
         "ubuntu"
@@ -29,13 +21,15 @@ impl ImageProvider for UbuntuImageProvider {
         format!("{name}/release/")
     }
 
-    fn get_image_names(&self, image_file: &str, name: &str) -> Vec<String> {
-        let mut names = Vec::new();
-        if let Some(version) = self.get_version_from_content(image_file) {
-            names.push(version);
-        }
-        names.push(name.to_string());
-        names
+    fn get_version(&self, image_file: &str, name: &str) -> String {
+        util::find_and_extract(r"ubuntu-([^-]+)-minimal-cloudimg-[^.]+.img", image_file)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| name.to_string())
+    }
+
+    fn get_codename(&self, name: &str) -> Option<String> {
+        Some(name.to_string())
     }
 
     fn get_image_file_pattern(&self, _name: &str, arch: Arch) -> String {
@@ -69,12 +63,14 @@ mod tests {
     }
 
     #[test]
-    fn test_get_image_names_extracts_version() {
+    fn test_get_version_and_codename() {
+        let provider = UbuntuImageProvider {};
+
         assert_eq!(
-            UbuntuImageProvider {}
-                .get_image_names("ubuntu-24.04-minimal-cloudimg-amd64.img", "noble"),
-            ["24.04", "noble"]
+            provider.get_version("ubuntu-24.04-minimal-cloudimg-amd64.img", "noble"),
+            "24.04"
         );
+        assert_eq!(provider.get_codename("noble"), Some("noble".to_string()));
     }
 
     #[test]

--- a/src/image/ubuntu_image_provider.rs
+++ b/src/image/ubuntu_image_provider.rs
@@ -13,7 +13,7 @@ impl UbuntuImageProvider {
 }
 
 impl ImageProvider for UbuntuImageProvider {
-    fn get_vendor(&self) -> &str {
+    fn get_distro(&self) -> &str {
         "ubuntu"
     }
 

--- a/src/models/image.rs
+++ b/src/models/image.rs
@@ -21,7 +21,7 @@ impl fmt::Display for HashAlg {
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Image {
-    pub vendor: String,
+    pub distro: String,
     pub names: Vec<String>,
     pub arch: Arch,
     pub image_url: String,
@@ -46,7 +46,7 @@ impl Image {
     pub fn get_image_names(&self) -> String {
         format!(
             "{}:{}",
-            self.vendor,
+            self.distro,
             if self.names.len() > 1 {
                 format!("{{{}}}", self.names.join(", "))
             } else {
@@ -56,17 +56,17 @@ impl Image {
     }
 
     pub fn to_name(&self) -> String {
-        format!("{}:{}:{}", self.vendor, self.get_version(), self.arch)
+        format!("{}:{}:{}", self.distro, self.get_version(), self.arch)
     }
 
     pub fn to_file_name(&self) -> String {
-        format!("{}_{}_{}", self.vendor, self.get_name(), self.arch)
+        format!("{}_{}_{}", self.distro, self.get_name(), self.arch)
     }
 }
 
 impl Ord for Image {
     fn cmp(&self, other: &Self) -> Ordering {
-        let mut result = self.vendor.cmp(&other.vendor);
+        let mut result = self.distro.cmp(&other.distro);
 
         if result == Ordering::Equal {
             let a = &self.names[0];
@@ -95,9 +95,9 @@ impl PartialOrd for Image {
 mod tests {
     use super::*;
 
-    fn build_image(vendor: &str, names: &[&str]) -> Image {
+    fn build_image(distro: &str, names: &[&str]) -> Image {
         Image {
-            vendor: vendor.to_string(),
+            distro: distro.to_string(),
             names: names.iter().map(|name| name.to_string()).collect(),
             arch: Arch::AMD64,
             image_url: String::new(),
@@ -171,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ord_compares_vendor_first() {
+    fn test_ord_compares_distro_first() {
         assert!(build_image("alma", &["9"]) < build_image("debian", &["1"]));
     }
 }

--- a/src/models/image.rs
+++ b/src/models/image.rs
@@ -36,6 +36,9 @@ pub struct Image {
 }
 
 impl Image {
+    /// Tags that every distribution has
+    pub const LATEST_TAG: &'static str = "latest";
+    pub const STABLE_TAG: &'static str = "stable";
     /// Version of a rolling release
     pub const ROLLING: &'static str = "rolling";
 

--- a/src/models/image.rs
+++ b/src/models/image.rs
@@ -20,9 +20,14 @@ impl fmt::Display for HashAlg {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Image {
     pub distro: String,
-    pub names: Vec<String>,
+    pub version: String,
+    pub codename: Option<String>,
+    /// Derived when the image list is read, never cached
+    #[serde(skip)]
+    pub tags: Vec<String>,
     pub arch: Arch,
     pub image_url: String,
     pub checksum_url: String,
@@ -31,32 +36,41 @@ pub struct Image {
 }
 
 impl Image {
+    /// Version of a rolling release
+    pub const ROLLING: &'static str = "rolling";
+
     pub fn get_version(&self) -> &str {
-        &self.names[0]
+        &self.version
     }
 
+    /// Codename of a release, or its version when it has none
     pub fn get_name(&self) -> &str {
-        if self.names.len() > 1 {
-            &self.names[1]
-        } else {
-            &self.names[0]
-        }
+        self.codename.as_deref().unwrap_or(&self.version)
     }
 
-    pub fn get_image_names(&self) -> String {
-        format!(
-            "{}:{}",
-            self.distro,
-            if self.names.len() > 1 {
-                format!("{{{}}}", self.names.join(", "))
-            } else {
-                self.names[0].clone()
-            }
-        )
+    pub fn has_name(&self, name: &str) -> bool {
+        self.version == name
+            || self.codename.as_deref() == Some(name)
+            || self.tags.iter().any(|tag| tag == name)
+    }
+
+    /// Image name for display, such as debian:12 or archlinux:rolling
+    pub fn get_image_name(&self) -> String {
+        format!("{}:{}", self.distro, self.version)
+    }
+
+    /// Other names of this image, ordered codename, stable, latest
+    pub fn get_tags(&self) -> String {
+        self.codename
+            .iter()
+            .chain(self.tags.iter())
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     pub fn to_name(&self) -> String {
-        format!("{}:{}:{}", self.distro, self.get_version(), self.arch)
+        format!("{}:{}", self.get_image_name(), self.arch)
     }
 
     pub fn to_file_name(&self) -> String {
@@ -69,8 +83,8 @@ impl Ord for Image {
         let mut result = self.distro.cmp(&other.distro);
 
         if result == Ordering::Equal {
-            let a = &self.names[0];
-            let b = &other.names[0];
+            let a = self.get_version();
+            let b = other.get_version();
 
             if let Ok(a) = a.parse::<u32>()
                 && let Ok(b) = b.parse::<u32>()
@@ -95,10 +109,12 @@ impl PartialOrd for Image {
 mod tests {
     use super::*;
 
-    fn build_image(distro: &str, names: &[&str]) -> Image {
+    fn build_image(distro: &str, version: &str, codename: Option<&str>) -> Image {
         Image {
             distro: distro.to_string(),
-            names: names.iter().map(|name| name.to_string()).collect(),
+            version: version.to_string(),
+            codename: codename.map(str::to_string),
+            tags: Vec::new(),
             arch: Arch::AMD64,
             image_url: String::new(),
             checksum_url: String::new(),
@@ -108,70 +124,42 @@ mod tests {
     }
 
     #[test]
-    fn test_get_version_is_first_name() {
+    fn test_get_image_name_uses_the_version() {
         assert_eq!(
-            build_image("debian", &["12", "bookworm"]).get_version(),
-            "12"
+            build_image("debian", "12", Some("bookworm")).get_image_name(),
+            "debian:12"
+        );
+        assert_eq!(
+            build_image("archlinux", Image::ROLLING, None).get_image_name(),
+            "archlinux:rolling"
         );
     }
 
     #[test]
-    fn test_get_name_prefers_second_name() {
-        assert_eq!(
-            build_image("debian", &["12", "bookworm"]).get_name(),
-            "bookworm"
-        );
-    }
+    fn test_get_tags_joins_the_codename_and_the_derived_tags() {
+        let mut ubuntu = build_image("ubuntu", "26.04", Some("resolute"));
+        ubuntu.tags = vec!["stable".to_string(), "latest".to_string()];
 
-    #[test]
-    fn test_get_name_falls_back_to_single_name() {
-        assert_eq!(build_image("debian", &["bookworm"]).get_name(), "bookworm");
-    }
-
-    #[test]
-    fn test_get_image_names_joins_multiple_names() {
-        assert_eq!(
-            build_image("debian", &["12", "bookworm"]).get_image_names(),
-            "debian:{12, bookworm}"
-        );
-    }
-
-    #[test]
-    fn test_get_image_names_with_single_name() {
-        assert_eq!(
-            build_image("debian", &["bookworm"]).get_image_names(),
-            "debian:bookworm"
-        );
-    }
-
-    #[test]
-    fn test_to_name_uses_version_and_arch() {
-        assert_eq!(
-            build_image("debian", &["12", "bookworm"]).to_name(),
-            "debian:12:amd64"
-        );
+        assert_eq!(ubuntu.get_tags(), "resolute, stable, latest");
+        assert_eq!(build_image("fedora", "43", None).get_tags(), "");
     }
 
     #[test]
     fn test_to_file_name_uses_name_and_arch() {
         assert_eq!(
-            build_image("debian", &["12", "bookworm"]).to_file_name(),
+            build_image("debian", "12", Some("bookworm")).to_file_name(),
             "debian_bookworm_amd64"
+        );
+        assert_eq!(
+            build_image("archlinux", Image::ROLLING, None).to_file_name(),
+            "archlinux_rolling_amd64"
         );
     }
 
     #[test]
-    fn test_ord_compares_numeric_versions_numerically() {
-        assert!(build_image("debian", &["10"]) > build_image("debian", &["9"]));
-    }
-
-    #[test]
-    fn test_ord_falls_back_to_lexical_comparison() {
-        assert!(build_image("ubuntu", &["noble"]) > build_image("ubuntu", &["jammy"]));
-    }
-
-    #[test]
-    fn test_ord_compares_distro_first() {
-        assert!(build_image("alma", &["9"]) < build_image("debian", &["1"]));
+    fn test_ord_sorts_by_distro_then_version() {
+        assert!(build_image("debian", "10", None) > build_image("debian", "9", None));
+        assert!(build_image("ubuntu", "26.04", None) > build_image("ubuntu", "25.10", None));
+        assert!(build_image("alma", "9", None) < build_image("debian", "1", None));
     }
 }

--- a/src/models/image_name.rs
+++ b/src/models/image_name.rs
@@ -1,11 +1,12 @@
-use crate::models::Arch;
+use crate::models::{Arch, Image};
 use regex::Regex;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-static IMAGE_NAME_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new("^(\\w+):([\\w\\.]+)(:(amd64|arm64))?$").unwrap());
+static IMAGE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new("^(?<distro>\\w+)(:(?<name>[\\w\\.]+))?(:(?<arch>amd64|arm64))?$").unwrap()
+});
 
 #[derive(Clone, Debug)]
 pub struct ImageName {
@@ -32,22 +33,24 @@ impl FromStr for ImageName {
     type Err = String;
 
     fn from_str(name: &str) -> Result<Self, Self::Err> {
-        if IMAGE_NAME_REGEX.is_match(name) {
-            let mut tokens = name.split(':');
-            let distro = tokens.next().unwrap().to_string();
-            let name = tokens.next().unwrap().to_string();
-            let arch = tokens
-                .next()
-                .map(|x| Arch::from_str(x).unwrap())
-                .unwrap_or(Arch::get_host());
-
-            Ok(Self { distro, name, arch })
-        } else {
-            Err(
-                "Image name must have the format: distro:name[:arch] (e.g. debian:bookworm, debian:buster:amd64)"
-                    .to_string(),
-            )
-        }
+        IMAGE_NAME_REGEX
+            .captures(name)
+            .map(|captures| Self {
+                distro: captures["distro"].to_string(),
+                // A bare distro is a shortcut for the stable release
+                name: captures
+                    .name("name")
+                    .map(|name| name.as_str().to_string())
+                    .unwrap_or(Image::STABLE_TAG.to_string()),
+                arch: captures
+                    .name("arch")
+                    .and_then(|arch| Arch::from_str(arch.as_str()).ok())
+                    .unwrap_or(Arch::get_host()),
+            })
+            .ok_or_else(|| {
+                "Image name must have the format: distro[:name][:arch] (e.g. debian, debian:bookworm, debian:stable:amd64)"
+                    .to_string()
+            })
     }
 }
 
@@ -62,31 +65,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_debian_bookworm() {
+    fn test_parse_distro_name_and_arch() {
         let image = ImageName::from_str("debian:bookworm").unwrap();
         assert_eq!(image.get_distro(), "debian");
         assert_eq!(image.get_name(), "bookworm");
-    }
+        assert_eq!(image.get_arch(), Arch::get_host());
 
-    #[test]
-    fn test_debian_buster_amd64() {
-        let image = ImageName::from_str("debian:buster:amd64").unwrap();
-        assert_eq!(image.get_distro(), "debian");
-        assert_eq!(image.get_name(), "buster");
-        assert_eq!(image.get_arch(), Arch::AMD64);
-    }
-
-    #[test]
-    fn test_debian_bookworm_arm64() {
         let image = ImageName::from_str("debian:bookworm:arm64").unwrap();
-        assert_eq!(image.get_distro(), "debian");
         assert_eq!(image.get_name(), "bookworm");
         assert_eq!(image.get_arch(), Arch::ARM64);
     }
 
     #[test]
-    fn test_reject_name_without_distro() {
-        assert!(ImageName::from_str("debian").is_err());
+    fn test_bare_distro_is_stable() {
+        let image = ImageName::from_str("debian").unwrap();
+        assert_eq!(image.get_distro(), "debian");
+        assert_eq!(image.get_name(), "stable");
+        assert_eq!(image.get_arch(), Arch::get_host());
     }
 
     #[test]

--- a/src/models/image_name.rs
+++ b/src/models/image_name.rs
@@ -9,14 +9,14 @@ static IMAGE_NAME_REGEX: LazyLock<Regex> =
 
 #[derive(Clone, Debug)]
 pub struct ImageName {
-    vendor: String,
+    distro: String,
     name: String,
     arch: Arch,
 }
 
 impl ImageName {
-    pub fn get_vendor(&self) -> &str {
-        &self.vendor
+    pub fn get_distro(&self) -> &str {
+        &self.distro
     }
 
     pub fn get_name(&self) -> &str {
@@ -34,17 +34,17 @@ impl FromStr for ImageName {
     fn from_str(name: &str) -> Result<Self, Self::Err> {
         if IMAGE_NAME_REGEX.is_match(name) {
             let mut tokens = name.split(':');
-            let vendor = tokens.next().unwrap().to_string();
+            let distro = tokens.next().unwrap().to_string();
             let name = tokens.next().unwrap().to_string();
             let arch = tokens
                 .next()
                 .map(|x| Arch::from_str(x).unwrap())
                 .unwrap_or(Arch::get_host());
 
-            Ok(Self { vendor, name, arch })
+            Ok(Self { distro, name, arch })
         } else {
             Err(
-                "Image name must have the format: vendor:name[:arch] (e.g. debian:bookworm, debian:buster:amd64)"
+                "Image name must have the format: distro:name[:arch] (e.g. debian:bookworm, debian:buster:amd64)"
                     .to_string(),
             )
         }
@@ -53,7 +53,7 @@ impl FromStr for ImageName {
 
 impl fmt::Display for ImageName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}:{}:{}", self.vendor, self.name, self.arch)
+        write!(f, "{}:{}:{}", self.distro, self.name, self.arch)
     }
 }
 
@@ -64,14 +64,14 @@ mod tests {
     #[test]
     fn test_debian_bookworm() {
         let image = ImageName::from_str("debian:bookworm").unwrap();
-        assert_eq!(image.get_vendor(), "debian");
+        assert_eq!(image.get_distro(), "debian");
         assert_eq!(image.get_name(), "bookworm");
     }
 
     #[test]
     fn test_debian_buster_amd64() {
         let image = ImageName::from_str("debian:buster:amd64").unwrap();
-        assert_eq!(image.get_vendor(), "debian");
+        assert_eq!(image.get_distro(), "debian");
         assert_eq!(image.get_name(), "buster");
         assert_eq!(image.get_arch(), Arch::AMD64);
     }
@@ -79,13 +79,13 @@ mod tests {
     #[test]
     fn test_debian_bookworm_arm64() {
         let image = ImageName::from_str("debian:bookworm:arm64").unwrap();
-        assert_eq!(image.get_vendor(), "debian");
+        assert_eq!(image.get_distro(), "debian");
         assert_eq!(image.get_name(), "bookworm");
         assert_eq!(image.get_arch(), Arch::ARM64);
     }
 
     #[test]
-    fn test_reject_name_without_vendor() {
+    fn test_reject_name_without_distro() {
         assert!(ImageName::from_str("debian").is_err());
     }
 


### PR DESCRIPTION
## Summary

Reformulate how Cubic names and tags VM images. The image model drops the positional `names` vector and the `vendor` field in favour of explicit `distro`, `version`, `codename` and `tags` fields, so the code matches the concepts it represents. Every distribution now carries two derived tags: `latest` for the newest release and `stable` for the newest long term release (the last LTS for Ubuntu, the current stable for Debian). A bare distribution name such as `ubuntu` is a shortcut for `stable`, so a user gets a safe default without naming a version. Rolling releases carry the version `rolling` and receive both tags, so Arch and Gentoo now display as `archlinux:rolling` and `gentoo:rolling`. The tags are derived from the version list every time the image list is read, so they are never cached and never go stale.

## Related Issue(s)

Closes #553

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Refactor
- [x] Documentation
- [ ] Other

## Test Plan

Ran `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (484 passing) and `cargo run -- images --help` to confirm the generated reference output. Each of the five commits builds and passes the test suite on its own.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed