### PR TITLE
ci: build cubic for macOS on Apple Silicon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,25 +18,35 @@ jobs:
         include:
           - name: cubic-linux-amd64
             target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
             packages: gcc-x86-64-linux-gnu
             suffix: ""
 
           - name: cubic-linux-arm64
             target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04
             packages: gcc-aarch64-linux-gnu
             suffix: ""
 
           - name: cubic-windows-amd64
             target: x86_64-pc-windows-gnu
+            os: ubuntu-22.04
             packages: gcc-mingw-w64-x86-64
             suffix: .exe
 
-    runs-on: ubuntu-22.04
+          - name: cubic-macos-arm64
+            target: aarch64-apple-darwin
+            os: macos-latest
+            packages: ""
+            suffix: ""
+
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
 
       - name: Install Build Dependencies
+        if: matrix.packages != ''
         run: sudo apt-get update && sudo apt-get install -y ${{ matrix.packages }}
 
       - name: Setup Rust
@@ -66,6 +76,10 @@ jobs:
           - os: windows-latest
             artifact: cubic-windows-amd64
             cmd: ./cubic.exe --help
+
+          - os: macos-latest
+            artifact: cubic-macos-arm64
+            cmd: chmod +x cubic && ./cubic --help
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -228,12 +242,19 @@ jobs:
           name: cubic-windows-amd64
           path: windows-amd64
 
+      - name: Download macOS ARM64
+        uses: actions/download-artifact@v4
+        with:
+          name: cubic-macos-arm64
+          path: macos-arm64
+
       - name: Stage Release Assets
         run: |
           mkdir -p dist
           cp linux-amd64/cubic "dist/cubic-${GITHUB_REF_NAME}-linux-amd64"
           cp linux-arm64/cubic "dist/cubic-${GITHUB_REF_NAME}-linux-arm64"
           cp windows-amd64/cubic.exe "dist/cubic-${GITHUB_REF_NAME}-windows-amd64.exe"
+          cp macos-arm64/cubic "dist/cubic-${GITHUB_REF_NAME}-macos-arm64"
 
       - name: Publish GitHub Release
         env:


### PR DESCRIPTION
## Summary

Add a macOS job to the release build pipeline so the aarch64-apple-darwin
target is built, smoke tested, and included in release assets on every
push and tag, alongside the existing Linux and Windows targets.

## Related Issue(s)

Closes #453

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Ran the build job on a branch push with the packaging and publish jobs
disabled to isolate the new macOS leg. The build, smoke check, and
artifact upload all passed on a macos-latest runner.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [x] Documentation was updated if needed