### PR TITLE
feat: add temporary VM instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Cubic fits a lot of everyday workflows:
 - Creates VM instances from reusable templates
 - Snapshots a VM disk and restores it later
 - Clones and renames VM instances
+- Runs temporary VM instances that are deleted after use
 - Isolates a VM from the network with one flag
 
 **Safe by default**

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -121,6 +121,7 @@ Features
 * Creates VM instances from reusable templates
 * Snapshots a VM disk and restores it later
 * Clones and renames VM instances
+* Runs temporary VM instances that are deleted after use
 * Isolates a VM from the network with one flag
 
 **Safe by default**

--- a/src/actions/create_instance_action.rs
+++ b/src/actions/create_instance_action.rs
@@ -18,6 +18,7 @@ impl CreateInstanceAction {
         context: &Context,
         image_path: &str,
         mut instance: Instance,
+        overlay: bool,
     ) -> Result<()> {
         let system = context.get_system();
         let instance_name = instance.name.clone();
@@ -32,7 +33,11 @@ impl CreateInstanceAction {
         SshKeyGenerator::new().generate_key(system, &Path::new(tmp_dir).join("ssh_client_key"))?;
 
         // Create virtual machine instance image file
-        system.copy_file(Path::new(image_path), Path::new(tmp_image))?;
+        if overlay {
+            QemuImg::new(system).create_overlay(image_path, tmp_image)?;
+        } else {
+            system.copy_file(Path::new(image_path), Path::new(tmp_image))?;
+        }
 
         // Set disk capacity
         QemuImg::new(system).resize(tmp_image, instance.disk_capacity.get_bytes() as u64)?;

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -62,7 +62,7 @@ impl Command for CloneCommand {
         target.ssh_host_key = None;
 
         // Create VM instance
-        CreateInstanceAction::new().run(context, image_path, target)?;
+        CreateInstanceAction::new().run(context, image_path, target, false)?;
 
         console.stop();
         Ok(())

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -159,8 +159,13 @@ impl CreateCommand {
     }
 }
 
-impl Command for CreateCommand {
-    fn run(&self, console: &mut Console<'_>, context: &Context) -> Result<()> {
+impl CreateCommand {
+    pub fn create(
+        &self,
+        console: &mut Console<'_>,
+        context: &Context,
+        overlay: bool,
+    ) -> Result<()> {
         let env = context.get_env();
         let instance_store = context.get_instance_store();
 
@@ -209,10 +214,16 @@ impl Command for CreateCommand {
         ));
 
         let image_path = &env.get_image_file(&image.to_file_name());
-        CreateInstanceAction::new().run(context, image_path, instance)?;
+        CreateInstanceAction::new().run(context, image_path, instance, overlay)?;
 
         console.stop();
         Ok(())
+    }
+}
+
+impl Command for CreateCommand {
+    fn run(&self, console: &mut Console<'_>, context: &Context) -> Result<()> {
+        self.create(console, context, false)
     }
 }
 

--- a/src/commands/run_command.rs
+++ b/src/commands/run_command.rs
@@ -1,8 +1,9 @@
+use crate::actions::{LoadInstanceAction, StopInstanceAction};
 use crate::commands::{self, Command};
 use crate::error::Result;
 use crate::models::Target;
 use crate::view::Console;
-use clap::{self, Parser};
+use clap::{self, ArgAction, Parser};
 
 /// Create and start VM instances
 ///
@@ -28,6 +29,9 @@ use clap::{self, Parser};
 ///   Run a VM instance without network access:
 ///   $ cubic run example6 --isolate ubuntu
 ///
+///   Run a VM instance and delete it when you exit:
+///   $ cubic run --rm example7 -i debian:trixie
+///
 ///   Every distribution has the tags latest and stable. The tag latest is the
 ///   newest release and the tag stable is the newest long term release. A plain
 ///   name is a shortcut for stable, so --image ubuntu gives you the last LTS.
@@ -37,20 +41,79 @@ use clap::{self, Parser};
 pub struct RunCommand {
     #[clap(flatten)]
     create_cmd: commands::CreateCommand,
+    /// Delete the VM instance when the session ends
+    #[clap(long, action = ArgAction::SetTrue)]
+    rm: bool,
     #[clap(flatten)]
     accel: commands::AccelArg,
     #[clap(flatten)]
     env_args: commands::EnvArgs,
 }
 
+impl RunCommand {
+    // Best effort, a failure here must not mask the session result.
+    fn cleanup(&self, console: &mut Console<'_>, context: &commands::Context) {
+        let name = self.create_cmd.instance_name.value.as_str();
+        let store = context.get_instance_store();
+
+        if let Ok(instance) = LoadInstanceAction::new().run(context, console, name) {
+            StopInstanceAction::new(&instance).run(store, true).ok();
+            store.delete(&instance).ok();
+        }
+    }
+}
+
 impl Command for RunCommand {
     fn run(&self, console: &mut Console<'_>, context: &commands::Context) -> Result<()> {
-        self.create_cmd.run(console, context)?;
-        commands::SshCommand {
+        self.create_cmd.create(console, context, self.rm)?;
+
+        let result = commands::SshCommand {
             target: Target::from_instance_name(self.create_cmd.instance_name.value.clone()),
             accel: self.accel,
             env_args: self.env_args.clone(),
         }
-        .run(console, context)
+        .run(console, context);
+
+        if self.rm {
+            self.cleanup(console, context);
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instance::InstanceStoreMock;
+    use crate::models::{Environment, Instance};
+    use crate::platform::SystemMock;
+    use std::rc::Rc;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_rm_stops_and_deletes_the_instance() {
+        let system = SystemMock::new();
+        let console = &mut Console::new(&system);
+        let store = InstanceStoreMock::new_with_running(
+            vec![Instance {
+                name: "web".to_string(),
+                ..Instance::default()
+            }],
+            &["web"],
+        );
+        let killed = Arc::clone(&store.killed);
+        let deleted = Arc::clone(&store.deleted);
+        let context = commands::Context::new(
+            Rc::new(SystemMock::new()),
+            Environment::default(),
+            Box::new(store),
+        );
+
+        RunCommand::try_parse_from(["run", "--rm", "web", "-i", "debian:trixie"])
+            .unwrap()
+            .cleanup(console, &context);
+
+        assert_eq!(*killed.lock().unwrap(), ["web"]);
+        assert_eq!(*deleted.lock().unwrap(), ["web"]);
     }
 }

--- a/src/qemu/qemu_img.rs
+++ b/src/qemu/qemu_img.rs
@@ -66,6 +66,25 @@ impl<'a> QemuImg<'a> {
         }
     }
 
+    pub fn create_overlay(&self, base_image: &str, image: &str) -> Result<()> {
+        let mut command = self.command();
+        command
+            .arg("create")
+            .arg("-q")
+            .arg("-f")
+            .arg("qcow2")
+            .arg("-F")
+            .arg("qcow2")
+            .arg("-b")
+            .arg(base_image)
+            .arg(image);
+
+        self.system
+            .run_command(&command)
+            .map(|_| ())
+            .map_err(Self::map_error)
+    }
+
     pub fn resize(&self, image: &str, size: u64) -> Result<()> {
         let mut command = self.command();
         command.arg("resize").arg(image).arg(size.to_string());
@@ -176,6 +195,18 @@ mod tests {
             QemuImg::new(&system).resize("/data/machines/test/image", 2048),
             Err(Error::QemuNotFound)
         ));
+    }
+
+    #[test]
+    fn test_create_overlay_backs_the_image_by_the_base_image() {
+        let command = "qemu-img create -q -f qcow2 -F qcow2 -b /cache/images/debian /data/machines/test/machine.img";
+        let system = SystemMock::new().add_command_output(command, b"");
+
+        QemuImg::new(&system)
+            .create_overlay("/cache/images/debian", "/data/machines/test/machine.img")
+            .unwrap();
+
+        assert_eq!(system.get_executed_commands(), vec![command]);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

Adds temporary VM instances. `cubic run --rm <name>` starts a VM instance and deletes it when the session ends, so a quick test, a throwaway experiment or a one off command leaves nothing behind and needs no cleanup by hand.

A temporary instance is an ordinary instance in every other respect. It takes the same options, appears in `cubic list` while it runs, and can be connected to or stopped from another terminal. It also starts instantly and needs no disk space of its own, so reaching for one costs nothing compared to a normal instance.

## Related Issue(s)

Closes #550

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

- `make test`, `make lint` and `make format` pass locally (486 tests).
- Added a unit test asserting that `--rm` stops the instance and then deletes it, which is the behaviour the flag promises.
- Added a unit test guarding that a temporary instance never writes to the shared cached image other instances are created from.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed