### PR TITLE
fix: wrap the install command so the copy button stays clear

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -160,7 +160,8 @@
     .cmd { position: relative; }
     pre {
       margin: 0;
-      overflow-x: auto;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
       background: var(--fg);
       color: #ffffff;
       border-radius: 10px;


### PR DESCRIPTION
## Summary

On the landing page the Copy button covered the install command. The command did not wrap, so long ones ran under the button. It was worst on the Ubuntu Snap tab with the longest command. Now the command wraps, so the text stays clear of the button at any width.

## Related Issue(s)

Closes #549

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Open `docs/index.html`, check each Install tab, and resize the window down to phone width. The command should stay clear of the Copy button and wrap instead of running under it.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally (no Rust affected, HTML only change)
- [ ] Documentation was updated if needed