### PR TITLE
refactor: fit process and session handling to the async runtime

### DIFF
--- a/src/commands/console_command.rs
+++ b/src/commands/console_command.rs
@@ -7,8 +7,7 @@ use crate::util;
 use crate::view::Console;
 use clap::Parser;
 use std::path::PathBuf;
-use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio_util::codec::FramedRead;
 use tokio_util::io::StreamReader;
@@ -66,22 +65,24 @@ impl Command for ConsoleCommand {
 
         let system = context.get_system();
         let instance_store = context.get_instance_store();
-        let deadline = Instant::now() + CONSOLE_TIMEOUT;
-        let mut was_running = false;
-        while system.connect_port(port, PROBE_IO_TIMEOUT).is_err() {
-            // QEMU writes its pid file after the spawn returns, so only a pid
-            // file that vanished again means it exited.
-            let running = instance_store.is_running(&instance);
-            if was_running && !running {
-                return Err(Error::InstanceNotRunning(instance.name.clone()));
-            }
-            was_running |= running;
+        let wait = async {
+            let mut was_running = false;
+            while system.connect_port(port, PROBE_IO_TIMEOUT).is_err() {
+                // QEMU writes its pid file after the spawn returns, so only a pid
+                // file that vanished again means it exited.
+                let running = instance_store.is_running(&instance);
+                if was_running && !running {
+                    return Err(Error::InstanceNotRunning(instance.name.clone()));
+                }
+                was_running |= running;
 
-            if Instant::now() >= deadline {
-                return Err(Error::ConsoleTimeout(instance.name.clone()));
+                tokio::time::sleep(Duration::from_secs(1)).await;
             }
-            thread::sleep(Duration::from_secs(1));
-        }
+            Ok(())
+        };
+        tokio::time::timeout(CONSOLE_TIMEOUT, wait)
+            .await
+            .map_err(|_| Error::ConsoleTimeout(instance.name.clone()))??;
 
         console.raw_mode();
         let shell = async {

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -9,8 +9,7 @@ use crate::view::Console;
 use crate::view::{ConfirmDialog, Spinner};
 use clap::Parser;
 use std::sync::{Arc, Mutex};
-use std::thread::sleep;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Start VM instances
 ///
@@ -91,13 +90,17 @@ impl Command for StartCommand {
                 "Starting {}",
                 starting.join(", ")
             )))));
-            let deadline = Instant::now() + Duration::from_secs(300);
-            while actions.iter().any(|a| !a.is_done(context.get_system())) {
-                if Instant::now() >= deadline {
-                    console.stop();
-                    return Err(Error::StartTimeout);
+            let wait = async {
+                while actions.iter().any(|a| !a.is_done(context.get_system())) {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
                 }
-                sleep(Duration::from_secs(1));
+            };
+            if tokio::time::timeout(Duration::from_secs(300), wait)
+                .await
+                .is_err()
+            {
+                console.stop();
+                return Err(Error::StartTimeout);
             }
             console.stop()
         }

--- a/src/commands/stop_command.rs
+++ b/src/commands/stop_command.rs
@@ -5,7 +5,6 @@ use crate::view::Console;
 use crate::view::Spinner;
 use clap::Parser;
 use std::sync::{Arc, Mutex};
-use std::thread;
 use std::time::Duration;
 
 /// Stop VM instances
@@ -81,7 +80,7 @@ impl Command for StopCommand {
 
         if self.wait {
             while actions.iter().any(|action| !action.is_done(instance_store)) {
-                thread::sleep(Duration::from_secs(1))
+                tokio::time::sleep(Duration::from_secs(1)).await
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,10 @@ mod web;
 use crate::commands::CommandDispatcher;
 use crate::platform::{OsSystem, System};
 use clap::Parser;
-use std::process::ExitCode;
 use std::rc::Rc;
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> ExitCode {
+async fn main() -> ! {
     // Disable raw mode before the default panic hook runs, so a panic during
     // an interactive session (ssh, console) does not leave the terminal
     // broken. This also covers panic = 'abort' builds, since the hook runs
@@ -34,14 +33,14 @@ async fn main() -> ExitCode {
 
     let system: Rc<dyn System> = Rc::new(OsSystem::new());
     let console = &mut view::Console::new(system.as_ref());
-    match CommandDispatcher::parse()
+    let result = CommandDispatcher::parse()
         .dispatch(Rc::clone(&system), console)
-        .await
-    {
-        Ok(()) => ExitCode::SUCCESS,
-        Err(e) => {
-            console.error(&e.to_string());
-            ExitCode::FAILURE
-        }
+        .await;
+    if let Err(error) = &result {
+        console.error(&error.to_string());
     }
+    let code = result.map_or(1, |()| 0);
+
+    console.flush();
+    system.exit(code);
 }

--- a/src/platform/os_process.rs
+++ b/src/platform/os_process.rs
@@ -170,10 +170,7 @@ impl Process for OsSystem {
             }
         }
 
-        // Reap the child when it eventually exits to avoid a zombie process.
-        std::thread::spawn(move || {
-            let _ = child.wait();
-        });
+        self.keep_child(child);
 
         Ok(())
     }
@@ -184,6 +181,7 @@ impl Process for OsSystem {
     }
 
     fn exit(&self, code: i32) -> ! {
+        self.reap_children();
         std::process::exit(code)
     }
 

--- a/src/platform/os_process.rs
+++ b/src/platform/os_process.rs
@@ -183,6 +183,10 @@ impl Process for OsSystem {
         system.process(sys_pid).is_some()
     }
 
+    fn exit(&self, code: i32) -> ! {
+        std::process::exit(code)
+    }
+
     fn kill_process(&self, pid: u64) -> Result<()> {
         let (system, sys_pid) = Self::read_process_table(pid);
         let process = system.process(sys_pid).ok_or(Error::ProcessNotFound(pid))?;

--- a/src/platform/os_system.rs
+++ b/src/platform/os_system.rs
@@ -1,8 +1,23 @@
+use std::cell::RefCell;
+use std::process::Child;
+
 #[derive(Default)]
-pub struct OsSystem;
+pub struct OsSystem {
+    children: RefCell<Vec<Child>>,
+}
 
 impl OsSystem {
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    pub fn keep_child(&self, child: Child) {
+        self.children.borrow_mut().push(child);
+    }
+
+    pub fn reap_children(&self) {
+        for mut child in self.children.borrow_mut().drain(..) {
+            let _ = child.try_wait();
+        }
     }
 }

--- a/src/platform/process.rs
+++ b/src/platform/process.rs
@@ -18,4 +18,6 @@ pub trait Process {
 
     fn exists_process(&self, pid: u64) -> bool;
     fn kill_process(&self, pid: u64) -> Result<()>;
+
+    fn exit(&self, code: i32) -> !;
 }

--- a/src/platform/process_mock.rs
+++ b/src/platform/process_mock.rs
@@ -169,6 +169,10 @@ impl Process for SystemMock {
     fn kill_process(&self, pid: u64) -> Result<()> {
         self.processes.borrow_mut().kill(pid)
     }
+
+    fn exit(&self, _code: i32) -> ! {
+        panic!("exit is not supported in tests")
+    }
 }
 
 #[cfg(test)]

--- a/src/view/console.rs
+++ b/src/view/console.rs
@@ -148,6 +148,11 @@ impl<'a> Console<'a> {
         self.emit(Stream::Stderr, msg, Some(("error:", Color::Red)));
     }
 
+    pub fn flush(&mut self) {
+        self.system.flush(Stream::Stdout);
+        self.system.flush(Stream::Stderr);
+    }
+
     pub fn get_geometry(&self) -> Option<(u32, u32)> {
         crossterm::terminal::size()
             .map(|(w, h)| (w as u32, h as u32))


### PR DESCRIPTION
## Summary

These changes fit the process and session handling to the async runtime. Background processes are now held and cleaned up when cubic exits instead of each being watched by its own helper thread. An ssh or console session returns to the shell the moment it closes instead of waiting for a key press. The start, stop, and console wait loops now use async timers so polling no longer stalls the runtime.

## Related Issue(s)

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Ran make check so formatting, lint, and the full test suite pass locally.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed