### PR TITLE
feat: make exec easier to script

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Examples:
   $ cubic show <instance>
 
   Execute a command in a VM instance:
-  $ cubic exec <instance> <shell command>
+  $ cubic exec <instance> -- <command>
 
   Transfer files and directories between host and VM instance:
   $ cubic scp <path/to/host/file> <instance>:<path/to/guest/file>

--- a/docs/howto/env_vars.rst
+++ b/docs/howto/env_vars.rst
@@ -64,7 +64,7 @@ Run a One-Off Command
 
 .. code-block::
 
-    $ cubic exec builder --env GITHUB_TOKEN "pip install git+https://github.com/your-org/private-lib.git"
+    $ cubic exec builder --env GITHUB_TOKEN -- pip install git+https://github.com/your-org/private-lib.git
 
 Related
 -------

--- a/docs/howto/exec.rst
+++ b/docs/howto/exec.rst
@@ -70,14 +70,32 @@ something you want the guest to see, because the words arrive as one string:
 Check the Result
 ----------------
 
-``cubic exec`` reports whether it reached the guest, not what the command
-decided there. A command that fails inside the guest still leaves ``cubic exec``
-successful, so ask the guest itself when a script depends on the answer:
+``cubic exec`` ends with the exit code of the command in the guest, so a script
+on the host can act on it:
 
 .. code-block::
 
-    $ cubic exec demo "test -f /etc/cubic-tutorial && echo present || echo missing"
-    missing
+    $ cubic exec demo -- test -f /etc/motd
+    $ echo $?
+    0
+    $ cubic exec demo -- test -f /etc/cubic-tutorial
+    $ echo $?
+    1
+
+The code 255 means the session ended without a result from the guest, for
+example when the connection broke or when you left the session with Enter,
+``~``, ``.``.
+
+``cubic ssh`` and ``cubic run`` work the same way and end with the exit code of
+the login shell in the guest.
+
+A command that reads from a pipe or a file works as well, because Cubic asks for
+a terminal in the guest only when your own terminal is attached:
+
+.. code-block::
+
+    $ echo hello | cubic exec demo -- cat
+    hello
 
 Run a Command at Creation
 -------------------------

--- a/docs/howto/exec.rst
+++ b/docs/howto/exec.rst
@@ -10,23 +10,62 @@ to get an answer out of a guest.
 Run a Command
 -------------
 
+Put ``--`` between the instance and the command:
+
 .. code-block::
 
-    $ cubic exec demo "uname -sr"
+    $ cubic exec demo -- uname -sr
     Linux 7.0.0-30-generic
 
-Quote the command, so the shell of the host passes it on instead of expanding
-it.
+Everything after the instance goes to the guest, so a word that starts with a
+hyphen arrives as it is:
+
+.. code-block::
+
+    $ cubic exec demo -- echo -ne hello
+    hello
+
+Three Ways to Write It
+----------------------
+
+Cubic joins the words of the command with a space and hands the result to the
+shell of the guest, so these three lines send the same string and all three
+work:
+
+.. code-block::
+
+    $ cubic exec demo -- echo -ne hello
+    $ cubic exec demo echo -ne hello
+    $ cubic exec demo "echo -ne hello"
+
+The ``--`` form says most clearly where the command starts, so the rest of this
+page uses it. Leaving ``--`` out reads well for a short command. The quoted form
+is the one older scripts use and it keeps working.
+
+Options of Cubic itself have to come before the command, because everything
+after the instance belongs to the guest:
+
+.. code-block::
+
+    $ cubic exec demo --env GITHUB_TOKEN -- pip install my-lib
 
 Run Several Commands
 --------------------
 
-The command reaches the guest through its shell, so the usual operators work
-inside the quotes:
+The command reaches the guest through its shell. Quote the whole command to
+keep the operators away from the shell of the host:
 
 .. code-block::
 
     $ cubic exec demo "sudo apt update && sudo apt install -y vim"
+
+Quote it as well when a word holds a space, or when the host would expand
+something you want the guest to see, because the words arrive as one string:
+
+.. code-block::
+
+    $ cubic exec demo "grep 'hello world' /etc/motd"
+    $ cubic exec demo "echo \$HOME"
 
 Check the Result
 ----------------

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -75,5 +75,5 @@ use std::sync::Arc;
 // The runtime is single threaded, so the returned futures never need Send.
 #[allow(async_fn_in_trait)]
 trait Command {
-    async fn run(&self, console: &Arc<Console>, context: &Context) -> Result<()>;
+    async fn run(&self, console: &Arc<Console>, context: &Context) -> Result<u8>;
 }

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -23,7 +23,7 @@ pub struct CloneCommand {
 }
 
 impl Command for CloneCommand {
-    async fn run(&self, console: &Arc<Console>, context: &Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &Context) -> Result<u8> {
         let instance_store = context.get_instance_store();
 
         // Verify that the target name is available
@@ -62,7 +62,7 @@ impl Command for CloneCommand {
         // Create VM instance
         CreateInstanceAction::new().run(context, image_path, target, false)?;
 
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -101,10 +101,10 @@ pub struct CommandDispatcher {
 }
 
 impl CommandDispatcher {
-    pub async fn dispatch(self, system: Arc<dyn System>, console: &Arc<Console>) -> Result<()> {
+    pub async fn dispatch(self, system: Arc<dyn System>, console: &Arc<Console>) -> Result<u8> {
         let Some(command) = self.command else {
             println!("{}", CommandDispatcher::command().render_long_help());
-            return Ok(());
+            return Ok(0);
         };
 
         console.set_verbosity(commands::Verbosity::new(

--- a/src/commands/command_dispatcher.rs
+++ b/src/commands/command_dispatcher.rs
@@ -72,7 +72,7 @@ Examples:
   $ cubic show <instance>
 
   Execute a command in a VM instance:
-  $ cubic exec <instance> <shell command>
+  $ cubic exec <instance> -- <command>
 
   Transfer files and directories between host and VM instance:
   $ cubic scp <path/to/host/file> <instance>:<path/to/guest/file>

--- a/src/commands/completions_command.rs
+++ b/src/commands/completions_command.rs
@@ -23,7 +23,7 @@ pub struct CompletionsCommand {
 }
 
 impl Command for CompletionsCommand {
-    async fn run(&self, _console: &Arc<Console>, _context: &Context) -> Result<()> {
+    async fn run(&self, _console: &Arc<Console>, _context: &Context) -> Result<u8> {
         let Some(shell) = self.shell.or_else(Shell::from_env) else {
             return Err(Error::CouldNotDetectShell);
         };
@@ -31,6 +31,6 @@ impl Command for CompletionsCommand {
         let mut cmd = CommandDispatcher::command();
         let name = cmd.get_name().to_string();
         clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
-        Ok(())
+        Ok(0)
     }
 }

--- a/src/commands/console_command.rs
+++ b/src/commands/console_command.rs
@@ -37,7 +37,7 @@ pub struct ConsoleCommand {
 }
 
 impl Command for ConsoleCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         commands::StartCommand {
             qemu_args: None,
             accel: self.accel,
@@ -79,7 +79,7 @@ impl Command for ConsoleCommand {
 
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }
-            Ok(())
+            Ok(0)
         };
         tokio::time::timeout(CONSOLE_TIMEOUT, wait)
             .await
@@ -109,7 +109,7 @@ impl Command for ConsoleCommand {
             console.error("Cannot open shell");
         }
         console.reset();
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -218,8 +218,9 @@ impl CreateCommand {
 }
 
 impl Command for CreateCommand {
-    async fn run(&self, console: &Arc<Console>, context: &Context) -> Result<()> {
-        self.create(console, context, false).await
+    async fn run(&self, console: &Arc<Console>, context: &Context) -> Result<u8> {
+        self.create(console, context, false).await?;
+        Ok(0)
     }
 }
 

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -76,7 +76,7 @@ impl DeleteCommand {
 }
 
 impl Command for DeleteCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let instance_store = context.get_instance_store();
 
         if self.targets.is_empty() {
@@ -105,7 +105,7 @@ impl Command for DeleteCommand {
 
         console.info("Running instances are stopped before deletion.");
         if !self.yes.value && !ConfirmDialog::new("Do you want to proceed?").confirm(console) {
-            return Ok(());
+            return Ok(0);
         }
 
         for target in &targets {
@@ -134,7 +134,7 @@ impl Command for DeleteCommand {
         }
 
         console.print("Successfully deleted all targets");
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/exec_command.rs
+++ b/src/commands/exec_command.rs
@@ -45,7 +45,7 @@ impl ExecCommand {
 }
 
 impl Command for ExecCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let env = context.get_env();
         let name = self.target.get_instance();
 
@@ -78,8 +78,7 @@ impl Command for ExecCommand {
         let channel = ssh
             .open_channel(console, &instance.name, &client_key, &user, ssh_port)
             .await?;
-        ssh.shell(console, name.as_str(), channel).await?;
-        Ok(())
+        ssh.shell(console, name.as_str(), channel).await
     }
 }
 

--- a/src/commands/exec_command.rs
+++ b/src/commands/exec_command.rs
@@ -9,9 +9,18 @@ use std::sync::Arc;
 
 /// Execute a command in a VM instance
 ///
+/// The words of the command are joined with a space and run by the shell of the
+/// VM instance, so all three forms below send the same command. Options of
+/// Cubic itself have to come before the command.
+///
 /// Examples:
 ///
-///   Update a VM instance:
+///   Run a command in a VM instance:
+///   $ cubic exec noble -- echo -ne hello
+///   $ cubic exec noble echo -ne hello
+///   $ cubic exec noble "echo -ne hello"
+///
+///   Quote the command to use the operators of the shell:
 ///   $ cubic exec noble "sudo apt update && sudo apt full-upgrade -y"
 ///
 #[derive(Parser)]
@@ -20,11 +29,19 @@ pub struct ExecCommand {
     /// Target instance (format: [username@]instance, e.g. 'myinstance' or 'cubic@myinstance')
     pub target: Target,
     /// Command to execute in the virtual machine instance
-    pub cmd: String,
+    #[clap(trailing_var_arg = true, allow_hyphen_values = true, num_args = 1.., required = true)]
+    pub cmd: Vec<String>,
     #[clap(flatten)]
     pub accel: commands::AccelArg,
     #[clap(flatten)]
     pub env_args: commands::EnvArgs,
+}
+
+impl ExecCommand {
+    // The guest shell parses the result, so a plain join is enough.
+    fn build_cmd(&self) -> String {
+        self.cmd.join(" ")
+    }
 }
 
 impl Command for ExecCommand {
@@ -50,18 +67,46 @@ impl Command for ExecCommand {
             .unwrap_or_else(|| instance.user.to_string());
         let ssh_port = instance.ssh_port;
         let client_key = env.get_ssh_private_key_file(name.as_str());
+        let cmd = self.build_cmd();
         console.debug(&format!(
-            "Executing on '{name}' as '{user}' on port {ssh_port} using key '{client_key}': {}",
-            self.cmd
+            "Executing on '{name}' as '{user}' on port {ssh_port} using key '{client_key}': {cmd}"
         ));
         let mut ssh = SshClient::new(context);
         ssh.set_private_keys(env.get_home_ssh_private_key_paths(context.get_system()));
-        ssh.set_cmd(Some(self.cmd.clone()));
+        ssh.set_cmd(Some(cmd));
         ssh.set_env_vars(self.env_args.env_vars.clone());
         let channel = ssh
             .open_channel(console, &instance.name, &client_key, &user, ssh_port)
             .await?;
         ssh.shell(console, name.as_str(), channel).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_cmd_from_unquoted_words() {
+        let command =
+            ExecCommand::try_parse_from(["exec", "vm", "--", "echo", "-ne", "hello"]).unwrap();
+        assert_eq!(command.build_cmd(), "echo -ne hello");
+    }
+
+    #[test]
+    fn test_build_cmd_keeps_a_quoted_command_unchanged() {
+        let command =
+            ExecCommand::try_parse_from(["exec", "vm", "sudo apt update && sudo apt upgrade"])
+                .unwrap();
+        assert_eq!(command.build_cmd(), "sudo apt update && sudo apt upgrade");
+    }
+
+    #[test]
+    fn test_options_are_parsed_before_the_command() {
+        let command =
+            ExecCommand::try_parse_from(["exec", "vm", "--env", "FOO", "echo", "hi"]).unwrap();
+        assert_eq!(command.env_args.env_vars, ["FOO"]);
+        assert_eq!(command.build_cmd(), "echo hi");
     }
 }

--- a/src/commands/list_image_command.rs
+++ b/src/commands/list_image_command.rs
@@ -38,7 +38,7 @@ pub struct ListImageCommand {
 }
 
 impl Command for ListImageCommand {
-    async fn run(&self, console: &Arc<Console>, context: &Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &Context) -> Result<u8> {
         let images = fetch_image_list(console, context.get_system(), context.get_env()).await;
 
         let mut view = TableView::new();
@@ -74,6 +74,6 @@ impl Command for ListImageCommand {
                 );
         }
         view.print(console);
-        Ok(())
+        Ok(0)
     }
 }

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -31,7 +31,7 @@ pub struct ListInstanceCommand {
 }
 
 impl Command for ListInstanceCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let instance_store = context.get_instance_store();
         let instance_names = instance_store.get_instances();
 
@@ -78,7 +78,7 @@ impl Command for ListInstanceCommand {
                 );
         }
         view.print(console);
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/list_port_command.rs
+++ b/src/commands/list_port_command.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 pub struct ListPortCommand;
 
 impl Command for ListPortCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let instance_store = context.get_instance_store();
         let instance_names = instance_store.get_instances();
 
@@ -66,11 +66,11 @@ impl Command for ListPortCommand {
         if rule_count == 0 {
             console.print("No port forwarding rules are configured.");
             console.print("Add one with cubic modify <instance> --port <host_port>:<guest_port>");
-            return Ok(());
+            return Ok(0);
         }
 
         view.print(console);
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/modify_command.rs
+++ b/src/commands/modify_command.rs
@@ -68,7 +68,7 @@ pub struct ModifyCommand {
 }
 
 impl Command for ModifyCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let instance_store = context.get_instance_store();
         let mut instance =
             LoadInstanceAction::new().run(context, console, self.instance.value.as_str())?;
@@ -112,7 +112,7 @@ impl Command for ModifyCommand {
         instance.hostfwd.retain(|p| !self.rm_port.contains(p));
 
         instance_store.store(&instance)?;
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/prune_command.rs
+++ b/src/commands/prune_command.rs
@@ -21,7 +21,7 @@ pub struct PruneCommand {
 }
 
 impl Command for PruneCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let env = context.get_env();
         let system = context.get_system();
 
@@ -55,7 +55,7 @@ impl Command for PruneCommand {
             console.print(&format!("Successfully freed {total} of disk space."));
         }
 
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/rename_command.rs
+++ b/src/commands/rename_command.rs
@@ -23,13 +23,14 @@ pub struct RenameCommand {
 }
 
 impl Command for RenameCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let instance_store = context.get_instance_store();
 
         instance_store.rename(
             &mut LoadInstanceAction::new().run(context, console, self.old_name.as_str())?,
             self.new_name.as_str(),
-        )
+        )?;
+        Ok(0)
     }
 }
 

--- a/src/commands/restart_command.rs
+++ b/src/commands/restart_command.rs
@@ -24,7 +24,7 @@ pub struct RestartCommand {
 }
 
 impl Command for RestartCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         commands::StopCommand {
             all: false.into(),
             wait: true,

--- a/src/commands/restore_command.rs
+++ b/src/commands/restore_command.rs
@@ -37,7 +37,7 @@ pub struct RestoreCommand {
 }
 
 impl Command for RestoreCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let instance_store = context.get_instance_store();
         let instance_name = self.snapshot.get_instance();
         let snapshot_name = self.snapshot.as_str();
@@ -54,7 +54,7 @@ impl Command for RestoreCommand {
         console.info("The instance is stopped and all changes since the snapshot are lost.");
 
         if !self.yes.value && !ConfirmDialog::new("Do you want to proceed?").confirm(console) {
-            return Ok(());
+            return Ok(0);
         }
 
         // The restore discards the current state, so kill instead of a clean stop.
@@ -70,7 +70,7 @@ impl Command for RestoreCommand {
         instance_store.restore_snapshot(&instance, snapshot_name)?;
 
         console.print(&format!("Successfully restored {}", self.snapshot));
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/run_command.rs
+++ b/src/commands/run_command.rs
@@ -65,7 +65,7 @@ impl RunCommand {
 }
 
 impl Command for RunCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         self.create_cmd.create(console, context, self.rm).await?;
 
         let result = commands::SshCommand {

--- a/src/commands/scp_command.rs
+++ b/src/commands/scp_command.rs
@@ -74,7 +74,7 @@ pub struct ScpCommand {
 }
 
 impl Command for ScpCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         check_target_is_running(context, console, &self.from)?;
         check_target_is_running(context, console, &self.to)?;
 
@@ -96,7 +96,7 @@ impl Command for ScpCommand {
         ssh.set_private_keys(env.get_home_ssh_private_key_paths(context.get_system()));
         ssh.copy(console, &from, from_key.as_deref(), &to, to_key.as_deref())
             .await?;
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -69,7 +69,7 @@ pub struct ShowCommand {
 }
 
 impl Command for ShowCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         match &self.name {
             Either::Left(instance) => {
                 commands::ShowInstanceCommand {

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -18,7 +18,7 @@ pub struct ShowImageCommand {
 }
 
 impl Command for ShowImageCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let env = context.get_env();
         let image = fetch_image_info(console, context.get_system(), env, &self.name).await?;
 
@@ -45,6 +45,6 @@ impl Command for ShowImageCommand {
         }
 
         view.print(console);
-        Ok(())
+        Ok(0)
     }
 }

--- a/src/commands/show_instance_command.rs
+++ b/src/commands/show_instance_command.rs
@@ -18,7 +18,7 @@ pub struct ShowInstanceCommand {
 }
 
 impl Command for ShowInstanceCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let env = context.get_env();
         let instance_store = context.get_instance_store();
 
@@ -87,7 +87,7 @@ impl Command for ShowInstanceCommand {
 
         view.print(console);
 
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/snapshot_command.rs
+++ b/src/commands/snapshot_command.rs
@@ -30,7 +30,7 @@ pub struct SnapshotCommand {
 }
 
 impl Command for SnapshotCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let instance_store = context.get_instance_store();
         let instance_name = self.snapshot.get_instance();
 
@@ -43,7 +43,7 @@ impl Command for SnapshotCommand {
         instance_store.create_snapshot(&instance, self.snapshot.as_str())?;
 
         console.print(&format!("Created snapshot {}", self.snapshot));
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/ssh_command.rs
+++ b/src/commands/ssh_command.rs
@@ -27,7 +27,7 @@ pub struct SshCommand {
 }
 
 impl Command for SshCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let env = context.get_env();
 
         let name = self.target.get_instance();
@@ -63,7 +63,6 @@ impl Command for SshCommand {
             .open_channel(console, &instance.name, &client_key, &user, ssh_port)
             .await?;
         spinner.stop();
-        ssh.shell(console, &instance.name, channel).await?;
-        Ok(())
+        ssh.shell(console, &instance.name, channel).await
     }
 }

--- a/src/commands/start_command.rs
+++ b/src/commands/start_command.rs
@@ -45,7 +45,7 @@ pub struct StartCommand {
 }
 
 impl Command for StartCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         self.instances.require_names()?;
 
         let instance_store = context.get_instance_store();
@@ -101,7 +101,7 @@ impl Command for StartCommand {
             }
         }
 
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/commands/stop_command.rs
+++ b/src/commands/stop_command.rs
@@ -38,7 +38,7 @@ pub struct StopCommand {
 }
 
 impl Command for StopCommand {
-    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<()> {
+    async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let instance_store = context.get_instance_store();
 
         if !self.all.value {
@@ -81,7 +81,7 @@ impl Command for StopCommand {
             }
         }
 
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> ! {
     if let Err(error) = &result {
         console.error(&error.to_string());
     }
-    let code = result.map_or(1, |()| 0);
+    let code = result.map_or(1, i32::from);
 
     console.flush();
     system.exit(code);

--- a/src/platform/os_terminal.rs
+++ b/src/platform/os_terminal.rs
@@ -30,6 +30,10 @@ impl Terminal for OsSystem {
         }
     }
 
+    fn is_stdin_terminal(&self) -> bool {
+        stdin().is_terminal()
+    }
+
     fn read_input(&self) -> String {
         let mut reply = String::new();
         stdin().read_line(&mut reply).unwrap();

--- a/src/platform/terminal.rs
+++ b/src/platform/terminal.rs
@@ -5,6 +5,7 @@ pub trait Terminal {
     fn println(&self, stream: Stream, msg: &str);
     fn flush(&self, stream: Stream);
     fn is_terminal(&self, stream: Stream) -> bool;
+    fn is_stdin_terminal(&self) -> bool;
 
     fn read_input(&self) -> String;
     fn read_secret(&self) -> std::result::Result<String, ()>;

--- a/src/platform/terminal_mock.rs
+++ b/src/platform/terminal_mock.rs
@@ -66,6 +66,10 @@ impl Terminal for SystemMock {
         self.terminal.lock().unwrap().is_terminal
     }
 
+    fn is_stdin_terminal(&self) -> bool {
+        false
+    }
+
     fn read_input(&self) -> String {
         self.terminal.lock().unwrap().pop_input().trim().to_string()
     }

--- a/src/ssh/ssh_client.rs
+++ b/src/ssh/ssh_client.rs
@@ -10,6 +10,7 @@ use russh_sftp::client::SftpSession;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
+use tokio::io::AsyncWriteExt;
 use tokio_util::codec::FramedRead;
 use tokio_util::io::StreamReader;
 
@@ -306,30 +307,79 @@ impl<'a> SshClient<'a> {
             .map_err(|_| Error::SshConnectionFailed(machine.to_string()))
     }
 
+    /// Forwards stdin to the guest. On EOF it passes the EOF on and then waits
+    /// forever, so the guest decides when the session ends. It returns on
+    /// error, which is how the detach shortcut ends a session.
+    async fn forward_input(
+        stdin: &mut (impl tokio::io::AsyncRead + Unpin),
+        ssh_writer: &mut (impl tokio::io::AsyncWrite + Unpin),
+        ssh_out: &ChannelWriteHalf<client::Msg>,
+    ) {
+        if tokio::io::copy(stdin, ssh_writer).await.is_ok() {
+            ssh_out.eof().await.ok();
+            std::future::pending::<()>().await;
+        }
+    }
+
+    /// Writes the output of the guest to stdout and picks up the exit status of
+    /// the remote command. An EOF does not end the loop, because the guest
+    /// sends the exit status after it.
+    async fn forward_output(
+        ssh_in: &mut ChannelReadHalf,
+        stdout: &mut tokio::io::Stdout,
+    ) -> Option<u32> {
+        let mut exit_status = None;
+
+        while let Some(msg) = ssh_in.wait().await {
+            match msg {
+                ChannelMsg::Data { data } | ChannelMsg::ExtendedData { data, .. } => {
+                    if stdout.write_all(&data).await.is_err() || stdout.flush().await.is_err() {
+                        break;
+                    }
+                }
+                ChannelMsg::ExitStatus {
+                    exit_status: status,
+                } => exit_status = Some(status),
+                ChannelMsg::Close => break,
+                _ => (),
+            }
+        }
+
+        exit_status
+    }
+
+    /// Runs the session and returns the exit status of the guest.
     pub async fn shell(
         &self,
         console: &Arc<Console>,
         instance: &str,
         channel: Channel<russh::client::Msg>,
-    ) -> Result<(), Error> {
-        let (w, h) = console.get_geometry().unwrap();
+    ) -> Result<u8, Error> {
+        // A pty is what an interactive session needs, but it also keeps the
+        // guest from ever seeing the end of stdin. Ask for one only when stdin
+        // is a terminal, the same rule the OpenSSH client follows.
+        let pty = self.context.get_system().is_stdin_terminal();
 
-        channel
-            .request_pty(
-                false,
-                &self
-                    .context
-                    .get_system()
-                    .read_env_var("TERM")
-                    .unwrap_or_else(|| "xterm".into()),
-                w,
-                h,
-                0,
-                0,
-                &[],
-            )
-            .await
-            .map_err(|_| Error::SshConnectionFailed(instance.to_string()))?;
+        if pty {
+            let (w, h) = console.get_geometry().unwrap_or((80, 24));
+
+            channel
+                .request_pty(
+                    false,
+                    &self
+                        .context
+                        .get_system()
+                        .read_env_var("TERM")
+                        .unwrap_or_else(|| "xterm".into()),
+                    w,
+                    h,
+                    0,
+                    0,
+                    &[],
+                )
+                .await
+                .map_err(|_| Error::SshConnectionFailed(instance.to_string()))?;
+        }
 
         for var in &self.env_vars {
             let (name, value) = if let Some((k, v)) = var.split_once('=') {
@@ -361,7 +411,6 @@ impl<'a> SshClient<'a> {
                 .map_err(|_| Error::SshConnectionFailed(instance.to_string()))?;
         }
         let (mut ssh_in, ssh_out) = channel.split();
-        let mut ssh_reader = ssh_in.make_reader();
         let mut ssh_writer = ssh_out.make_writer();
 
         console.raw_mode();
@@ -370,13 +419,17 @@ impl<'a> SshClient<'a> {
             util::ShortcutDecoder::new(),
         ));
         let mut stdout = tokio::io::stdout();
+        let mut exit_status = None;
         tokio::select!(
-            _ = tokio::io::copy(&mut stdin, &mut ssh_writer) => {},
-            _ = tokio::io::copy(&mut ssh_reader, &mut stdout) => {},
-            _ = send_geometry_updates(console, &ssh_out) => {},
+            _ = Self::forward_input(&mut stdin, &mut ssh_writer, &ssh_out) => {},
+            status = Self::forward_output(&mut ssh_in, &mut stdout) => exit_status = status,
+            _ = send_geometry_updates(console, &ssh_out), if pty => {},
         );
         console.reset();
-        Ok(())
+
+        // 255 is the OpenSSH convention for a session that ended without an
+        // exit status.
+        Ok(exit_status.map_or(255, |status| status as u8))
     }
 
     async fn open_sftp(


### PR DESCRIPTION
## Summary

Make `cubic exec` easier to script. Commands can be written plainly without wrapping them in quotes, and a word that starts with a hyphen reaches the VM instance as it is while quoted commands keep working. On top of that `cubic exec`, `ssh` and `run` now end with the exit code of the command in the guest, so a script on the host can act on the result. A session that ends without a status gives 255 to match the OpenSSH client.

## Related Issue(s)

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

`make check` passes locally (rustfmt, clippy with `-D warnings`, yamllint, shellcheck, 487 tests, audit).

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed