### PR TITLE
fix: show a consistent Arch label for images

### DIFF
--- a/src/commands/show_command.rs
+++ b/src/commands/show_command.rs
@@ -40,11 +40,11 @@ use std::sync::Arc;
 ///   Show information of a VM image
 ///   A plain name is an instance, so an image needs a name or a tag
 ///   $ cubic show ubuntu:latest
-///   Name:         ubuntu:26.04
-///   Tags:         resolute, stable, latest
-///   Architecture: amd64
-///   Size:         408 M
-///   Cached:       yes
+///   Name:   ubuntu:26.04
+///   Tags:   resolute, stable, latest
+///   Arch:   amd64
+///   Size:   408 M
+///   Cached: yes
 ///
 ///   Show all image information, adding checksum, file path and URLs
 ///   $ cubic show --all ubuntu:noble

--- a/src/commands/show_image_command.rs
+++ b/src/commands/show_image_command.rs
@@ -25,7 +25,7 @@ impl Command for ShowImageCommand {
         let mut view = MapView::new();
         view.add("Name", &image.get_image_name());
         view.add("Tags", &image.get_tags());
-        view.add("Architecture", &image.arch.to_string());
+        view.add("Arch", &image.arch.to_string());
         if let Some(size) = image.size {
             view.add("Size", &DataSize::new(size as usize).to_size());
         }


### PR DESCRIPTION
## Summary

cubic show now prints Arch for images just like it does for instances and the list commands, so the field name is predictable across the CLI.

## Related Issue(s)

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Ran `make check`.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed