### PR TITLE
feat: simplify the human readable data sizes

### DIFF
--- a/docs/howto/ports.rst
+++ b/docs/howto/ports.rst
@@ -65,9 +65,9 @@ including every port forwarding rule:
     Running:      yes
     Arch:         amd64
     CPUs:         4
-    Memory:       4.0 GiB
-    Disk Used:    1.2 GiB
-    Disk Total:   100.0 GiB
+    Memory:       4096 M
+    Disk Used:    1229 M
+    Disk Total:   100 G
     User:         alice
     Isolated:     no
     SSH Port:     10022

--- a/docs/howto/resources.rst
+++ b/docs/howto/resources.rst
@@ -39,9 +39,9 @@ Check the Result
     Running:      no
     Arch:         amd64
     CPUs:         2
-    Memory:       2.0 GiB
-    Disk Used:    447.8 MiB
-    Disk Total:   200.0 GiB
+    Memory:       2048 M
+    Disk Used:    448 M
+    Disk Total:   200 G
     User:         alice
     Isolated:     no
     SSH Port:     33033

--- a/docs/howto/snapshots.rst
+++ b/docs/howto/snapshots.rst
@@ -32,9 +32,9 @@ List the Snapshots
     Running:      no
     Arch:         amd64
     CPUs:         4
-    Memory:       2.0 GiB
-    Disk Used:    941.2 MiB
-    Disk Total:   100.0 GiB
+    Memory:       2048 M
+    Disk Used:    941 M
+    Disk Total:   100 G
     User:         alice
     Isolated:     no
     SSH Port:     40881

--- a/docs/reference/values.rst
+++ b/docs/reference/values.rst
@@ -61,9 +61,10 @@ binary, so ``1G`` is one gibibyte and not one gigabyte.
      - 1099511627776
 
 Lowercase letters and decimals are rejected, so use ``512M`` rather than
-``0.5G`` or ``512m``. Cubic prints sizes back as ``KiB``, ``MiB``, ``GiB`` and
-``TiB`` with one decimal, and stores them as plain bytes in the
-:ref:`instance file`.
+``0.5G`` or ``512m``. Cubic prints sizes back with a single letter ``B``, ``K``,
+``M``, ``G`` or ``T`` and no decimal, dropping to the next smaller unit when the
+value would fall below ten, so ``1G`` of memory prints as ``1024 M``. Sizes are
+stored as plain bytes in the :ref:`instance file`.
 
 Defaults of a New VM Instance
 -----------------------------

--- a/docs/tutorial/getting_started.rst
+++ b/docs/tutorial/getting_started.rst
@@ -24,8 +24,8 @@ See What You Created
 .. code-block::
 
     $ cubic instances
-    Name      Arch    CPUs    Memory   Disk Used   Disk Total   Running
-    example   amd64      4   2.0 GiB   941.2 MiB    100.0 GiB        no
+    Name      Arch    CPUs   Memory      Disk   Running
+    example   amd64      4   2048 M   1/100 G        no
 
 The VM instance exists but nothing runs yet, so ``Running`` is ``no``. Cubic
 picked the number of CPUs and the memory from the resources of your host, so
@@ -74,8 +74,8 @@ The VM instance keeps running after you leave it:
 .. code-block::
 
     $ cubic instances
-    Name      Arch    CPUs    Memory   Disk Used   Disk Total   Running
-    example   amd64      4   2.0 GiB   941.2 MiB    100.0 GiB       yes
+    Name      Arch    CPUs   Memory      Disk   Running
+    example   amd64      4   2048 M   1/100 G       yes
 
 Next Steps
 ----------

--- a/docs/tutorial/isolate.rst
+++ b/docs/tutorial/isolate.rst
@@ -22,9 +22,9 @@ Create an Isolated VM Instance
     Running:    no
     Arch:       amd64
     CPUs:       4
-    Memory:     2.0 GiB
-    Disk Used:  407.6 MiB
-    Disk Total: 100.0 GiB
+    Memory:     2048 M
+    Disk Used:  408 M
+    Disk Total: 100 G
     User:       alice
     Isolated:   yes
     SSH Port:   46831

--- a/docs/tutorial/snapshots.rst
+++ b/docs/tutorial/snapshots.rst
@@ -42,9 +42,9 @@ The name ``demo/clean`` is the snapshot ``clean`` of the VM instance ``demo``.
     Running:      no
     Arch:         amd64
     CPUs:         4
-    Memory:       2.0 GiB
-    Disk Used:    407.6 MiB
-    Disk Total:   100.0 GiB
+    Memory:       2048 M
+    Disk Used:    408 M
+    Disk Total:   100 G
     User:         alice
     Isolated:     no
     SSH Port:     40881

--- a/docs/tutorial/templates.rst
+++ b/docs/tutorial/templates.rst
@@ -44,9 +44,9 @@ See What the Template Did
 .. code-block::
 
     $ cubic instances
-    Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
-    web-1   amd64      2   2.0 GiB   407.6 MiB    100.0 GiB        no
-    web-2   amd64      2   2.0 GiB   407.6 MiB    100.0 GiB        no
+    Name    Arch    CPUs   Memory      Disk   Running
+    web-1   amd64      2   2048 M   0/100 G        no
+    web-2   amd64      2   2048 M   0/100 G        no
 
 Both VM instances have two CPUs and two GiB of memory because the template said
 so. Without a template Cubic would have picked those values from the resources

--- a/src/commands/list_image_command.rs
+++ b/src/commands/list_image_command.rs
@@ -10,15 +10,15 @@ use clap::Parser;
 /// Examples:
 ///
 ///   $ cubic images
-///   Name                Tags                       Arch         Size   Cached
-///   archlinux:rolling   stable, latest             amd64   530.8 MiB       no
-///   debian:12           bookworm                   amd64   428.7 MiB       no
-///   debian:13           trixie, stable, latest     amd64   413.6 MiB      yes
-///   fedora:43                                      amd64   556.3 MiB       no
-///   fedora:44           stable, latest             amd64   556.7 MiB       no
+///   Name                Tags                       Arch     Size   Cached
+///   archlinux:rolling   stable, latest             amd64   531 M       no
+///   debian:12           bookworm                   amd64   429 M       no
+///   debian:13           trixie, stable, latest     amd64   414 M      yes
+///   fedora:43                                      amd64   556 M       no
+///   fedora:44           stable, latest             amd64   557 M       no
 ///   [...]
-///   ubuntu:25.10        questing                   amd64   394.2 MiB       no
-///   ubuntu:26.04        resolute, stable, latest   amd64   407.8 MiB      yes
+///   ubuntu:25.10        questing                   amd64   394 M       no
+///   ubuntu:26.04        resolute, stable, latest   amd64   408 M      yes
 ///   [...]
 ///
 ///   Use the name of a row or swap its version for one of its tags, so

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -10,17 +10,17 @@ use clap::Parser;
 /// Examples:
 ///
 ///   $ cubic instances
-///   Name          Arch    CPUs     Memory   Disk Used   Disk Total   Running
-///   noble-arm64   arm64      8    8.0 GiB     4.4 GiB    100.0 GiB       yes
-///   trixie        amd64      6   16.0 GiB         n/a    100.0 GiB       yes
-///   fedora        amd64      4    4.0 GiB    10.0 GiB    100.0 GiB        no
+///   Name          Arch    CPUs   Memory       Disk   Running
+///   noble-arm64   arm64      8   8192 M    4/100 G       yes
+///   trixie        amd64      6     16 G      100 G       yes
+///   fedora        amd64      4   4096 M   10/100 G        no
 ///
 ///   Show the process id of each running VM instance:
 ///   $ cubic instances --all
-///   PID    Name          Arch    CPUs     Memory   Disk Used   Disk Total   Running
-///          noble-arm64   arm64      8    8.0 GiB     4.4 GiB    100.0 GiB       yes
-///   1059   trixie        amd64      6   16.0 GiB         n/a    100.0 GiB       yes
-///          fedora        amd64      4    4.0 GiB    10.0 GiB    100.0 GiB        no
+///   PID    Name          Arch    CPUs   Memory       Disk   Running
+///          noble-arm64   arm64      8   8192 M    4/100 G       yes
+///   1059   trixie        amd64      6     16 G      100 G       yes
+///          fedora        amd64      4   4096 M   10/100 G        no
 ///
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
@@ -44,8 +44,7 @@ impl Command for ListInstanceCommand {
             .add("Arch", Alignment::Left)
             .add("CPUs", Alignment::Right)
             .add("Memory", Alignment::Right)
-            .add("Disk Used", Alignment::Right)
-            .add("Disk Total", Alignment::Right)
+            .add("Disk", Alignment::Right)
             .add("Running", Alignment::Right);
 
         for instance_name in &instance_names {
@@ -59,15 +58,19 @@ impl Command for ListInstanceCommand {
                     .unwrap_or_default();
                 row.add(&pid, Alignment::Left);
             }
+            let disk = match &instance.disk_used {
+                Some(used) => format!(
+                    "{}/{}",
+                    used.to_value_in(&instance.disk_capacity),
+                    instance.disk_capacity.to_size()
+                ),
+                None => instance.disk_capacity.to_size(),
+            };
             row.add(instance_name, Alignment::Left)
                 .add(&instance.arch.to_string(), Alignment::Left)
                 .add(&instance.cpus.to_string(), Alignment::Right)
                 .add(&instance.mem.to_size(), Alignment::Right)
-                .add(
-                    &util::format_or_na(instance.disk_used.as_ref().map(|size| size.to_size())),
-                    Alignment::Right,
-                )
-                .add(&instance.disk_capacity.to_size(), Alignment::Right)
+                .add(&disk, Alignment::Right)
                 .add(
                     util::to_yes_no(instance_store.is_running(&instance)),
                     Alignment::Right,
@@ -108,6 +111,7 @@ mod tests {
                 user: UserName::from_str("cubic").unwrap(),
                 cpus: 1,
                 mem: DataSize::new(1024),
+                disk_used: Some(DataSize::new(512 * 1024)),
                 disk_capacity: DataSize::new(1048576),
                 ssh_port: 9000,
                 hostfwd: Vec::new(),
@@ -140,9 +144,9 @@ mod tests {
         assert_eq!(
             system.get_output(),
             "\
-Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
-test    amd64      1   1.0 KiB         n/a      1.0 MiB        no
-test2   amd64      5     0   B         n/a      4.9 KiB        no
+Name    Arch    CPUs   Memory         Disk   Running
+test    amd64      1   1024 B   512/1024 K        no
+test2   amd64      5      0 B       5000 B        no
 "
         );
     }
@@ -160,9 +164,9 @@ test2   amd64      5     0   B         n/a      4.9 KiB        no
         assert_eq!(
             system.get_output(),
             "\
-PID   Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
-      test    amd64      1   1.0 KiB         n/a      1.0 MiB        no
-      test2   amd64      5     0   B         n/a      4.9 KiB        no
+PID   Name    Arch    CPUs   Memory         Disk   Running
+      test    amd64      1   1024 B   512/1024 K        no
+      test2   amd64      5      0 B       5000 B        no
 "
         );
     }
@@ -183,9 +187,9 @@ PID   Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
         assert_eq!(
             system.get_output(),
             "\
-PID    Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
-       test    amd64      1   1.0 KiB         n/a      1.0 MiB        no
-1059   test2   amd64      5     0   B         n/a      4.9 KiB       yes
+PID    Name    Arch    CPUs   Memory         Disk   Running
+       test    amd64      1   1024 B   512/1024 K        no
+1059   test2   amd64      5      0 B       5000 B       yes
 "
         );
     }
@@ -202,7 +206,7 @@ PID    Name    Arch    CPUs    Memory   Disk Used   Disk Total   Running
 
         assert_eq!(
             system.get_output(),
-            "Name   Arch   CPUs   Memory   Disk Used   Disk Total   Running\n"
+            "Name   Arch   CPUs   Memory   Disk   Running\n"
         );
     }
 }

--- a/src/commands/prune_command.rs
+++ b/src/commands/prune_command.rs
@@ -131,6 +131,6 @@ mod tests {
                 .add_file("/cache/instances/test/user-data.img", &[0; 1024]),
         );
 
-        assert!(run_prune(&system, &env).contains("frees 2.0 KiB"));
+        assert!(run_prune(&system, &env).contains("frees 2048 B"));
     }
 }

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -16,9 +16,9 @@ use clap::Parser;
 ///   Running:      yes
 ///   Arch:         amd64
 ///   CPUs:         6
-///   Memory:       16.0 GiB
-///   Disk Used:    5.2 GiB
-///   Disk Total:   100.0 GiB
+///   Memory:       16 G
+///   Disk Used:    5325 M
+///   Disk Total:   100 G
 ///   User:         cubic
 ///   Isolated:     no
 ///   SSH Port:     54315
@@ -42,7 +42,7 @@ use clap::Parser;
 ///   Name:         ubuntu:26.04
 ///   Tags:         resolute, stable, latest
 ///   Architecture: amd64
-///   Size:         407.8 MiB
+///   Size:         408 M
 ///   Cached:       yes
 ///
 ///   Show all image information, adding checksum, file path and URLs

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -136,8 +136,8 @@ mod tests {
 Running:    no
 Arch:       amd64
 CPUs:       1
-Memory:     1.0 KiB
-Disk Total: 1.0 MiB
+Memory:     1024 B
+Disk Total: 1024 K
 User:       myuser
 Isolated:   no
 SSH Port:   9000
@@ -215,8 +215,8 @@ Forward:    127.0.0.1:4000:40/tcp
 Running:      no
 Arch:         arm64
 CPUs:         2
-Memory:       1   B
-Disk Total:   1   B
+Memory:       1 B
+Disk Total:   1 B
 User:         john
 Isolated:     yes
 SSH Port:     8000

--- a/src/models/data_size.rs
+++ b/src/models/data_size.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
 
+const UNITS: [&str; 5] = ["B", "K", "M", "G", "T"];
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct DataSize {
     bytes: usize,
@@ -16,13 +18,34 @@ impl DataSize {
     }
 
     pub fn to_size(&self) -> String {
-        match self.bytes.checked_ilog(1024) {
-            Some(1) => format!("{:.1} KiB", self.bytes as f64 / 1024_f64.powf(1_f64)),
-            Some(2) => format!("{:.1} MiB", self.bytes as f64 / 1024_f64.powf(2_f64)),
-            Some(3) => format!("{:.1} GiB", self.bytes as f64 / 1024_f64.powf(3_f64)),
-            Some(4) => format!("{:.1} TiB", self.bytes as f64 / 1024_f64.powf(4_f64)),
-            _ => format!("{}   B", self.bytes as f64),
+        let power = self.get_power();
+        format!("{} {}", self.to_value_at(power), UNITS[power])
+    }
+
+    // Value rounded to the unit another size prints in, so a used size and a
+    // total size can share one unit and read as a fraction.
+    pub fn to_value_in(&self, total: &DataSize) -> u64 {
+        self.to_value_at(total.get_power())
+    }
+
+    fn to_value_at(&self, power: usize) -> u64 {
+        (self.bytes as f64 / 1024_f64.powi(power as i32)).round() as u64
+    }
+
+    // The unit index this size prints in.
+    fn get_power(&self) -> usize {
+        let bytes = self.bytes as f64;
+        let mut power = (1..UNITS.len())
+            .rev()
+            .find(|power| bytes / 1024_f64.powi(*power as i32) >= 10_f64)
+            .unwrap_or(0);
+
+        // Keep the number to four digits, so 10000 B shows as 10 K.
+        if power + 1 < UNITS.len() && bytes / 1024_f64.powi(power as i32) >= 10_000_f64 {
+            power += 1;
         }
+
+        power
     }
 }
 
@@ -82,28 +105,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_byte_to_size() {
-        assert_eq!(&DataSize::new(1).to_size(), "1   B")
+    fn test_zero_to_size() {
+        assert_eq!(&DataSize::new(0).to_size(), "0 B")
     }
 
     #[test]
-    fn test_kilobyte_to_size() {
-        assert_eq!(&DataSize::new(1024).to_size(), "1.0 KiB")
+    fn test_drops_to_a_lower_unit_below_ten() {
+        assert_eq!(&DataSize::new(1024_usize.pow(2)).to_size(), "1024 K")
     }
 
     #[test]
-    fn test_megabyte_to_size() {
-        assert_eq!(&DataSize::new(1024_usize.pow(2)).to_size(), "1.0 MiB")
+    fn test_keeps_the_unit_from_ten() {
+        assert_eq!(&DataSize::new(10 * 1024_usize.pow(2)).to_size(), "10 M")
     }
 
     #[test]
-    fn test_gigabyte_to_size() {
-        assert_eq!(&DataSize::new(1024_usize.pow(3)).to_size(), "1.0 GiB")
+    fn test_rounds_to_the_nearest_whole() {
+        assert_eq!(
+            &DataSize::new(107 * 1024_usize.pow(3) / 10).to_size(),
+            "11 G"
+        )
     }
 
     #[test]
-    fn test_terabyte_to_size() {
-        assert_eq!(&DataSize::new(1024_usize.pow(4)).to_size(), "1.0 TiB")
+    fn test_caps_the_number_at_four_digits() {
+        assert_eq!(&DataSize::new(9999).to_size(), "9999 B");
+        assert_eq!(&DataSize::new(10_000).to_size(), "10 K");
+    }
+
+    #[test]
+    fn test_scales_the_value_to_another_unit() {
+        let total = DataSize::new(100 * 1024_usize.pow(3));
+        assert_eq!(DataSize::new(1024_usize.pow(3)).to_value_in(&total), 1);
+        assert_eq!(
+            DataSize::new(44 * 1024_usize.pow(3)).to_value_in(&total),
+            44
+        );
     }
 
     #[test]

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -13,10 +13,6 @@ pub fn to_yes_no(condition: bool) -> &'static str {
     if condition { "yes" } else { "no" }
 }
 
-pub fn format_or_na<T: ToString>(value: Option<T>) -> String {
-    value.map_or_else(|| "n/a".to_string(), |value| value.to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -41,12 +37,5 @@ mod tests {
     fn test_to_yes_no() {
         assert_eq!(to_yes_no(true), "yes");
         assert_eq!(to_yes_no(false), "no");
-    }
-
-    #[test]
-    fn test_format_or_na() {
-        assert_eq!(format_or_na(Some(8001)), "8001");
-        assert_eq!(format_or_na(Some("1.0 GiB".to_string())), "1.0 GiB");
-        assert_eq!(format_or_na(None::<u16>), "n/a");
     }
 }

--- a/src/view/transfer_view.rs
+++ b/src/view/transfer_view.rs
@@ -28,15 +28,24 @@ impl TransferView {
 impl Animation for TransferView {
     fn render(&mut self, width: usize) -> String {
         let text = format!("{:TEXT_WIDTH$.TEXT_WIDTH$}", self.message);
-        let transferred = DataSize::new(self.transferred_bytes as usize).to_size();
 
         let Some(total_bytes) = self.total_bytes else {
+            let transferred = DataSize::new(self.transferred_bytes as usize).to_size();
             return format!("{text}{transferred}");
         };
 
-        let total = DataSize::new(total_bytes as usize).to_size();
+        // Show the transferred size in the unit of the total so the two read
+        // as a fraction. Its value never has more digits than the total, so
+        // the field width stays fixed and nothing shifts during a transfer.
+        let total = DataSize::new(total_bytes as usize);
+        let transferred = DataSize::new(self.transferred_bytes as usize).to_value_in(&total);
+        let size_width = total.to_value_in(&total).to_string().len();
         let percent = self.transferred_bytes as f64 / total_bytes as f64;
-        let stats = format!("{:>3.0}% {transferred} / {total}", percent * 100_f64);
+        let stats = format!(
+            "{:>3.0}% {transferred:>size_width$}/{}",
+            percent * 100_f64,
+            total.to_size()
+        );
         let bar_width = width
             .saturating_sub(text.len() + 2 + stats.len())
             .max(MIN_BAR_WIDTH);
@@ -64,7 +73,17 @@ mod tests {
         let mut view = TransferView::new("Downloading ubuntu");
         view.set_progress(50, Some(100));
         let line = view.render(80);
-        assert!(line.ends_with("50% 50   B / 100   B"));
+        assert!(line.ends_with("50%  50/100 B"));
+    }
+
+    #[test]
+    fn test_stats_stay_put_as_the_size_grows() {
+        let mut view = TransferView::new("Downloading ubuntu");
+        view.set_progress(1, Some(10 * 1024 * 1024 * 1024));
+        let small = view.render(80);
+        view.set_progress(5 * 1024 * 1024 * 1024, Some(10 * 1024 * 1024 * 1024));
+        let large = view.render(80);
+        assert_eq!(small.find('/'), large.find('/'));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This makes data sizes easier to read. A size now shows as a whole number with one short unit like 10 K or 4 G. No more decimals. Sizes stay binary so one G is 1024 M.

When there is a total to compare against, cubic shows the two sizes as a fraction in the same unit. The instances list shows disk use as used over capacity like 4/100 G. The download view shows how much has arrived out of the total. Using one unit keeps the numbers lined up so the progress bar does not jump around while a download runs.

## Related Issue(s)

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Ran `make fix-format` and `make test`. All tests pass. New tests check the fraction output in the instances list and the download view.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed