### PR TITLE
feat: return unused guest memory to the host

### DIFF
--- a/src/qemu/qemu_system.rs
+++ b/src/qemu/qemu_system.rs
@@ -46,8 +46,11 @@ impl QemuSystem {
         // never falls back to /dev/urandom, which is absent on Windows.
         command.arg("-object").arg("rng-builtin,id=rng0");
         command.arg("-device").arg("virtio-rng-pci,rng=rng0");
-        // Allow memory reclaim via virtio-balloon.
-        command.arg("-device").arg("virtio-balloon-pci");
+        // Reclaim host memory via virtio-balloon. Free page reporting lets the
+        // guest hand back its free pages on its own, without any host action.
+        command
+            .arg("-device")
+            .arg("virtio-balloon-pci,free-page-reporting=on");
 
         Ok(QemuSystem { command })
     }
@@ -244,9 +247,13 @@ mod tests {
     }
 
     #[test]
-    fn test_from_adds_virtio_balloon() {
+    fn test_from_adds_virtio_balloon_that_reports_free_pages() {
         let qemu = QemuSystem::from(&SystemMock::new(), Arch::ARM64).unwrap();
-        assert!(qemu.command.get_command().contains("virtio-balloon-pci"));
+        assert!(
+            qemu.command
+                .get_command()
+                .contains("virtio-balloon-pci,free-page-reporting=on")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

QEMU never gave back host memory for guest pages the guest had freed. `virtio-balloon-pci` was attached with no properties, which is a manual balloon that only reclaims when a host sets a target, and nothing ever set one.

`free-page-reporting=on` makes the guest report its free pages on its own, and QEMU discards the matching host range. 

## Related Issue(s)

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

`make format`, `make lint` and `make test` pass.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed