### PR TITLE
fix: clean up temporary instances after an interrupted run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,6 +2406,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,6 +2681,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1", default-features = false, features = [
     "macros",
     "net",
     "rt",
+    "signal",
     "time",
 ] }
 tokio-rustls = { version = "0", default-features = false, features = ["ring"] }

--- a/src/actions/create_instance_action.rs
+++ b/src/actions/create_instance_action.rs
@@ -18,7 +18,7 @@ impl CreateInstanceAction {
         context: &Context,
         image_path: &str,
         mut instance: Instance,
-        overlay: bool,
+        auto_remove: bool,
     ) -> Result<()> {
         let system = context.get_system();
         let instance_name = instance.name.clone();
@@ -33,7 +33,7 @@ impl CreateInstanceAction {
         SshKeyGenerator::new().generate_key(system, &Path::new(tmp_dir).join("ssh_client_key"))?;
 
         // Create virtual machine instance image file
-        if overlay {
+        if auto_remove {
             QemuImg::new(system).create_overlay(image_path, tmp_image)?;
         } else {
             system.copy_file(Path::new(image_path), Path::new(tmp_image))?;
@@ -43,6 +43,7 @@ impl CreateInstanceAction {
         QemuImg::new(system).resize(tmp_image, instance.disk_capacity.get_bytes() as u64)?;
 
         // Write configuration file
+        instance.auto_remove = auto_remove;
         instance.name = format!("{instance_name}.tmp");
         context.get_instance_store().store(&instance)?;
         instance.name = instance_name;

--- a/src/commands/clone_command.rs
+++ b/src/commands/clone_command.rs
@@ -26,11 +26,6 @@ impl Command for CloneCommand {
     async fn run(&self, console: &Arc<Console>, context: &Context) -> Result<u8> {
         let instance_store = context.get_instance_store();
 
-        // Verify that the target name is available
-        if instance_store.exists(self.new_name.as_str()) {
-            return Err(Error::InstanceAlreadyExists(self.new_name.to_string()));
-        }
-
         if ResourceAllocator::is_disk_space_low(context.get_system(), context.get_env()) {
             console.warn(LOW_DISK_SPACE_WARNING);
         }
@@ -42,6 +37,9 @@ impl Command for CloneCommand {
         if instance_store.is_running(source) {
             return Err(Error::InstanceNotStopped(source.name.to_string()));
         }
+
+        // Verify that the target name is available
+        instance_store.claim_name(self.new_name.as_str())?;
 
         let text = format!("Cloning {} to {}", self.name, self.new_name);
         let _spinner = Spinner::new(Arc::clone(console), text);

--- a/src/commands/create_command.rs
+++ b/src/commands/create_command.rs
@@ -163,16 +163,12 @@ impl CreateCommand {
         &self,
         console: &Arc<Console>,
         context: &Context,
-        overlay: bool,
+        auto_remove: bool,
     ) -> Result<()> {
         let env = context.get_env();
         let instance_store = context.get_instance_store();
 
-        if instance_store.exists(self.instance_name.value.as_str()) {
-            return Err(Error::InstanceAlreadyExists(
-                self.instance_name.value.to_string(),
-            ));
-        }
+        instance_store.claim_name(self.instance_name.value.as_str())?;
 
         if ResourceAllocator::is_disk_space_low(context.get_system(), env) {
             console.warn(LOW_DISK_SPACE_WARNING);
@@ -211,7 +207,7 @@ impl CreateCommand {
         ));
 
         let image_path = &env.get_image_file(&image.to_file_name());
-        CreateInstanceAction::new().run(context, image_path, instance, overlay)?;
+        CreateInstanceAction::new().run(context, image_path, instance, auto_remove)?;
 
         Ok(())
     }

--- a/src/commands/list_instance_command.rs
+++ b/src/commands/list_instance_command.rs
@@ -50,6 +50,9 @@ impl Command for ListInstanceCommand {
 
         for instance_name in &instance_names {
             let instance = LoadInstanceAction::new().run(context, console, instance_name)?;
+            if instance_store.is_stale(&instance) {
+                continue;
+            }
 
             let row = view.add_row();
             if self.all.value {
@@ -197,6 +200,31 @@ PID   Name    Arch    CPUs   Memory         Disk   Running
 PID    Name    Arch    CPUs   Memory         Disk   Running
        test    amd64      1   1024 B   512/1024 K        no
 1059   test2   amd64      5      0 B       5000 B       yes
+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_instance_command_hides_a_stale_instance() {
+        let system = SystemMock::new();
+        let system = Arc::new(system);
+        let console = &Console::new(Arc::clone(&system) as Arc<dyn System>);
+        let mut instances = build_instances();
+        instances[0].auto_remove = true;
+        instances[1].auto_remove = true;
+        let context =
+            build_context_with_store(InstanceStoreMock::new_with_running(instances, &["test2"]));
+
+        ListInstanceCommand { all: false.into() }
+            .run(console, &context)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            system.get_output(),
+            "\
+Name    Arch    CPUs   Memory     Disk   Running
+test2   amd64      5      0 B   5000 B       yes
 "
         );
     }

--- a/src/commands/prune_command.rs
+++ b/src/commands/prune_command.rs
@@ -1,17 +1,18 @@
 use crate::commands::{self, Command};
 use crate::error::Result;
-use crate::models::DataSize;
+use crate::models::{DataSize, Instance};
 use crate::view::{ConfirmDialog, Console};
 use clap::Parser;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 const LEGACY_INSTANCES_DIR: &str = "instances";
 
 /// Clear caches
 ///
-/// This command removes cached VM image files and instance files left behind
-/// by older versions of cubic.
+/// This command removes cached VM image files, stopped temporary instances
+/// and instance files left behind by interrupted runs or older versions of
+/// cubic.
 ///
 #[derive(Parser)]
 #[clap(verbatim_doc_comment)]
@@ -24,16 +25,38 @@ impl Command for PruneCommand {
     async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         let env = context.get_env();
         let system = context.get_system();
+        let instance_store = context.get_instance_store();
 
-        let dirs = [
+        let stale_instances: Vec<Instance> = instance_store
+            .get_instances()
+            .into_iter()
+            .filter_map(|name| instance_store.load(&name).ok())
+            .filter(|instance| instance_store.is_stale(instance))
+            .collect();
+        let stale_dirs: Vec<PathBuf> = stale_instances
+            .iter()
+            .map(|instance| PathBuf::from(env.get_instance_dir2(&instance.name)))
+            .collect();
+        // A create that was interrupted before its final rename leaves a .tmp dir
+        let tmp_dirs = system
+            .read_dir(Path::new(&env.get_instance_dir()))
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|path| path.extension().is_some_and(|ext| ext == "tmp"));
+
+        let dirs: Vec<PathBuf> = [
             PathBuf::from(env.get_image_dir()),
             PathBuf::from(env.get_cache_dir()).join(LEGACY_INSTANCES_DIR),
-        ];
+        ]
+        .into_iter()
+        .chain(tmp_dirs)
+        .collect();
 
         // Calculate size
         let cache_file = PathBuf::from(env.get_image_cache_file());
         let total = DataSize::new(
             dirs.iter()
+                .chain(stale_dirs.iter())
                 .chain([&cache_file])
                 .fold(0, |total, path| total + system.get_path_size(path)) as usize,
         )
@@ -49,6 +72,11 @@ impl Command for PruneCommand {
             system.remove_file(&cache_file).ok();
             for dir in &dirs {
                 system.remove_dir(dir).ok();
+            }
+            // The store skips an instance that a session started while the
+            // dialog above waited for an answer.
+            for instance in &stale_instances {
+                instance_store.delete(instance).ok();
             }
 
             // Print size of deleted files
@@ -78,19 +106,34 @@ mod tests {
     }
 
     fn build_context(system: &Arc<SystemMock>, env: &Environment) -> commands::Context {
+        build_context_with_store(system, env, InstanceStoreMock::new(Vec::new()))
+    }
+
+    fn build_context_with_store(
+        system: &Arc<SystemMock>,
+        env: &Environment,
+        store: InstanceStoreMock,
+    ) -> commands::Context {
         commands::Context::new(
             Arc::clone(system) as Arc<dyn System>,
             env.clone(),
-            Box::new(InstanceStoreMock::new(Vec::new())),
+            Box::new(store),
         )
     }
 
     async fn run_prune(system: &Arc<SystemMock>, env: &Environment) -> String {
+        run_prune_with_context(system, build_context(system, env)).await
+    }
+
+    async fn run_prune_with_context(
+        system: &Arc<SystemMock>,
+        context: commands::Context,
+    ) -> String {
         let console = &Console::new(Arc::clone(system) as Arc<dyn System>);
         PruneCommand {
             yes: commands::YesArg { value: true },
         }
-        .run(console, &build_context(system, env))
+        .run(console, &context)
         .await
         .unwrap();
         system.get_output()
@@ -122,6 +165,38 @@ mod tests {
         run_prune(&system, &env).await;
 
         assert!(system.exists_path(Path::new(&instance_file)));
+    }
+
+    #[tokio::test]
+    async fn test_delete_stale_instances_and_interrupted_creates() {
+        let env = build_env();
+        let tmp = format!("{}/plain.tmp", env.get_instance_dir());
+        let system = Arc::new(SystemMock::new().add_dir(&tmp));
+        let store = InstanceStoreMock::new_with_running(
+            vec![
+                Instance {
+                    name: "stale".to_string(),
+                    auto_remove: true,
+                    ..Instance::default()
+                },
+                Instance {
+                    name: "running".to_string(),
+                    auto_remove: true,
+                    ..Instance::default()
+                },
+                Instance {
+                    name: "plain".to_string(),
+                    ..Instance::default()
+                },
+            ],
+            &["running"],
+        );
+        let deleted = Arc::clone(&store.deleted);
+
+        run_prune_with_context(&system, build_context_with_store(&system, &env, store)).await;
+
+        assert_eq!(*deleted.lock().unwrap(), ["stale"]);
+        assert!(!system.exists_path(Path::new(&tmp)));
     }
 
     #[tokio::test]

--- a/src/commands/run_command.rs
+++ b/src/commands/run_command.rs
@@ -68,13 +68,20 @@ impl Command for RunCommand {
     async fn run(&self, console: &Arc<Console>, context: &commands::Context) -> Result<u8> {
         self.create_cmd.create(console, context, self.rm).await?;
 
-        let result = commands::SshCommand {
+        let ssh = commands::SshCommand {
             target: Target::from_instance_name(self.create_cmd.instance_name.value.clone()),
             accel: self.accel,
             env_args: self.env_args.clone(),
-        }
-        .run(console, context)
-        .await;
+        };
+        // Ctrl+C ends the session like an exit. The dropped shell cannot
+        // reset the terminal, so reset it here.
+        let result = tokio::select! {
+            result = ssh.run(console, context) => result,
+            _ = tokio::signal::ctrl_c() => {
+                console.reset();
+                Ok(130)
+            }
+        };
 
         if self.rm {
             self.cleanup(console, context);

--- a/src/instance/instance_dao.rs
+++ b/src/instance/instance_dao.rs
@@ -101,11 +101,10 @@ impl InstanceStore for InstanceDao {
     }
 
     fn rename(&self, instance: &mut Instance, new_name: &str) -> Result<()> {
-        if self.exists(new_name) {
-            Err(Error::InstanceAlreadyExists(new_name.to_string()))
-        } else if self.is_running(instance) {
+        if self.is_running(instance) {
             Err(Error::InstanceNotStopped(instance.name.to_string()))
         } else {
+            self.claim_name(new_name)?;
             self.system.rename_file(
                 Path::new(&self.env.get_instance_dir2(&instance.name)),
                 Path::new(&self.env.get_instance_dir2(new_name)),

--- a/src/instance/instance_serializer.rs
+++ b/src/instance/instance_serializer.rs
@@ -57,6 +57,7 @@ disk_capacity = 1000
 ssh_port = 10000
 hostfwd = []
 isolate = false
+auto_remove = false
 "#
         );
     }
@@ -98,6 +99,7 @@ hostfwd = []
 execute = "echo hello world"
 isolate = true
 ssh_host_key = "ssh-ed25519 AAAA"
+auto_remove = false
 "#
         );
     }

--- a/src/instance/instance_store.rs
+++ b/src/instance/instance_store.rs
@@ -1,4 +1,4 @@
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::models::Instance;
 use crate::qemu::QemuMonitorClient;
 use std::str;
@@ -18,8 +18,63 @@ pub trait InstanceStore {
     fn delete_snapshot(&self, instance: &Instance, name: &str) -> Result<()>;
 
     fn is_running(&self, instance: &Instance) -> bool;
+
+    /// A stopped --rm instance that its session never cleaned up
+    fn is_stale(&self, instance: &Instance) -> bool {
+        instance.auto_remove && !self.is_running(instance)
+    }
+
+    /// Frees a name that only a stale instance still holds
+    fn claim_name(&self, name: &str) -> Result<()> {
+        match self.load(name) {
+            Err(Error::UnknownInstance(_)) => Ok(()),
+            Ok(instance) if self.is_stale(&instance) => self.delete(&instance),
+            _ => Err(Error::InstanceAlreadyExists(name.to_string())),
+        }
+    }
+
     fn get_pid(&self, instance: &Instance) -> Option<u64>;
     fn kill(&self, instance: &Instance) -> Result<()>;
 
     fn get_monitor(&self, instance: &Instance) -> Result<QemuMonitorClient>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instance::InstanceStoreMock;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_claim_name_deletes_a_stale_instance() {
+        let store = InstanceStoreMock::new(vec![Instance {
+            name: "test".to_string(),
+            auto_remove: true,
+            ..Instance::default()
+        }]);
+        let deleted = Arc::clone(&store.deleted);
+
+        store.claim_name("test").unwrap();
+
+        assert_eq!(*deleted.lock().unwrap(), ["test"]);
+    }
+
+    #[test]
+    fn test_claim_name_rejects_a_running_auto_remove_instance() {
+        let store = InstanceStoreMock::new_with_running(
+            vec![Instance {
+                name: "test".to_string(),
+                auto_remove: true,
+                ..Instance::default()
+            }],
+            &["test"],
+        );
+
+        let result = store.claim_name("test");
+
+        assert!(matches!(
+            result,
+            Err(Error::InstanceAlreadyExists(ref name)) if name == "test"
+        ));
+    }
 }

--- a/src/models/instance.rs
+++ b/src/models/instance.rs
@@ -31,6 +31,9 @@ pub struct Instance {
     /// Guest SSH host key, pinned on the first connect
     #[serde(default)]
     pub ssh_host_key: Option<String>,
+    /// Set by `cubic run --rm`, the instance is deleted once it stops
+    #[serde(default)]
+    pub auto_remove: bool,
 }
 
 impl Instance {


### PR DESCRIPTION
## Summary

A throwaway VM created with `cubic run --rm` no longer lingers when the run ends with Ctrl+C or a crash. Each instance records that it is temporary, so `cubic run` deletes it when the session ends with Ctrl+C, `cubic instances` keeps a stopped one out of the list, `cubic create`, `cubic clone` and `cubic rename` reuse its name right away, and `cubic prune` clears the leftovers of an interrupted run, including the `.tmp` directory a create leaves behind. Prune deletes through the instance store, so an instance that a session started in the meantime stays.

## Related Issue(s)

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test Plan

Passed `make check` and manual tests.

## Checklist

- [x] This pull request has exactly one intent
- [x] Commits are signed off and use a Conventional Commit prefix (see CONTRIBUTING.md)
- [x] Formatting, lint, and tests pass locally
- [ ] Documentation was updated if needed